### PR TITLE
refactor(core): consolidate RetrievedChunk and CitedPassage into sing…

### DIFF
--- a/api/src/api/controllers/qa_controller.py
+++ b/api/src/api/controllers/qa_controller.py
@@ -25,7 +25,7 @@ from core.clients.embeddings_client import EmbeddingsClient
 from core.clients.llm_client import LLMClient
 from core.types.chat import ChatMessage
 from core.types.responses import CitedPassage, HarnessAResponse
-from retrieval_qa.retrieval.query import RetrievedChunk, retrieve_relevant_chunks
+from retrieval_qa.retrieval.query import retrieve_relevant_chunks
 
 _SYSTEM_PROMPT = (
     "You answer the user's question using only the provided passages. "
@@ -36,7 +36,7 @@ _SYSTEM_PROMPT = (
 
 def _build_messages(
     query: str,
-    chunks: Sequence[RetrievedChunk],
+    chunks: Sequence[CitedPassage],
 ) -> list[ChatMessage]:
     """Assemble the chat-completions message list for the inference call.
 
@@ -112,10 +112,9 @@ def run_query(
     messages = _build_messages(query, chunks)
     answer = llm_client.chat(messages)
 
-    cited_passages = [CitedPassage(chunk_id=chunk.chunk_id, text=chunk.text) for chunk in chunks]
     return HarnessAResponse(
         answer=answer,
-        cited_passages=cited_passages,
+        cited_passages=list(chunks),
         grounded=bool(chunks),
     )
 

--- a/api/tests/api/controllers/test_qa_controller.py
+++ b/api/tests/api/controllers/test_qa_controller.py
@@ -7,7 +7,7 @@ import pytest
 
 from api.controllers.qa_controller import run_query
 from core.exceptions import UpstreamBadResponse, UpstreamUnavailable
-from core.types.responses import HarnessAResponse
+from core.types.responses import CitedPassage, HarnessAResponse
 
 
 def _fake_embeddings_client(vector: list[float], side_effect: object | None = None) -> MagicMock:
@@ -37,8 +37,8 @@ def _vector(value: float = 0.5) -> list[float]:
 def test_run_query_grounds_when_retrieval_returns_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
     """Relevant chunks yield grounded=True with cited_passages populated."""
     retrieved_chunks = [
-        MagicMock(chunk_id=uuid4(), text="pgvector supports HNSW indexes."),
-        MagicMock(chunk_id=uuid4(), text="Cosine distance uses the <=> operator."),
+        CitedPassage(chunk_id=uuid4(), text="pgvector supports HNSW indexes."),
+        CitedPassage(chunk_id=uuid4(), text="Cosine distance uses the <=> operator."),
     ]
 
     fake_session = MagicMock()
@@ -238,7 +238,7 @@ def test_run_query_propagates_upstream_bad_response_from_inference(
 
 def test_run_query_passes_chunks_to_llm_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
     """The injected-context prompt embeds referenced chunk text into the user message."""
-    retrieved = [MagicMock(chunk_id=uuid4(), text="chunk A text")]
+    retrieved = [CitedPassage(chunk_id=uuid4(), text="chunk A text")]
 
     monkeypatch.setattr(
         "api.controllers.qa_controller.retrieve_relevant_chunks",

--- a/api/tests/api/test_query.py
+++ b/api/tests/api/test_query.py
@@ -18,6 +18,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from core.exceptions import UpstreamBadResponse, UpstreamUnavailable
+from core.types.responses import CitedPassage
 
 
 def _default_fake_llm_client(*args: object, **kwargs: object) -> MagicMock:
@@ -34,9 +35,9 @@ def _refusal_fake_llm_client(*args: object, **kwargs: object) -> MagicMock:
     return client
 
 
-def _fake_chunk(*, text: str = "chunk text") -> MagicMock:
-    """Build a MagicMock chunk shaped like ``RetrievedChunk``."""
-    return MagicMock(chunk_id=uuid.uuid4(), text=text)
+def _fake_chunk(*, text: str = "chunk text") -> CitedPassage:
+    """Build a CitedPassage chunk for test fixtures."""
+    return CitedPassage(chunk_id=uuid.uuid4(), text=text)
 
 
 # ============================================================

--- a/retrieval_qa/src/retrieval_qa/retrieval/query.py
+++ b/retrieval_qa/src/retrieval_qa/retrieval/query.py
@@ -19,27 +19,12 @@ The cosine distance operator ``<=>`` matches the HNSW index's
 ``vector_cosine_ops`` opclass declared in the Alembic migration (ADR-0014).
 """
 
-from uuid import UUID
-
-from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.exc import InterfaceError, OperationalError
 from sqlalchemy.orm import Session
 
 from core.exceptions import UpstreamUnavailable
-
-
-class RetrievedChunk(BaseModel):
-    """A retrieved chunk with the fields needed downstream.
-
-    ``text`` mirrors ``CitedPassage.text`` (full chunk content) so the QA
-    controller can build both the prompt and the response from one shape
-    without re-fetching.
-    """
-
-    chunk_id: UUID
-    text: str
-
+from core.types.responses import CitedPassage
 
 _RETRIEVE_SQL = text(
     """
@@ -66,7 +51,7 @@ def retrieve_relevant_chunks(
     model_name: str,
     ef_search: int,
     top_k: int,
-) -> list[RetrievedChunk]:
+) -> list[CitedPassage]:
     """Retrieve the top-k closest chunks for ``query_vector`` by cosine distance.
 
     Issues ``SET LOCAL hnsw.ef_search`` inside the caller's transaction and
@@ -104,12 +89,12 @@ def retrieve_relevant_chunks(
     except (OperationalError, InterfaceError) as exc:
         raise UpstreamUnavailable(f"Database unreachable: {exc}") from exc
     rows = result.fetchall()
-    chunks: list[RetrievedChunk] = []
+    chunks: list[CitedPassage] = []
     for row in rows:
         chunk_id = row._mapping["chunk_id"]
         text_content = row._mapping["text"]
-        chunks.append(RetrievedChunk(chunk_id=chunk_id, text=text_content))
+        chunks.append(CitedPassage(chunk_id=chunk_id, text=text_content))
     return chunks
 
 
-__all__ = ["RetrievedChunk", "retrieve_relevant_chunks"]
+__all__ = ["CitedPassage", "retrieve_relevant_chunks"]

--- a/retrieval_qa/tests/retrieval_qa/retrieval/test_query.py
+++ b/retrieval_qa/tests/retrieval_qa/retrieval/test_query.py
@@ -7,7 +7,8 @@ from sqlalchemy.orm import Session
 
 from core.database.schema import Chunk, Document, Embedding
 from core.types.document import DocumentStatus, DocumentType
-from retrieval_qa.retrieval.query import RetrievedChunk, retrieve_relevant_chunks
+from core.types.responses import CitedPassage
+from retrieval_qa.retrieval.query import retrieve_relevant_chunks
 
 
 def _seed_paper(
@@ -75,7 +76,7 @@ def test_retrieve_returns_closest_chunks_by_cosine(test_session: Session) -> Non
 
 
 def test_retrieve_returns_full_chunk_text_not_truncated(test_session: Session) -> None:
-    """RetrievedChunk.text carries the full chunk content."""
+    """CitedPassage.text carries the full chunk content."""
     long_text = "word " * 200
     vector = [0.5] * 1536
     _seed_paper(
@@ -181,14 +182,14 @@ def test_retrieve_empty_corpus_returns_empty_list(test_session: Session) -> None
     assert results == []
 
 
-def test_retrieved_chunk_is_pydantic_model_with_chunk_id_and_text() -> None:
-    """RetrievedChunk exposes chunk_id (UUID) and text (str) fields."""
+def test_cited_passage_is_pydantic_model_with_chunk_id_and_text() -> None:
+    """CitedPassage exposes chunk_id (UUID) and text (str) fields."""
     from uuid import UUID
 
-    fields = set(RetrievedChunk.model_fields)
+    fields = set(CitedPassage.model_fields)
     assert fields == {"chunk_id", "text"}
-    assert RetrievedChunk.model_fields["chunk_id"].annotation is UUID
-    assert RetrievedChunk.model_fields["text"].annotation is str
+    assert CitedPassage.model_fields["chunk_id"].annotation is UUID
+    assert CitedPassage.model_fields["text"].annotation is str
 
 
 def test_retrieve_issues_set_local_ef_search_inside_transaction(


### PR DESCRIPTION
…le model

Replace the duplicate RetrievedChunk model in retrieval_qa with CitedPassage from core/types/responses, eliminating the O(n) mapping in the QA controller. Per ADR-0011 the shared type lives in core since retrieval_qa depends on core.