### PR TITLE
fix(retrieval-qa): make EPUB chunker structure-aware instead of regex…

### DIFF
--- a/retrieval_qa/src/retrieval_qa/chunking/book_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/book_chunker.py
@@ -83,6 +83,70 @@ class _HTMLTextExtractor(HTMLParser):
         return re.sub(r"\n\s*\n+", "\n\n", text).strip()
 
 
+class _SectionExtractor(HTMLParser):
+    """Parse XHTML into heading-delimited sections.
+
+    Records ``(heading_level, heading_text, body_text)`` tuples where
+    *heading_level* is 1--6 for ``<h1>``--``<h6>`` (``None`` for preamble
+    before the first heading).
+    """
+
+    _HEADING_TAGS = frozenset({"h1", "h2", "h3", "h4", "h5", "h6"})
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.sections: list[tuple[int | None, str | None, str]] = []
+        self._current_level: int | None = None
+        self._current_heading: str | None = None
+        self._current_parts: list[str] = []
+        self._skip = False
+        self._in_heading = False
+        self._heading_parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in {"script", "style", "head"}:
+            self._skip = True
+        elif tag in self._HEADING_TAGS:
+            self._flush_body_section()
+            self._in_heading = True
+            self._current_level = int(tag[1])
+            self._heading_parts = []
+        elif tag in {"p", "div", "li", "br"}:
+            self._current_parts.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"script", "style", "head"}:
+            self._skip = False
+        elif tag in self._HEADING_TAGS:
+            self._in_heading = False
+            heading_text = "".join(self._heading_parts).strip()
+            self._current_heading = heading_text if heading_text else None
+        elif tag in {"p", "div", "li"}:
+            self._current_parts.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if self._skip:
+            return
+        if self._in_heading:
+            self._heading_parts.append(data)
+        else:
+            self._current_parts.append(data)
+
+    def _flush_body_section(self) -> None:
+        text = "".join(self._current_parts)
+        text = re.sub(r"\n\s*\n+", "\n\n", text).strip()
+        if text:
+            self.sections.append((self._current_level, self._current_heading, text))
+        self._current_parts = []
+        self._current_heading = None
+        self._current_level = None
+
+    def get_sections(self) -> list[tuple[int | None, str | None, str]]:
+        """Return the list of ``(level, heading, body)`` tuples extracted."""
+        self._flush_body_section()
+        return self.sections
+
+
 def _count_tokens(text: str) -> int:
     """Approximate token count for chunk sizing.
 
@@ -229,8 +293,40 @@ def _parse_opf(opf_content: str) -> tuple[list[str], dict[str, str]]:
     return spine_order, item_map
 
 
-def _extract_text_from_epub(epub_bytes: bytes) -> str:
-    """Extract text from an EPUB byte stream."""
+def _extract_epub_text(
+    archive: zipfile.ZipFile,
+    opf_dir: str,
+    spine_order: list[str],
+    item_map: dict[str, str],
+) -> str:
+    """Extract plain text from EPUB spine items (legacy tag-stripping path)."""
+    parts: list[str] = []
+    for item_id in spine_order:
+        href = item_map.get(item_id)
+        if href is None:
+            continue
+        file_path = os.path.normpath(os.path.join(opf_dir, href)) if opf_dir else href
+        try:
+            raw = archive.read(file_path).decode("utf-8")
+        except KeyError:
+            raw = archive.read(href).decode("utf-8")
+
+        extractor = _HTMLTextExtractor()
+        extractor.feed(raw)
+        text = extractor.get_text()
+        if text:
+            parts.append(text)
+    return "\n\n".join(parts)
+
+
+def _extract_chapters_from_epub(epub_bytes: bytes) -> list[tuple[int, str | None, str]]:
+    """Extract chapters from an EPUB using native HTML heading structure.
+
+    Uses the EPUB spine order and HTML heading tags (``<h1>``--``<h6>``) to
+    identify chapter and section boundaries.  ``<h1>`` increments the chapter
+    number; ``<h2>``--``<h6>`` are treated as sub-sections within the current
+    chapter.  Falls back to regex heuristics when no heading tags are present.
+    """
     try:
         with zipfile.ZipFile(BytesIO(epub_bytes)) as archive:
             container_xml = archive.read("META-INF/container.xml").decode("utf-8")
@@ -240,7 +336,9 @@ def _extract_text_from_epub(epub_bytes: bytes) -> str:
             opf_content = archive.read(opf_path).decode("utf-8")
             spine_order, item_map = _parse_opf(opf_content)
 
-            parts: list[str] = []
+            # Phase 1 -- structure-aware extraction via HTML headings
+            all_section_data: list[list[tuple[int | None, str | None, str]]] = []
+            total_headings = 0
             for item_id in spine_order:
                 href = item_map.get(item_id)
                 if href is None:
@@ -251,13 +349,27 @@ def _extract_text_from_epub(epub_bytes: bytes) -> str:
                 except KeyError:
                     raw = archive.read(href).decode("utf-8")
 
-                extractor = _HTMLTextExtractor()
+                extractor = _SectionExtractor()
                 extractor.feed(raw)
-                text = extractor.get_text()
-                if text:
-                    parts.append(text)
+                extractor.close()
+                sections = extractor.get_sections()
+                all_section_data.append(sections)
+                total_headings += sum(1 for level, _, _ in sections if level is not None)
 
-            return "\n\n".join(parts)
+            if total_headings > 0:
+                chapters: list[tuple[int, str | None, str]] = []
+                chapter_number = 0
+                for item_sections in all_section_data:
+                    for level, heading, body in item_sections:
+                        if level == 1:
+                            chapter_number += 1
+                        content = f"{heading}\n\n{body}" if heading else body
+                        chapters.append((chapter_number, heading, content))
+                return chapters
+
+            # Phase 2 -- no headings found, fall back to regex heuristics
+            text = _extract_epub_text(archive, opf_dir, spine_order, item_map)
+            return _split_into_chapters(text)
     except Exception as exc:
         raise IngestionError(f"Failed to parse EPUB: {exc}") from exc
 
@@ -295,15 +407,18 @@ def chunk_book(file_bytes: bytes) -> list[BookChunk]:
     """
     document_format = _detect_format(file_bytes)
     if document_format is BookFormat.PDF:
-        text = _extract_text_from_pdf(file_bytes)
+        raw_text = _extract_text_from_pdf(file_bytes)
+        if not raw_text.strip():
+            raise IngestionError("Book contains no extractable text")
+        chapters = _split_into_chapters(raw_text)
     else:
-        text = _extract_text_from_epub(file_bytes)
+        chapters = _extract_chapters_from_epub(file_bytes)
 
-    if not text.strip():
+    if not chapters:
         raise IngestionError("Book contains no extractable text")
 
     chunks: list[BookChunk] = []
-    for chapter, heading, body in _split_into_chapters(text):
+    for chapter, heading, body in chapters:
         if not body.strip():
             continue
         metadata = BookChunkMetadata(chapter=chapter, heading=heading)
@@ -315,14 +430,15 @@ def chunk_book(file_bytes: bytes) -> list[BookChunk]:
             )
         )
 
-    # If the heuristic found no usable sections, emit the whole document as a
-    # single chunk so the pipeline never produces zero chunks.
+    # If no section produced usable content, emit the whole document as a single
+    # chunk so the pipeline never produces zero chunks.
     if not chunks:
+        full_text = "\n\n".join(body for _, _, body in chapters)
         chunks.append(
             BookChunk(
-                content=text,
+                content=full_text,
                 metadata=BookChunkMetadata(chapter=1, heading=None),
-                token_count=_count_tokens(text),
+                token_count=_count_tokens(full_text),
             )
         )
 

--- a/retrieval_qa/tests/retrieval_qa/test_book_chunker.py
+++ b/retrieval_qa/tests/retrieval_qa/test_book_chunker.py
@@ -1,10 +1,70 @@
 """Tests for the book chunker."""
 
+import io
+import zipfile
+
 import pytest
 
 from core.exceptions import IngestionError
 from core.types.chunk import BookChunkMetadata
 from retrieval_qa.chunking.book_chunker import chunk_book
+
+
+def _make_epub(chapters: list[tuple[str, str, str]]) -> bytes:
+    """Build an in-memory EPUB from chapter specs.
+
+    Each tuple is ``(file_name, xhtml_body, spine_idref)``.
+
+    The *xhtml_body* is placed directly inside ``<body>...</body>``.
+    All chapters share the same OPF manifest/spine structure.
+    """
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("mimetype", "application/epub+zip", compress_type=zipfile.ZIP_STORED)
+        zf.writestr(
+            "META-INF/container.xml",
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<container version="1.0"'
+            ' xmlns="urn:oasis:names:tc:opendocument:xmlns:container">'
+            "<rootfiles>"
+            '<rootfile full-path="OEBPS/content.opf"'
+            ' media-type="application/oebps-package+xml"/>'
+            "</rootfiles>"
+            "</container>",
+        )
+        items_xml = ""
+        spine_xml = ""
+        for file_name, _body, spine_idref in chapters:
+            items_xml += (
+                f'<item id="{spine_idref}" href="{file_name}" media-type="application/xhtml+xml"/>'
+            )
+            spine_xml += f'<itemref idref="{spine_idref}"/>'
+        zf.writestr(
+            "OEBPS/content.opf",
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<package xmlns="http://www.idpf.org/2007/opf"'
+            ' unique-identifier="bookid" version="2.0">'
+            "<metadata>"
+            '<dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">Test Book</dc:title>'
+            '<dc:identifier xmlns:dc="http://purl.org/dc/elements/1.1/"'
+            ' id="bookid">test-001</dc:identifier>'
+            '<dc:language xmlns:dc="http://purl.org/dc/elements/1.1/">en</dc:language>'
+            "</metadata>"
+            f"<manifest>{items_xml}</manifest>"
+            f"<spine>{spine_xml}</spine>"
+            "</package>",
+        )
+        for file_name, body, _spine_idref in chapters:
+            zf.writestr(
+                f"OEBPS/{file_name}",
+                '<?xml version="1.0" encoding="utf-8"?>'
+                "<!DOCTYPE html>"
+                '<html xmlns="http://www.w3.org/1999/xhtml">'
+                "<head><title>Test</title></head>"
+                f"<body>{body}</body></html>",
+            )
+    buffer.seek(0)
+    return buffer.read()
 
 
 def test_book_chunker_emits_chapters(sample_book_pdf: bytes) -> None:
@@ -52,3 +112,87 @@ def test_book_chunk_metadata_validates_at_boundary(sample_book_pdf: bytes) -> No
         # model_validate should succeed and extra='forbid' means unknown keys
         # would have already raised during construction.
         assert BookChunkMetadata.model_validate(chunk.metadata.model_dump())
+
+
+def test_epub_chunks_by_heading_tags() -> None:
+    """EPUB with ``<h1>`` headings (no 'Chapter N' text) splits correctly."""
+    epub = _make_epub(
+        [
+            ("ch1.xhtml", "<h1>The Beginning</h1><p>First chapter content.</p>", "ch1"),
+            ("ch2.xhtml", "<h1>The Middle</h1><p>Second chapter content.</p>", "ch2"),
+            ("ch3.xhtml", "<h1>The End</h1><p>Third chapter content.</p>", "ch3"),
+        ]
+    )
+    chunks = chunk_book(epub)
+
+    assert len(chunks) == 3
+    assert [c.metadata.chapter for c in chunks] == [1, 2, 3]
+    assert [c.metadata.heading for c in chunks] == [
+        "The Beginning",
+        "The Middle",
+        "The End",
+    ]
+    assert all("Chapter" not in c.content for c in chunks)
+
+
+def test_epub_heading_content_included_in_chunk() -> None:
+    """Heading text appears in both chunk content and metadata."""
+    epub = _make_epub(
+        [
+            ("ch1.xhtml", "<h1>Part One</h1><p>Some text.</p>", "ch1"),
+        ]
+    )
+    chunks = chunk_book(epub)
+
+    assert len(chunks) == 1
+    assert chunks[0].metadata.heading == "Part One"
+    assert chunks[0].content.startswith("Part One")
+    assert "Some text." in chunks[0].content
+
+
+def test_epub_subheadings_same_chapter() -> None:
+    """``<h2>`` sub-headings produce additional chunks within the same chapter."""
+    epub = _make_epub(
+        [
+            (
+                "ch1.xhtml",
+                "<h1>Chapter 1</h1>"
+                "<p>Introduction.</p>"
+                "<h2>Section A</h2><p>Content A.</p>"
+                "<h2>Section B</h2><p>Content B.</p>",
+                "ch1",
+            ),
+        ]
+    )
+    chunks = chunk_book(epub)
+
+    assert len(chunks) == 3
+    assert [c.metadata.chapter for c in chunks] == [1, 1, 1]
+    assert [c.metadata.heading for c in chunks] == ["Chapter 1", "Section A", "Section B"]
+
+
+def test_epub_fallback_to_regex_when_no_headings() -> None:
+    """EPUB without heading tags falls back to regex heuristics."""
+    epub = _make_epub(
+        [
+            (
+                "ch1.xhtml",
+                "<p>Chapter 1</p><p>The beginning of the story.</p>",
+                "ch1",
+            ),
+            (
+                "ch2.xhtml",
+                "<p>Chapter 2</p><p>The story continues.</p>",
+                "ch2",
+            ),
+        ]
+    )
+    chunks = chunk_book(epub)
+
+    # Regex should detect "Chapter 1" / "Chapter 2" as chapter boundaries
+    chapters = {c.metadata.chapter for c in chunks}
+    assert 1 in chapters
+    assert 2 in chapters
+    # Exactly one chunk per chapter (no subheadings in plain <p> text)
+    assert len(chunks) == 2
+    assert [c.metadata.heading for c in chunks] == [None, None]


### PR DESCRIPTION
…-only

The EPUB chunker was stripping all HTML tags and then re-inferring chapter boundaries via fragile regex heuristics. This meant EPUBs whose headings did not match the 'Chapter N' pattern were not split correctly.

- Add _SectionExtractor that parses XHTML and preserves heading semantics as (heading_level, heading_text, body_text) tuples
- Replace _extract_text_from_epub with _extract_chapters_from_epub that uses the native spine order and HTML heading tags for section boundaries
- <h1> increments chapter number; <h2>+ are sub-sections within the same chapter
- EPUBs without HTML headings fall back to the existing regex heuristics
- PDF chunking is unaffected (still uses old heuristic path)

Fixes #39