### PR TITLE
refactor(ingestion): replace raw-string dispatch with DocumentType enum

### DIFF
--- a/api/src/api/routes/ingest.py
+++ b/api/src/api/routes/ingest.py
@@ -80,7 +80,7 @@ async def ingest_document(
     schedule_ingestion(
         background_tasks,
         document_id=document_id,
-        document_type=document_type.value,
+        document_type=document_type,
         source_filename=source_filename,
         file_bytes=file_bytes,
     )

--- a/ingestion/src/ingestion/pipeline.py
+++ b/ingestion/src/ingestion/pipeline.py
@@ -1,6 +1,7 @@
 """Background ingestion pipeline for uploaded documents."""
 
 from collections.abc import Sequence
+from typing import assert_never
 from uuid import UUID
 
 from sqlalchemy.orm import Session
@@ -8,7 +9,7 @@ from sqlalchemy.orm import Session
 from core.clients.embeddings_client import EmbeddingsClient
 from core.database.schema import Chunk, Document, Embedding
 from core.exceptions import IngestionError
-from core.types.document import DocumentStatus
+from core.types.document import DocumentStatus, DocumentType
 from retrieval_qa.chunking.book_chunker import BookChunk, chunk_book
 from retrieval_qa.chunking.paper_chunker import PaperChunk, chunk_paper
 
@@ -27,21 +28,24 @@ def _chunk_inputs(
 
 
 def _chunk_document(
-    document_type: str,
+    document_type: DocumentType,
     file_bytes: bytes,
 ) -> list[tuple[str, dict[str, object], int]]:
     """Return (content, type_metadata, token_count) tuples for a document.
 
-    Dispatches to the document-type-specific chunker. Unknown types are
-    deliberately rejected so the schema stays document-type-aware.
+    Dispatches to the document-type-specific chunker. The ``match`` /
+    ``assert_never`` pair provides compile-time exhaustiveness: adding a new
+    ``DocumentType`` member produces a type-check error at every dispatch site.
     """
-    if document_type == "paper":
-        return _chunk_inputs(chunk_paper(file_bytes))
-
-    if document_type == "book":
-        return _chunk_inputs(chunk_book(file_bytes))
-
-    raise IngestionError(f"Chunker not implemented for document type: {document_type}")
+    match document_type:
+        case DocumentType.PAPER:
+            return _chunk_inputs(chunk_paper(file_bytes))
+        case DocumentType.BOOK:
+            return _chunk_inputs(chunk_book(file_bytes))
+        case DocumentType.DOCUMENTATION:
+            raise IngestionError(f"Chunker not implemented for document type: {document_type}")
+        case _ as unreachable:
+            assert_never(unreachable)
 
 
 def _embed_chunks(
@@ -71,7 +75,7 @@ def _embed_chunks(
 def run_ingestion(
     document_id: UUID,
     title: str,
-    document_type: str,
+    document_type: DocumentType,
     source_filename: str,
     file_bytes: bytes,
     session: Session,
@@ -88,7 +92,7 @@ def run_ingestion(
     Args:
         document_id: UUID of the document row created at upload time.
         title: Document title supplied by the user.
-        document_type: Lower-case document type (e.g. ``"paper"``).
+        document_type: Document type (e.g. ``DocumentType.PAPER``).
         source_filename: Original upload filename.
         file_bytes: Raw uploaded file contents.
         session: SQLAlchemy session bound to the documents database.

--- a/ingestion/src/ingestion/tasks.py
+++ b/ingestion/src/ingestion/tasks.py
@@ -14,13 +14,13 @@ from core.config.settings import settings
 from core.database.connection import SessionLocal
 from core.database.schema import Document
 from core.exceptions import IngestionError
-from core.types.document import DocumentStatus
+from core.types.document import DocumentStatus, DocumentType
 from ingestion.pipeline import run_ingestion
 
 
 def _execute_ingestion_task(
     document_id: UUID,
-    document_type: str,
+    document_type: DocumentType,
     source_filename: str,
     file_bytes: bytes,
 ) -> None:
@@ -75,7 +75,7 @@ def _execute_ingestion_task(
 def schedule_ingestion(
     background_tasks: BackgroundTasks,
     document_id: UUID,
-    document_type: str,
+    document_type: DocumentType,
     source_filename: str,
     file_bytes: bytes,
 ) -> None:
@@ -84,7 +84,7 @@ def schedule_ingestion(
     Args:
         background_tasks: FastAPI's background task container.
         document_id: UUID of the newly created document row.
-        document_type: Lower-case document type string.
+        document_type: Document type (e.g. ``DocumentType.PAPER``).
         source_filename: Original upload filename.
         file_bytes: Raw uploaded file contents.
     """

--- a/ingestion/tests/ingestion/test_pipeline.py
+++ b/ingestion/tests/ingestion/test_pipeline.py
@@ -40,7 +40,7 @@ def test_pipeline_happy_path_reaches_ready(
     run_ingestion(
         document_id=document.document_id,
         title="Sample Paper",
-        document_type="paper",
+        document_type=DocumentType.PAPER,
         source_filename="sample.pdf",
         file_bytes=sample_paper_pdf,
         session=test_session,
@@ -91,7 +91,7 @@ def test_pipeline_failure_marks_failed_with_error(
         run_ingestion(
             document_id=document.document_id,
             title="Failing Paper",
-            document_type="paper",
+            document_type=DocumentType.PAPER,
             source_filename="fail.pdf",
             file_bytes=sample_paper_pdf,
             session=test_session,
@@ -123,7 +123,7 @@ def test_pipeline_book_happy_path_reaches_ready(
     run_ingestion(
         document_id=document.document_id,
         title="Sample Book",
-        document_type="book",
+        document_type=DocumentType.BOOK,
         source_filename="sample.pdf",
         file_bytes=sample_book_pdf,
         session=test_session,
@@ -169,7 +169,7 @@ def test_pipeline_rejects_unsupported_document_type(
         run_ingestion(
             document_id=document.document_id,
             title="Unknown",
-            document_type="documentation",
+            document_type=DocumentType.DOCUMENTATION,
             source_filename="docs.md",
             file_bytes=b"contents",
             session=test_session,
@@ -194,7 +194,7 @@ def test_reingestion_creates_new_document_id(
     run_ingestion(
         document_id=first.document_id,
         title="Paper",
-        document_type="paper",
+        document_type=DocumentType.PAPER,
         source_filename="sample.pdf",
         file_bytes=sample_paper_pdf,
         session=test_session,
@@ -217,7 +217,7 @@ def test_reingestion_creates_new_document_id(
     run_ingestion(
         document_id=second.document_id,
         title="Paper",
-        document_type="paper",
+        document_type=DocumentType.PAPER,
         source_filename="sample.pdf",
         file_bytes=sample_paper_pdf,
         session=test_session,

--- a/ingestion/tests/ingestion/test_tasks.py
+++ b/ingestion/tests/ingestion/test_tasks.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+from core.types.document import DocumentType
 from ingestion.tasks import schedule_ingestion
 
 
@@ -14,7 +15,7 @@ def test_schedule_ingestion_adds_background_task() -> None:
     schedule_ingestion(
         background_tasks=mock_bg,
         document_id=doc_id,
-        document_type="paper",
+        document_type=DocumentType.PAPER,
         source_filename="test.pdf",
         file_bytes=b"fake-pdf-bytes",
     )
@@ -25,7 +26,7 @@ def test_schedule_ingestion_adds_background_task() -> None:
     assert callable(args[0][0])
     # Remaining positional args match the arguments passed through
     assert args[0][1] == doc_id
-    assert args[0][2] == "paper"
+    assert args[0][2] == DocumentType.PAPER
     assert args[0][3] == "test.pdf"
     assert args[0][4] == b"fake-pdf-bytes"
 

--- a/retrieval_qa/src/retrieval_qa/chunking/book_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/book_chunker.py
@@ -8,6 +8,7 @@ import os
 import re
 import xml.etree.ElementTree as ET
 import zipfile
+from enum import StrEnum
 from html.parser import HTMLParser
 from io import BytesIO
 
@@ -16,6 +17,14 @@ from pypdf import PdfReader
 
 from core.exceptions import IngestionError
 from core.types.chunk import BookChunkMetadata
+
+
+class BookFormat(StrEnum):
+    """Supported book file formats for ingestion."""
+
+    PDF = "pdf"
+    EPUB = "epub"
+
 
 # Matches lines that look like chapter headers, e.g.:
 #   "Chapter 1"
@@ -253,10 +262,10 @@ def _extract_text_from_epub(epub_bytes: bytes) -> str:
         raise IngestionError(f"Failed to parse EPUB: {exc}") from exc
 
 
-def _detect_format(file_bytes: bytes) -> str:
+def _detect_format(file_bytes: bytes) -> BookFormat:
     """Detect whether ``file_bytes`` is a PDF or EPUB."""
     if file_bytes.startswith(b"%PDF"):
-        return "pdf"
+        return BookFormat.PDF
 
     if file_bytes.startswith(b"PK"):
         try:
@@ -264,7 +273,7 @@ def _detect_format(file_bytes: bytes) -> str:
                 if "mimetype" in archive.namelist():
                     mimetype = archive.read("mimetype").strip().lower()
                     if mimetype == b"application/epub+zip":
-                        return "epub"
+                        return BookFormat.EPUB
         except zipfile.BadZipFile:
             pass
 
@@ -285,7 +294,7 @@ def chunk_book(file_bytes: bytes) -> list[BookChunk]:
             book format.
     """
     document_format = _detect_format(file_bytes)
-    if document_format == "pdf":
+    if document_format is BookFormat.PDF:
         text = _extract_text_from_pdf(file_bytes)
     else:
         text = _extract_text_from_epub(file_bytes)


### PR DESCRIPTION
Replace str-based document type dispatch with typed DocumentType StrEnum across the ingestion pipeline. The _chunk_document dispatcher now uses match/case + assert_never for compile-time exhaustiveness, so adding a new DocumentType member produces a type-check error at every dispatch site lacking a handler.

Changes:
- pipeline.py: _chunk_document and run_ingestion accept DocumentType
- tasks.py: _execute_ingestion_task and schedule_ingestion accept DocumentType
- api/routes/ingest.py: pass document_type directly, no .value conversion
- book_chunker.py: add BookFormat StrEnum, _detect_format returns BookFormat

Closes #37