### PR TITLE
docs: update stale state descriptions in README.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 
 ## Current state
 
-This repository is **scaffolded but pre-implementation**. ADRs, stack decisions, coding standards, and the monorepo layout are in place, plus the build/CI scaffolding: root + per-module `pyproject.toml` (uv workspace), `uv.lock`, `.github/workflows/` (`pr-checks.yml`, `release.yml`), `commitlint.config.js`, and empty package skeletons (`src/<name>/__init__.py` + `tests/<name>/test_smoke.py`). **No implementation source code yet** — the `__init__.py` files are placeholders. The toolchain is configured and green: `uv sync` installs ruff/mypy/pytest/import-linter and builds the workspace members; `uv run ruff check`, `uv run ruff format --check`, `uv run mypy`, `uv run lint-imports`, and `uv run pytest` all pass on the scaffold.
+This repository is in **early implementation (tracer bullet complete)**. ADRs, stack decisions, coding standards, and the monorepo layout are in place, plus the build/CI scaffolding: root + per-module `pyproject.toml` (uv workspace), `uv.lock`, `.github/workflows/` (`ci.yml`, `cd.yml`, `security.yml`, `dependabot-auto-merge.yml`), `commitlint.config.mjs`, and `Dockerfile`. Four of five packages have real implementation code (~2300 lines total); only `depth_dive/` still has just placeholders. The toolchain is green: `uv sync` installs all deps; `uv run ruff check`, `uv run ruff format --check`, `uv run mypy`, `uv run lint-imports`, and `uv run pytest` all pass.
 
 ## Authoritative sources — read before acting
 
@@ -88,8 +88,8 @@ Rules:
 
 ## What does not exist yet
 
-- Implementation source code — the `src/<name>/__init__.py` files are empty placeholders; internal sub-packages (`chunking/`, `retrieval/`, `generation/`, `web_search/`, `types/`, `routes/`, etc.) are created alongside the first file that needs them.
-- `Dockerfile`, `.env.example` (the `release.yml` Docker build job is structural and will work once a `Dockerfile` lands).
-- Runtime dependencies in member `pyproject.toml` files (Pydantic, SQLAlchemy, pgvector, FastAPI, etc.) — add each alongside the first implementation commit that needs it, per the bootstrap order below.
+- **Retrieval QA query logic** — `retrieval_qa/src/retrieval_qa/retrieval/` is not yet created; there is no `POST /query` endpoint or similarity-search pipeline.
+- **Depth Dive implementation** — `depth_dive/src/depth_dive/generation/` and `web_search/` are still placeholders.
+- **`api/routes/__init__.py`** — route modules are imported directly in `server.py`; no package init file exists.
 
-When adding the first implementation files, bootstrap in the order implied by the monorepo layout: `core/` → `retrieval_qa/` → `api/` → `ingestion/` → `depth_dive/`.
+Bootstrap order is already complete for the first four packages (`core/` → `retrieval_qa/` → `api/` → `ingestion/`). `depth_dive/` is the remaining package to implement.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A RAG-powered study tool that turns uploaded papers, books, and documentation into interactive learning sessions — retrieval QA (Harness A) and dual-coding Depth Dives (Harness B).
 
-> **Status:** Scaffolded, pre-implementation. Monorepo structure, `pyproject.toml` (uv workspace), `uv.lock`, and CI workflows (`.github/workflows/`) are in place; package skeletons are empty — no implementation source code yet. See [docs/](./docs/) for architecture decisions and plans.
+> **Status:** Early implementation — tracer bullet complete. Four of five packages (`core/`, `retrieval_qa/`, `api/`, `ingestion/`) have implementation code (~2300 lines total). Only `depth_dive/` remains as a scaffold. Ingestion pipeline (upload PDF → chunk → embed → store in pgvector with HNSW index) and two API endpoints (`POST /ingest`, `GET /documents/{id}`) are operational. See [docs/](./docs/) for architecture decisions and plans.
 
 ## Architecture
 


### PR DESCRIPTION
Updates both files to reflect the current early-implementation state (the repo is no longer a pre-implementation scaffold — ~2300 lines exist across 4 of 5 packages).

**README.md:** Rewrote the status banner to describe the actual tracer-bullet-complete state.
**AGENTS.md:** Fixed workflow filenames (pr-checks.yml→ci.yml), commitlint extension (.js→.mjs), and replaced the entirely wrong 'What does not exist yet' section with an accurate list of remaining work.