### PR TITLE
refactor(core): introduce RetrievalConfig to eliminate data clump

### DIFF
--- a/api/src/api/controllers/qa_controller.py
+++ b/api/src/api/controllers/qa_controller.py
@@ -25,6 +25,7 @@ from core.clients.embeddings_client import EmbeddingsClient
 from core.clients.llm_client import LLMClient
 from core.types.chat import ChatMessage
 from core.types.responses import CitedPassage, HarnessAResponse
+from core.types.retrieval_config import RetrievalConfig
 from retrieval_qa.retrieval.query import retrieve_relevant_chunks
 
 _SYSTEM_PROMPT = (
@@ -69,9 +70,7 @@ def run_query(
     session: Session,
     embeddings_client: EmbeddingsClient,
     llm_client: LLMClient,
-    model_name: str,
-    ef_search: int,
-    top_k: int,
+    config: RetrievalConfig,
 ) -> HarnessAResponse:
     """Run the full Harness A query flow and return a ``HarnessAResponse``.
 
@@ -82,10 +81,7 @@ def run_query(
             session's transaction.
         embeddings_client: Client used to embed the query (1536-dim).
         llm_client: Client used to generate the answer.
-        model_name: Active embedding model name (provenance filter on
-            ``embeddings.model_name``).
-        ef_search: HNSW query-time candidate-list size.
-        top_k: Maximum number of chunks to retrieve.
+        config: Retrieval configuration (model name, ef_search, top_k).
 
     Returns:
         A ``HarnessAResponse`` with ``answer`` always populated,
@@ -104,9 +100,7 @@ def run_query(
     chunks = retrieve_relevant_chunks(
         query_vector=query_vector,
         session=session,
-        model_name=model_name,
-        ef_search=ef_search,
-        top_k=top_k,
+        config=config,
     )
 
     messages = _build_messages(query, chunks)

--- a/api/src/api/routes/retrieval_qa.py
+++ b/api/src/api/routes/retrieval_qa.py
@@ -8,6 +8,7 @@ from core.clients.llm_client import LLMClient
 from core.config.settings import settings
 from core.database.connection import db_session
 from core.types.responses import HarnessARequest, HarnessAResponse
+from core.types.retrieval_config import RetrievalConfig
 
 router = APIRouter(tags=["query"])
 
@@ -34,7 +35,9 @@ def query(body: HarnessARequest) -> HarnessAResponse:
                 api_key=settings.openai_api_key,
                 model=settings.inference_model,
             ),
-            model_name=settings.embedding_model,
-            ef_search=settings.hnsw_ef_search,
-            top_k=settings.query_top_k,
+            config=RetrievalConfig(
+                model_name=settings.embedding_model,
+                ef_search=settings.hnsw_ef_search,
+                top_k=settings.query_top_k,
+            ),
         )

--- a/api/tests/api/controllers/test_qa_controller.py
+++ b/api/tests/api/controllers/test_qa_controller.py
@@ -1,5 +1,6 @@
 """Unit tests for the QA controller (clients + retrieval mocked)."""
 
+from typing import cast
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -8,6 +9,7 @@ import pytest
 from api.controllers.qa_controller import run_query
 from core.exceptions import UpstreamBadResponse, UpstreamUnavailable
 from core.types.responses import CitedPassage, HarnessAResponse
+from core.types.retrieval_config import RetrievalConfig
 
 
 def _fake_embeddings_client(vector: list[float], side_effect: object | None = None) -> MagicMock:
@@ -52,9 +54,7 @@ def test_run_query_grounds_when_retrieval_returns_chunks(monkeypatch: pytest.Mon
         session=fake_session,
         embeddings_client=_fake_embeddings_client(_vector()),
         llm_client=_fake_llm_client("Cosine distance via <=> against an HNSW index."),
-        model_name="text-embedding-3-small",
-        ef_search=40,
-        top_k=5,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
     )
 
     assert isinstance(response, HarnessAResponse)
@@ -78,9 +78,7 @@ def test_run_query_not_grounded_when_retrieval_empty(monkeypatch: pytest.MonkeyP
         session=MagicMock(),
         embeddings_client=_fake_embeddings_client(_vector()),
         llm_client=_fake_llm_client("I couldn't find anything relevant in the corpus."),
-        model_name="text-embedding-3-small",
-        ef_search=40,
-        top_k=5,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
     )
 
     assert response.grounded is False
@@ -100,9 +98,7 @@ def test_run_query_answer_field_always_populated(monkeypatch: pytest.MonkeyPatch
         session=MagicMock(),
         embeddings_client=_fake_embeddings_client(_vector()),
         llm_client=_fake_llm_client("firm refusal text"),
-        model_name="text-embedding-3-small",
-        ef_search=40,
-        top_k=5,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
     )
 
     assert response.answer == "firm refusal text"
@@ -128,15 +124,14 @@ def test_run_query_embeds_query_before_retrieval(monkeypatch: pytest.MonkeyPatch
         session=MagicMock(),
         embeddings_client=embeddings_client,
         llm_client=_fake_llm_client("answer"),
-        model_name="text-embedding-3-small",
-        ef_search=42,
-        top_k=3,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=42, top_k=3),
     )
 
     embeddings_client.embed.assert_called_once_with(["what is logits?"])
-    assert captured["model_name"] == "text-embedding-3-small"
-    assert captured["ef_search"] == 42
-    assert captured["top_k"] == 3
+    config = cast(RetrievalConfig, captured["config"])
+    assert config.model_name == "text-embedding-3-small"
+    assert config.ef_search == 42
+    assert config.top_k == 3
     assert captured["query_vector"] == _vector(0.7)
 
 
@@ -158,9 +153,7 @@ def test_run_query_propagates_upstream_unavailable_from_embeddings(
                 side_effect=UpstreamUnavailable("down"),
             ),
             llm_client=_fake_llm_client("answer"),
-            model_name="text-embedding-3-small",
-            ef_search=40,
-            top_k=5,
+            config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
         )
 
 
@@ -182,9 +175,7 @@ def test_run_query_propagates_upstream_bad_response_from_embeddings(
                 side_effect=UpstreamBadResponse("bad"),
             ),
             llm_client=_fake_llm_client("answer"),
-            model_name="text-embedding-3-small",
-            ef_search=40,
-            top_k=5,
+            config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
         )
 
 
@@ -206,9 +197,7 @@ def test_run_query_propagates_upstream_unavailable_from_inference(
                 "answer",
                 side_effect=UpstreamUnavailable("down"),
             ),
-            model_name="text-embedding-3-small",
-            ef_search=40,
-            top_k=5,
+            config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
         )
 
 
@@ -230,9 +219,7 @@ def test_run_query_propagates_upstream_bad_response_from_inference(
                 "answer",
                 side_effect=UpstreamBadResponse("bad"),
             ),
-            model_name="text-embedding-3-small",
-            ef_search=40,
-            top_k=5,
+            config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
         )
 
 
@@ -251,9 +238,7 @@ def test_run_query_passes_chunks_to_llm_prompt(monkeypatch: pytest.MonkeyPatch) 
         session=MagicMock(),
         embeddings_client=_fake_embeddings_client(_vector()),
         llm_client=llm_client,
-        model_name="text-embedding-3-small",
-        ef_search=40,
-        top_k=5,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
     )
 
     llm_client.chat.assert_called_once()
@@ -278,9 +263,7 @@ def test_run_query_no_chunks_prompt_does_not_include_passage_text(
         session=MagicMock(),
         embeddings_client=_fake_embeddings_client(_vector()),
         llm_client=llm_client,
-        model_name="text-embedding-3-small",
-        ef_search=40,
-        top_k=5,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
     )
 
     llm_client.chat.assert_called_once()

--- a/core/src/core/types/__init__.py
+++ b/core/src/core/types/__init__.py
@@ -11,6 +11,7 @@ from core.types.document import (
     DocumentStatusResponse,
     DocumentType,
 )
+from core.types.retrieval_config import RetrievalConfig
 
 __all__ = [
     "BookChunkMetadata",
@@ -20,4 +21,5 @@ __all__ = [
     "DocumentType",
     "DocumentationChunkMetadata",
     "PaperChunkMetadata",
+    "RetrievalConfig",
 ]

--- a/core/src/core/types/retrieval_config.py
+++ b/core/src/core/types/retrieval_config.py
@@ -1,0 +1,30 @@
+"""Retrieval configuration model.
+
+Encapsulates the parameters that control pgvector similarity search:
+embedding model provenance filter, HNSW candidate-list size, and result
+limit. Carried as a single object across the retrieval boundary so that
+adding a new parameter (e.g. ``rerank_k``, ``min_score``) does not require
+threading it through every call site.
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class RetrievalConfig(BaseModel):
+    """Configuration for a pgvector similarity-search query.
+
+    Attributes:
+        model_name: Active embedding model name (provenance filter on
+            ``embeddings.model_name``).
+        ef_search: HNSW query-time candidate-list size (``hnsw.ef_search``).
+        top_k: Maximum number of chunks to return.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    model_name: str
+    ef_search: int
+    top_k: int
+
+
+__all__ = ["RetrievalConfig"]

--- a/retrieval_qa/src/retrieval_qa/retrieval/query.py
+++ b/retrieval_qa/src/retrieval_qa/retrieval/query.py
@@ -25,6 +25,7 @@ from sqlalchemy.orm import Session
 
 from core.exceptions import UpstreamUnavailable
 from core.types.responses import CitedPassage
+from core.types.retrieval_config import RetrievalConfig
 
 _RETRIEVE_SQL = text(
     """
@@ -48,9 +49,7 @@ def retrieve_relevant_chunks(
     *,
     query_vector: list[float],
     session: Session,
-    model_name: str,
-    ef_search: int,
-    top_k: int,
+    config: RetrievalConfig,
 ) -> list[CitedPassage]:
     """Retrieve the top-k closest chunks for ``query_vector`` by cosine distance.
 
@@ -62,9 +61,7 @@ def retrieve_relevant_chunks(
         session: SQLAlchemy session bound to the documents database. The
             ``SET LOCAL`` is scoped to the current transaction, so callers
             should not commit before consuming the results.
-        model_name: Embedding model name to filter on (provenance column).
-        ef_search: HNSW candidate-list size for this query.
-        top_k: Maximum number of chunks to return.
+        config: Retrieval configuration (model name, ef_search, top_k).
 
     Returns:
         Chunks in ascending cosine-distance order. An empty list signals the
@@ -80,10 +77,10 @@ def retrieve_relevant_chunks(
         result = session.execute(
             _RETRIEVE_SQL,
             {
-                "ef_search": ef_search,
-                "model_name": model_name,
+                "ef_search": config.ef_search,
+                "model_name": config.model_name,
                 "query_vector": str(query_vector),
-                "top_k": top_k,
+                "top_k": config.top_k,
             },
         )
     except (OperationalError, InterfaceError) as exc:

--- a/retrieval_qa/tests/retrieval_qa/retrieval/test_query.py
+++ b/retrieval_qa/tests/retrieval_qa/retrieval/test_query.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 from core.database.schema import Chunk, Document, Embedding
 from core.types.document import DocumentStatus, DocumentType
 from core.types.responses import CitedPassage
+from core.types.retrieval_config import RetrievalConfig
 from retrieval_qa.retrieval.query import retrieve_relevant_chunks
 
 
@@ -64,9 +65,7 @@ def test_retrieve_returns_closest_chunks_by_cosine(test_session: Session) -> Non
     results = retrieve_relevant_chunks(
         query_vector=near,
         session=test_session,
-        model_name="text-embedding-3-small",
-        ef_search=40,
-        top_k=2,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=2),
     )
 
     assert len(results) == 2
@@ -89,9 +88,7 @@ def test_retrieve_returns_full_chunk_text_not_truncated(test_session: Session) -
     results = retrieve_relevant_chunks(
         query_vector=vector,
         session=test_session,
-        model_name="text-embedding-3-small",
-        ef_search=40,
-        top_k=1,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=1),
     )
 
     assert len(results) == 1
@@ -111,9 +108,7 @@ def test_retrieve_respects_top_k_limit(test_session: Session) -> None:
     results = retrieve_relevant_chunks(
         query_vector=vector,
         session=test_session,
-        model_name="text-embedding-3-small",
-        ef_search=40,
-        top_k=3,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=3),
     )
 
     assert len(results) == 3
@@ -141,9 +136,7 @@ def test_retrieve_only_returns_chunks_from_ready_documents(
     results = retrieve_relevant_chunks(
         query_vector=vector,
         session=test_session,
-        model_name="text-embedding-3-small",
-        ef_search=40,
-        top_k=5,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
     )
 
     assert len(results) == 1
@@ -162,9 +155,7 @@ def test_retrieve_scopes_embeddings_to_model_name(test_session: Session) -> None
     results = retrieve_relevant_chunks(
         query_vector=[0.5] * 1536,
         session=test_session,
-        model_name="some-other-model",
-        ef_search=40,
-        top_k=5,
+        config=RetrievalConfig(model_name="some-other-model", ef_search=40, top_k=5),
     )
 
     assert results == []
@@ -175,9 +166,7 @@ def test_retrieve_empty_corpus_returns_empty_list(test_session: Session) -> None
     results = retrieve_relevant_chunks(
         query_vector=[0.5] * 1536,
         session=test_session,
-        model_name="text-embedding-3-small",
-        ef_search=40,
-        top_k=5,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
     )
     assert results == []
 
@@ -224,9 +213,7 @@ def test_retrieve_issues_set_local_ef_search_inside_transaction(
         retrieve_relevant_chunks(
             query_vector=vector,
             session=test_session,
-            model_name="text-embedding-3-small",
-            ef_search=123,
-            top_k=1,
+            config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=123, top_k=1),
         )
     finally:
         event.remove(test_session.bind, "before_cursor_execute", _before_cursor_execute)
@@ -254,9 +241,7 @@ def test_retrieve_returns_empty_list_when_query_vector_wrong_dim(
         retrieve_relevant_chunks(
             query_vector=[0.5] * 10,  # wrong dim
             session=test_session,
-            model_name="text-embedding-3-small",
-            ef_search=40,
-            top_k=1,
+            config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=1),
         )
 
 
@@ -276,7 +261,5 @@ def test_retrieve_wraps_db_connection_error_as_upstream_unavailable() -> None:
         retrieve_relevant_chunks(
             query_vector=[0.5] * 1536,
             session=fake_session,
-            model_name="text-embedding-3-small",
-            ef_search=40,
-            top_k=1,
+            config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=1),
         )


### PR DESCRIPTION
Replace the three individual params (model_name, ef_search, top_k) in retrieve_relevant_chunks and run_query with a single RetrievalConfig Pydantic model.

Closes #29