### PR TITLE
fix(core): replace bare dict messages with ChatMessage Pydantic model

### DIFF
--- a/api/src/api/controllers/qa_controller.py
+++ b/api/src/api/controllers/qa_controller.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import Session
 
 from core.clients.embeddings_client import EmbeddingsClient
 from core.clients.llm_client import LLMClient
+from core.types.chat import ChatMessage
 from core.types.responses import CitedPassage, HarnessAResponse
 from retrieval_qa.retrieval.query import RetrievedChunk, retrieve_relevant_chunks
 
@@ -36,7 +37,7 @@ _SYSTEM_PROMPT = (
 def _build_messages(
     query: str,
     chunks: Sequence[RetrievedChunk],
-) -> list[dict[str, str]]:
+) -> list[ChatMessage]:
     """Assemble the chat-completions message list for the inference call.
 
     Args:
@@ -57,8 +58,8 @@ def _build_messages(
     user_parts.append(f"Question: {query}")
     user_message = "\n\n".join(p for p in user_parts if p)
     return [
-        {"role": "system", "content": _SYSTEM_PROMPT},
-        {"role": "user", "content": user_message},
+        ChatMessage(role="system", content=_SYSTEM_PROMPT),
+        ChatMessage(role="user", content=user_message),
     ]
 
 

--- a/api/tests/api/controllers/test_qa_controller.py
+++ b/api/tests/api/controllers/test_qa_controller.py
@@ -258,9 +258,9 @@ def test_run_query_passes_chunks_to_llm_prompt(monkeypatch: pytest.MonkeyPatch) 
 
     llm_client.chat.assert_called_once()
     sent_messages = llm_client.chat.call_args.args[0]
-    user_msg = next(m for m in sent_messages if m["role"] == "user")
-    assert "chunk A text" in user_msg["content"]
-    assert "what are chunks?" in user_msg["content"]
+    user_msg = next(m for m in sent_messages if m.role == "user")
+    assert "chunk A text" in user_msg.content
+    assert "what are chunks?" in user_msg.content
 
 
 def test_run_query_no_chunks_prompt_does_not_include_passage_text(
@@ -285,6 +285,6 @@ def test_run_query_no_chunks_prompt_does_not_include_passage_text(
 
     llm_client.chat.assert_called_once()
     sent_messages = llm_client.chat.call_args.args[0]
-    user_msg = next(m for m in sent_messages if m["role"] == "user")
-    assert "topic the corpus does not cover" in user_msg["content"]
-    assert "Passages:" not in user_msg["content"]
+    user_msg = next(m for m in sent_messages if m.role == "user")
+    assert "topic the corpus does not cover" in user_msg.content
+    assert "Passages:" not in user_msg.content

--- a/core/src/core/clients/llm_client.py
+++ b/core/src/core/clients/llm_client.py
@@ -7,12 +7,12 @@ narrow: one model, plain chat-completions shape, no streaming/tools.
 """
 
 from collections.abc import Sequence
-from typing import Any
 
 from openai import APIConnectionError, APIStatusError, OpenAI
 
 from core.config.settings import settings
 from core.exceptions import UpstreamBadResponse, UpstreamUnavailable
+from core.types.chat import ChatMessage
 
 
 class LLMClient:
@@ -39,11 +39,11 @@ class LLMClient:
             self._client = OpenAI(api_key=self._api_key)
         return self._client
 
-    def chat(self, messages: Sequence[dict[str, Any]]) -> str:
+    def chat(self, messages: Sequence[ChatMessage]) -> str:
         """Generate a completion synchronously and return the message content.
 
         Args:
-            messages: OpenAI chat-completions message list (role/content).
+            messages: Chat messages (role/content) to send to the model.
 
         Returns:
             The first choice's message content as a string.
@@ -57,10 +57,7 @@ class LLMClient:
         try:
             completion = self._get_client().chat.completions.create(
                 model=self._model,
-                # The OpenAI SDK expects its own TypedDict union for messages;
-                # we accept plain dicts at our boundary (ADR-0003 hand-rolled
-                # pipeline) and pass them through to the SDK.
-                messages=list(messages),  # type: ignore[arg-type]
+                messages=[m.model_dump() for m in messages],  # type: ignore[misc]
             )
         except APIConnectionError as exc:
             raise UpstreamUnavailable(f"Inference API unreachable: {exc}") from exc

--- a/core/src/core/types/__init__.py
+++ b/core/src/core/types/__init__.py
@@ -1,5 +1,6 @@
 """Shared Pydantic boundary types."""
 
+from core.types.chat import ChatMessage
 from core.types.chunk import (
     BookChunkMetadata,
     DocumentationChunkMetadata,
@@ -13,6 +14,7 @@ from core.types.document import (
 
 __all__ = [
     "BookChunkMetadata",
+    "ChatMessage",
     "DocumentStatus",
     "DocumentStatusResponse",
     "DocumentType",

--- a/core/src/core/types/chat.py
+++ b/core/src/core/types/chat.py
@@ -1,0 +1,10 @@
+"""Boundary types for chat messages across the inference pipeline."""
+
+from pydantic import BaseModel
+
+
+class ChatMessage(BaseModel):
+    """A single chat-completions message with role and content."""
+
+    role: str
+    content: str

--- a/core/tests/core/test_llm_client.py
+++ b/core/tests/core/test_llm_client.py
@@ -7,6 +7,7 @@ from openai import APIConnectionError, APIStatusError
 
 from core.clients.llm_client import LLMClient
 from core.exceptions import UpstreamBadResponse, UpstreamUnavailable
+from core.types.chat import ChatMessage
 
 
 def _fake_completion(content: str) -> MagicMock:
@@ -45,7 +46,7 @@ def test_chat_returns_message_content(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(client, "_get_client", lambda: fake_openai)
 
     result = client.chat(
-        messages=[{"role": "user", "content": "What is the answer?"}],
+        messages=[ChatMessage(role="user", content="What is the answer?")],
     )
 
     assert result == "The answer is 42."
@@ -72,7 +73,7 @@ def test_chat_raises_upstream_unavailable_on_connection_error(
     monkeypatch.setattr(client, "_get_client", lambda: fake_openai)
 
     with pytest.raises(UpstreamUnavailable):
-        client.chat(messages=[{"role": "user", "content": "x"}])
+        client.chat(messages=[ChatMessage(role="user", content="x")])
 
 
 def test_chat_raises_upstream_bad_response_on_api_status_error(
@@ -86,7 +87,7 @@ def test_chat_raises_upstream_bad_response_on_api_status_error(
     monkeypatch.setattr(client, "_get_client", lambda: fake_openai)
 
     with pytest.raises(UpstreamBadResponse):
-        client.chat(messages=[{"role": "user", "content": "x"}])
+        client.chat(messages=[ChatMessage(role="user", content="x")])
 
 
 def test_chat_raises_upstream_bad_response_when_choices_empty(
@@ -102,7 +103,7 @@ def test_chat_raises_upstream_bad_response_when_choices_empty(
     monkeypatch.setattr(client, "_get_client", lambda: fake_openai)
 
     with pytest.raises(UpstreamBadResponse):
-        client.chat(messages=[{"role": "user", "content": "x"}])
+        client.chat(messages=[ChatMessage(role="user", content="x")])
 
 
 def test_chat_raises_upstream_bad_response_when_content_missing(
@@ -119,4 +120,4 @@ def test_chat_raises_upstream_bad_response_when_content_missing(
     monkeypatch.setattr(client, "_get_client", lambda: fake_openai)
 
     with pytest.raises(UpstreamBadResponse):
-        client.chat(messages=[{"role": "user", "content": "x"}])
+        client.chat(messages=[ChatMessage(role="user", content="x")])


### PR DESCRIPTION
LLMClient.chat() accepted Sequence[dict[str, Any]] across the controller boundary, bypassing compile-time and runtime validation of message shape. A misspelled key or missing field would surface as a cryptic OpenAI SDK error instead of a clear validation error.

Introduce a ChatMessage(role, content) Pydantic model in core/types/ and update the boundary to Sequence[ChatMessage]. Update the controller's _build_messages helper and all test call sites.

Closes #25