### PR TITLE
ci: skip commitlint for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
   commitlint:
     name: commit message format
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
## Problem

PR #5 (dependabot) fails the commitlint step because dependabot auto-generates commit bodies with lines exceeding 100 characters (long dependency URLs, table rows), triggering the body-max-line-length rule enforced by @commitlint/config-conventional.

## Solution

Skip the commitlint check for dependabot PRs. The aggregate gate (CI passed) already handles skipped correctly — it only fails on failure or cancelled.

## After merge

Once this PR merges into main, close and re-open PR #5 to re-trigger CI, or push a trivial commit to its branch.
