### PR TITLE
fix: data model, migration, and dead code review fixes (#13-#18)

### DIFF
--- a/api/src/api/routes/ingest.py
+++ b/api/src/api/routes/ingest.py
@@ -9,7 +9,6 @@ from fastapi import APIRouter, BackgroundTasks, Form, HTTPException, Request, Re
 from core.config.settings import settings
 from core.database.connection import db_session
 from core.database.schema import Document
-from core.exceptions import IngestionError
 from core.types.document import DocumentStatusResponse, DocumentType
 from ingestion.tasks import schedule_ingestion
 
@@ -75,8 +74,6 @@ async def ingest_document(
             session.flush()
             document_id: UUID = document.document_id
             response_body = DocumentStatusResponse.model_validate(document)
-    except IngestionError as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Failed to create document: {exc}") from exc
 

--- a/core/src/core/database/migrations/versions/2fff441e94ab_initial_schema_with_documents_chunks_.py
+++ b/core/src/core/database/migrations/versions/2fff441e94ab_initial_schema_with_documents_chunks_.py
@@ -47,13 +47,13 @@ def upgrade() -> None:
     op.create_table(
         "documents",
         sa.Column("document_id", sa.Uuid(), nullable=False),
-        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
         sa.Column(
             "document_type",
             document_type_enum,
             nullable=False,
         ),
-        sa.Column("source_filename", sa.String(), nullable=False),
+        sa.Column("source_filename", sa.Text(), nullable=False),
         sa.Column(
             "status",
             document_status_enum,

--- a/core/src/core/database/migrations/versions/2fff441e94ab_initial_schema_with_documents_chunks_.py
+++ b/core/src/core/database/migrations/versions/2fff441e94ab_initial_schema_with_documents_chunks_.py
@@ -85,7 +85,12 @@ def upgrade() -> None:
         sa.Column("position", sa.Integer(), nullable=False),
         sa.Column("content", sa.String(), nullable=False),
         sa.Column("token_count", sa.Integer(), nullable=False),
-        sa.Column("type_metadata", sa.JSON(), nullable=False),
+        sa.Column(
+            "type_metadata",
+            sa.JSON(),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),

--- a/core/src/core/database/schema.py
+++ b/core/src/core/database/schema.py
@@ -21,6 +21,7 @@ from sqlalchemy import (
     CheckConstraint,
     DateTime,
     ForeignKey,
+    Text,
     UniqueConstraint,
     text,
 )
@@ -54,7 +55,7 @@ class Document(Base):
         primary_key=True,
         default=_uuid7_stdlib,
     )
-    title: Mapped[str]
+    title: Mapped[str] = mapped_column(Text())
     document_type: Mapped[DocumentType] = mapped_column(
         ENUM(
             DocumentType,
@@ -63,7 +64,7 @@ class Document(Base):
             values_callable=lambda enum: [e.value for e in enum],
         ),
     )
-    source_filename: Mapped[str]
+    source_filename: Mapped[str] = mapped_column(Text())
     status: Mapped[DocumentStatus] = mapped_column(
         ENUM(
             DocumentStatus,

--- a/core/tests/core/test_exceptions.py
+++ b/core/tests/core/test_exceptions.py
@@ -1,0 +1,50 @@
+"""Tests for the named exception hierarchy."""
+
+import pytest
+
+from core.exceptions import (
+    IngestionError,
+    LearningHubError,
+    RetrievalError,
+    UpstreamBadResponse,
+    UpstreamUnavailable,
+)
+
+
+def test_learninghuberror_is_base_exception() -> None:
+    """LearningHubError inherits from Exception and is catchable."""
+    assert issubclass(LearningHubError, Exception)
+    with pytest.raises(LearningHubError):
+        raise LearningHubError("boom")
+
+
+def test_ingestionerror_inherits_learninghuberror() -> None:
+    """IngestionError is a subclass of LearningHubError."""
+    assert issubclass(IngestionError, LearningHubError)
+
+
+def test_retrievalerror_inherits_learninghuberror() -> None:
+    """RetrievalError is a subclass of LearningHubError."""
+    assert issubclass(RetrievalError, LearningHubError)
+
+
+def test_upstreambadresponse_inherits_retrievalerror() -> None:
+    """UpstreamBadResponse is a subclass of RetrievalError."""
+    assert issubclass(UpstreamBadResponse, RetrievalError)
+
+
+def test_upstreamunavailable_inherits_retrievalerror() -> None:
+    """UpstreamUnavailable is a subclass of RetrievalError."""
+    assert issubclass(UpstreamUnavailable, RetrievalError)
+
+
+def test_exception_cause_chain_preserved() -> None:
+    """Chained exceptions preserve __cause__."""
+    try:
+        try:
+            raise ValueError("root cause")
+        except ValueError as exc:
+            raise IngestionError("ingestion failed") from exc
+    except IngestionError as exc:
+        assert exc.__cause__ is not None
+        assert "root cause" in str(exc.__cause__)

--- a/core/tests/core/types/test_chunk.py
+++ b/core/tests/core/types/test_chunk.py
@@ -1,0 +1,52 @@
+"""Tests for chunk metadata Pydantic models."""
+
+import pytest
+from pydantic import ValidationError
+
+from core.types.chunk import (
+    BookChunkMetadata,
+    DocumentationChunkMetadata,
+    PaperChunkMetadata,
+)
+
+
+def test_paper_chunk_metadata_valid() -> None:
+    """PaperChunkMetadata accepts valid section metadata."""
+    meta = PaperChunkMetadata(section="Introduction", subsection=None, page=1)
+    assert meta.section == "Introduction"
+    assert meta.subsection is None
+    assert meta.page == 1
+
+
+def test_paper_chunk_metadata_rejects_extra_fields() -> None:
+    """PaperChunkMetadata with extra='forbid' rejects unknown fields."""
+    with pytest.raises(ValidationError):
+        PaperChunkMetadata.model_validate(
+            {"section": "Intro", "subsection": None, "page": 1, "extra_field": "nope"}
+        )
+
+
+def test_book_chunk_metadata_valid() -> None:
+    """BookChunkMetadata accepts valid chapter metadata."""
+    meta = BookChunkMetadata(chapter=3, heading="Methods")
+    assert meta.chapter == 3
+    assert meta.heading == "Methods"
+
+
+def test_book_chunk_metadata_rejects_extra_fields() -> None:
+    """BookChunkMetadata with extra='forbid' rejects unknown fields."""
+    with pytest.raises(ValidationError):
+        BookChunkMetadata.model_validate({"chapter": 1, "heading": None, "sneaky": True})
+
+
+def test_documentation_chunk_metadata_valid() -> None:
+    """DocumentationChunkMetadata accepts valid page/section metadata."""
+    meta = DocumentationChunkMetadata(page="api-reference", section="auth")
+    assert meta.page == "api-reference"
+    assert meta.section == "auth"
+
+
+def test_documentation_chunk_metadata_rejects_extra_fields() -> None:
+    """DocumentationChunkMetadata with extra='forbid' rejects unknown fields."""
+    with pytest.raises(ValidationError):
+        DocumentationChunkMetadata.model_validate({"page": "p1", "section": None, "bogus": 42})

--- a/core/tests/core/types/test_document.py
+++ b/core/tests/core/types/test_document.py
@@ -1,0 +1,79 @@
+"""Tests for document-related Pydantic models."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from core.types.document import DocumentStatus, DocumentStatusResponse, DocumentType
+
+
+def test_document_type_enum_values() -> None:
+    """DocumentType exposes the expected string values."""
+    assert str(DocumentType.PAPER) == "paper"
+    assert str(DocumentType.BOOK) == "book"
+    assert str(DocumentType.DOCUMENTATION) == "documentation"
+
+
+def test_document_status_enum_values() -> None:
+    """DocumentStatus exposes the expected pipeline phase values."""
+    assert str(DocumentStatus.VALIDATING) == "validating"
+    assert str(DocumentStatus.CHUNKING) == "chunking"
+    assert str(DocumentStatus.EMBEDDING) == "embedding"
+    assert str(DocumentStatus.READY) == "ready"
+    assert str(DocumentStatus.FAILED) == "failed"
+
+
+def test_document_status_response_roundtrip() -> None:
+    """DocumentStatusResponse serialises and deserialises cleanly."""
+    now = datetime.now(UTC)
+    doc_id = uuid4()
+    resp = DocumentStatusResponse(
+        document_id=doc_id,
+        title="Test Paper",
+        document_type=DocumentType.PAPER,
+        status=DocumentStatus.READY,
+        error_message=None,
+        source_filename="test.pdf",
+        created_at=now,
+        updated_at=now,
+    )
+    data = resp.model_dump()
+    restored = DocumentStatusResponse.model_validate(data)
+    assert restored.document_id == doc_id
+    assert restored.title == "Test Paper"
+    assert restored.status == DocumentStatus.READY
+
+
+def test_document_status_response_ignores_unknown_fields() -> None:
+    """DocumentStatusResponse silently drops extra fields."""
+    now = datetime.now(UTC)
+    resp = DocumentStatusResponse.model_validate(
+        {
+            "document_id": str(uuid4()),
+            "title": "Test",
+            "document_type": "paper",
+            "status": "validating",
+            "error_message": None,
+            "source_filename": "test.pdf",
+            "created_at": now.isoformat(),
+            "updated_at": now.isoformat(),
+            "unexpected_field": "oops",
+        }
+    )
+    assert resp.title == "Test"
+    assert not hasattr(resp, "unexpected_field")
+
+
+def test_document_status_response_allows_none_error_message() -> None:
+    """error_message may be None for successful documents."""
+    now = datetime.now(UTC)
+    resp = DocumentStatusResponse(
+        document_id=uuid4(),
+        title="Clean",
+        document_type=DocumentType.BOOK,
+        status=DocumentStatus.READY,
+        error_message=None,
+        source_filename="book.pdf",
+        created_at=now,
+        updated_at=now,
+    )
+    assert resp.error_message is None

--- a/ingestion/tests/ingestion/test_tasks.py
+++ b/ingestion/tests/ingestion/test_tasks.py
@@ -1,0 +1,37 @@
+"""Tests for the FastAPI background-tasks glue layer."""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from ingestion.tasks import schedule_ingestion
+
+
+def test_schedule_ingestion_adds_background_task() -> None:
+    """schedule_ingestion registers _execute_ingestion_task on BackgroundTasks."""
+    mock_bg = MagicMock()
+    doc_id = uuid4()
+
+    schedule_ingestion(
+        background_tasks=mock_bg,
+        document_id=doc_id,
+        document_type="paper",
+        source_filename="test.pdf",
+        file_bytes=b"fake-pdf-bytes",
+    )
+
+    mock_bg.add_task.assert_called_once()
+    args = mock_bg.add_task.call_args
+    # First positional arg is the callable
+    assert callable(args[0][0])
+    # Remaining positional args match the arguments passed through
+    assert args[0][1] == doc_id
+    assert args[0][2] == "paper"
+    assert args[0][3] == "test.pdf"
+    assert args[0][4] == b"fake-pdf-bytes"
+
+
+def test_schedule_ingestion_is_public_api() -> None:
+    """schedule_ingestion is exposed in __all__."""
+    from ingestion.tasks import __all__
+
+    assert "schedule_ingestion" in __all__

--- a/retrieval_qa/src/retrieval_qa/chunking/paper_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/paper_chunker.py
@@ -5,9 +5,9 @@ emitting ``PaperChunkMetadata`` for each chunk.
 """
 
 import re
-from dataclasses import dataclass
 from io import BytesIO
 
+from pydantic import BaseModel, ConfigDict
 from pypdf import PdfReader
 
 from core.types.chunk import PaperChunkMetadata
@@ -23,9 +23,10 @@ _SECTION_PATTERN = re.compile(
 )
 
 
-@dataclass
-class PaperChunk:
+class PaperChunk(BaseModel):
     """A single chunk produced by the paper chunker."""
+
+    model_config = ConfigDict(extra="forbid")
 
     content: str
     metadata: PaperChunkMetadata


### PR DESCRIPTION
Addresses hard violations and implementation mismatches from the ingestion tracer bullet code review:

- **#13**: Convert PaperChunk from @dataclass to Pydantic v2 BaseModel
- **#14**: Add missing docstrings to test functions
- **#15**: Add test mirrors for exceptions, types, and tasks modules
- **#16**: Remove unreachable except IngestionError in ingest route
- **#17**: Add server_default to type_metadata column in migration
- **#18**: Use TEXT instead of VARCHAR for title and source_filename

All checks pass: ruff, mypy, pytest (28 pass, 16 skipped — database-dependent).