### PR TITLE
refactor(tests): extract ingest helper into shared conftest fixture

### DIFF
--- a/api/tests/api/test_ingest.py
+++ b/api/tests/api/test_ingest.py
@@ -1,5 +1,7 @@
 """Integration tests for the POST /ingest route."""
 
+import uuid
+from collections.abc import Callable
 from unittest.mock import MagicMock
 
 import pytest
@@ -124,3 +126,32 @@ def test_ingest_pipeline_failure_marks_failed(
     body = status_response.json()
     assert body["status"] == "failed"
     assert body["error_message"] is not None
+
+
+def _default_fake_llm_client(*args: object, **kwargs: object) -> MagicMock:
+    """A mocked LLM client that returns a fixed grounded answer."""
+    client = MagicMock()
+    client.chat.return_value = "Grounded answer derived from retrieved passages."
+    return client
+
+
+def test_ingest_then_query_end_to_end(
+    client: TestClient,
+    ingest_a_paper: Callable[[str], str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ingest a paper, then query it expecting grounded=true with cited passages."""
+    monkeypatch.setattr("api.routes.retrieval_qa.LLMClient", _default_fake_llm_client)
+
+    ingest_a_paper("RAG Paper")
+
+    response = client.post("/query", json={"query": "Tell me about retrieval strategies."})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["grounded"] is True
+    assert len(body["cited_passages"]) >= 1
+    for passage in body["cited_passages"]:
+        uuid.UUID(passage["chunk_id"])
+        assert isinstance(passage["text"], str)
+        assert passage["text"]
+    assert body["answer"]

--- a/api/tests/api/test_query.py
+++ b/api/tests/api/test_query.py
@@ -11,6 +11,7 @@ Two fixture variants are used:
 """
 
 import uuid
+from collections.abc import Callable
 from unittest.mock import MagicMock
 
 import pytest
@@ -36,20 +37,6 @@ def _refusal_fake_llm_client(*args: object, **kwargs: object) -> MagicMock:
 def _fake_chunk(*, text: str = "chunk text") -> MagicMock:
     """Build a MagicMock chunk shaped like ``RetrievedChunk``."""
     return MagicMock(chunk_id=uuid.uuid4(), text=text)
-
-
-def _ingest_a_paper(client: TestClient, sample_paper_pdf: bytes, title: str = "Paper") -> str:
-    """Helper: POST /ingest, wait for status=ready, return document_id."""
-    response = client.post(
-        "/ingest",
-        files={"file": ("sample.pdf", sample_paper_pdf, "application/pdf")},
-        data={"title": title, "document_type": "paper"},
-    )
-    assert response.status_code == 202
-    document_id = response.json()["document_id"]
-    status = client.get(f"/documents/{document_id}").json()["status"]
-    assert status == "ready", f"document never reached ready: {status}"
-    return str(document_id)
 
 
 # ============================================================
@@ -241,12 +228,12 @@ def test_query_grounds_with_mocked_retrieval(
 
 def test_query_end_to_end_grounds_with_real_chunks(
     client: TestClient,
-    sample_paper_pdf: bytes,
+    ingest_a_paper: Callable[[str], str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A relevant query against a ready corpus returns 200 grounded=true with citations."""
     monkeypatch.setattr("api.routes.retrieval_qa.LLMClient", _default_fake_llm_client)
-    _ingest_a_paper(client, sample_paper_pdf, title="RAG Paper")
+    ingest_a_paper("RAG Paper")
 
     response = client.post("/query", json={"query": "Tell me about retrieval strategies."})
 
@@ -263,7 +250,7 @@ def test_query_end_to_end_grounds_with_real_chunks(
 
 def test_query_end_to_end_irrelevant_returns_not_grounded(
     client: TestClient,
-    sample_paper_pdf: bytes,
+    ingest_a_paper: Callable[[str], str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Asking an irrelevant question yields 200 grounded=false with empty passages."""
@@ -274,7 +261,7 @@ def test_query_end_to_end_irrelevant_returns_not_grounded(
         "api.controllers.qa_controller.retrieve_relevant_chunks",
         lambda **kwargs: [],
     )
-    _ingest_a_paper(client, sample_paper_pdf, title="RAG Paper")
+    ingest_a_paper("RAG Paper")
 
     response = client.post("/query", json={"query": "What is the capital of France?"})
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,11 +1,13 @@
-"""Shared fixtures for api tests."""
+"""Shared fixtures and utilities for api tests."""
 
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
+
+IngestAPaper = Callable[[str], str]
 
 
 @pytest.fixture
@@ -60,6 +62,25 @@ def mock_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     from api.server import create_app
 
     return TestClient(create_app())
+
+
+@pytest.fixture
+def ingest_a_paper(client: TestClient, sample_paper_pdf: bytes) -> IngestAPaper:
+    """Fixture returning a callable that ingests a paper and awaits ready."""
+
+    def _ingest(title: str = "Paper") -> str:
+        response = client.post(
+            "/ingest",
+            files={"file": ("sample.pdf", sample_paper_pdf, "application/pdf")},
+            data={"title": title, "document_type": "paper"},
+        )
+        assert response.status_code == 202
+        document_id = response.json()["document_id"]
+        status = client.get(f"/documents/{document_id}").json()["status"]
+        assert status == "ready", f"document never reached ready: {status}"
+        return str(document_id)
+
+    return _ingest
 
 
 def _default_fake_client(*args: object, **kwargs: object) -> MagicMock:


### PR DESCRIPTION
Replace duplicated _ingest_a_paper in test_query.py with a factory fixture in conftest.py. All three query e2e tests now consume the fixture. Add test_ingest_then_query_end_to_end in test_ingest.py to cover the full ingest-then-query path (issue #26).