### PR TITLE
ci: add dependabot config, auto-merge workflow, and CI aggregate gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci-cd"
+    groups:
+      github-actions-all:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "python"
+    groups:
+      development-tooling:
+        patterns:
+          - "ruff"
+          - "mypy"
+          - "pytest*"
+          - "import-linter"
+      production-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "ruff"
+          - "mypy"
+          - "pytest*"
+          - "import-linter"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,3 +129,23 @@ jobs:
         uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
         with:
           configFile: commitlint.config.mjs
+
+  # 5. AGGREGATE GATE (single predictable check name for ruleset)
+  ci-passed:
+    name: CI passed
+    if: always()
+    needs: [detect-changes, quality, boundaries, commitlint]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all prerequisites passed
+        env:
+          DETECT: ${{ needs.detect-changes.result }}
+          QUALITY: ${{ needs.quality.result }}
+          BOUNDARIES: ${{ needs.boundaries.result }}
+          COMMITLINT: ${{ needs.commitlint.result }}
+        run: |
+          for result in "$DETECT" "$QUALITY" "$BOUNDARIES" "$COMMITLINT"; do
+            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              exit 1
+            fi
+          done

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Approve and Enable Auto-Merge for Patches
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds:

- `.github/dependabot.yml` — weekly dependency updates for github-actions and uv ecosystems with grouped PRs (development-tooling vs production-dependencies)
- `.github/workflows/dependabot-auto-merge.yml` — auto-approves and squash-merges patch updates from Dependabot
- `.github/workflows/ci.yml` — aggregate `CI passed` job that serves as a single predictable check name for the ruleset
- Repository ruleset **Require status checks before merge** (created via API) — blocks squash & merge on `main` until 7 checks pass