### PR TITLE
fix(ingestion): add pipeline-level type_metadata validation before DB…

### DIFF
--- a/docs/adr/0014-data-schema-and-api-contracts-for-harness-a.md
+++ b/docs/adr/0014-data-schema-and-api-contracts-for-harness-a.md
@@ -74,7 +74,12 @@ Schema-level chunk metadata is JSONB; the *shape contract* is enforced in Python
 - `BookChunkMetadata{chapter: int, heading: str | None}`
 - `DocumentationChunkMetadata{page: str, section: str | None}`
 
-All three with `model_config = ConfigDict(extra="forbid")` — a chunker bug surfacing an unknown key fails at the application write boundary, before persisting unvalidated JSONB. The chunker implementations (in `retrieval_qa/chunking/`, per `ai-system-tree.md`) and the retrieval code (in `retrieval_qa/retrieval/`) both import from `core/types/`; both depend on `core`, never on each other (ADR-0011 preserved).
+All three with `model_config = ConfigDict(extra="forbid")` — a chunker bug surfacing an unknown key fails at the application write boundary, before persisting unvalidated JSONB. Enforcement is **two-layer**:
+
+1. **Chunker construction** — each chunker builds the Pydantic model directly (e.g. `BookChunkMetadata(chapter=..., heading=...)`), which validates types and rejects unknown keys at Python object construction time.
+2. **Pipeline re-validation** — the ingestion pipeline's `_validate_type_metadata()` function in `ingestion/pipeline.py` calls `model_validate()` on the serialized dict just before the SQLAlchemy `Chunk(row)` write. This catches any code path that constructs `type_metadata` as a raw dict without passing through the Pydantic constructor.
+
+The chunker implementations (in `retrieval_qa/chunking/`, per `ai-system-tree.md`) and the retrieval code (in `retrieval_qa/retrieval/`) both import from `core/types/`; both depend on `core`, never on each other (ADR-0011 preserved).
 
 Rejected alternatives:
 - **Pure JSONB with no Python contract** (Option A) — leaves the contract implicit in two places' heads; a chunker bug that writes `{page: "seven"}` (page as string) lands in the DB silently.

--- a/ingestion/src/ingestion/pipeline.py
+++ b/ingestion/src/ingestion/pipeline.py
@@ -4,16 +4,51 @@ from collections.abc import Sequence
 from typing import assert_never
 from uuid import UUID
 
+from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
 from core.clients.embeddings_client import EmbeddingsClient
 from core.database.schema import Chunk, Document, Embedding
 from core.exceptions import IngestionError
+from core.types.chunk import (
+    BookChunkMetadata,
+    DocumentationChunkMetadata,
+    PaperChunkMetadata,
+)
 from core.types.document import DocumentStatus, DocumentType
 from retrieval_qa.chunking.book_chunker import BookChunk, chunk_book
 from retrieval_qa.chunking.paper_chunker import PaperChunk, chunk_paper
 
 _Chunk = PaperChunk | BookChunk
+
+
+def _validate_type_metadata(
+    document_type: DocumentType,
+    type_metadata: dict[str, object],
+) -> None:
+    """Validate type_metadata against the Pydantic model for the document type.
+
+    This is the second layer of enforcement (the first being Pydantic
+    construction in the chunker itself).  Running it here, just before the
+    SQLAlchemy write, ensures that no code path — even one that bypasses the
+    chunker — can persist invalid metadata to the JSONB column.
+
+    Raises ``IngestionError`` when validation fails.
+    """
+    try:
+        match document_type:
+            case DocumentType.PAPER:
+                PaperChunkMetadata.model_validate(type_metadata)
+            case DocumentType.BOOK:
+                BookChunkMetadata.model_validate(type_metadata)
+            case DocumentType.DOCUMENTATION:
+                DocumentationChunkMetadata.model_validate(type_metadata)
+            case _ as unreachable:
+                assert_never(unreachable)
+    except ValidationError as exc:
+        raise IngestionError(
+            f"type_metadata validation failed for {document_type.value}: {exc}"
+        ) from exc
 
 
 def _chunk_inputs(
@@ -114,6 +149,7 @@ def run_ingestion(
 
         db_chunks: list[Chunk] = []
         for position, (content, type_metadata, token_count) in enumerate(chunk_inputs):
+            _validate_type_metadata(document_type, type_metadata)
             chunk = Chunk(
                 document_id=document_id,
                 position=position,

--- a/ingestion/tests/ingestion/test_pipeline.py
+++ b/ingestion/tests/ingestion/test_pipeline.py
@@ -1,6 +1,6 @@
 """Integration tests for the ingestion pipeline."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy.orm import Session
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from core.database.schema import Chunk, Document, Embedding
 from core.exceptions import IngestionError
 from core.types.document import DocumentStatus, DocumentType
-from ingestion.pipeline import run_ingestion
+from ingestion.pipeline import _validate_type_metadata, run_ingestion
 
 
 @pytest.fixture
@@ -235,3 +235,173 @@ def test_reingestion_creates_new_document_id(
         test_session.query(Chunk).filter(Chunk.document_id == second.document_id).count()
         == first_chunk_count
     )
+
+
+# ── _validate_type_metadata unit tests ─────────────────────────────────────
+
+
+class TestValidateTypeMetadata:
+    """Unit tests for ``_validate_type_metadata()``."""
+
+    def test_passes_valid_book_metadata(self) -> None:
+        """Valid BookChunkMetadata passes validation."""
+        _validate_type_metadata(DocumentType.BOOK, {"chapter": 1, "heading": "Intro"})
+
+    def test_rejects_string_chapter_in_book(self) -> None:
+        """A string chapter value raises IngestionError."""
+        with pytest.raises(IngestionError):
+            _validate_type_metadata(DocumentType.BOOK, {"chapter": "three", "heading": "Methods"})
+
+    def test_rejects_extra_fields(self) -> None:
+        """An unknown key in type_metadata raises IngestionError."""
+        with pytest.raises(IngestionError):
+            _validate_type_metadata(
+                DocumentType.BOOK,
+                {"chapter": 1, "heading": "Intro", "sneaky": "bad"},
+            )
+
+    def test_passes_valid_paper_metadata(self) -> None:
+        """Valid PaperChunkMetadata passes validation."""
+        _validate_type_metadata(
+            DocumentType.PAPER,
+            {"section": "Methods", "subsection": None, "page": 3},
+        )
+
+    def test_rejects_invalid_paper_metadata(self) -> None:
+        """Paper metadata with string page raises IngestionError."""
+        with pytest.raises(IngestionError):
+            _validate_type_metadata(
+                DocumentType.PAPER,
+                {"section": "Methods", "subsection": None, "page": "three"},
+            )
+
+    def test_passes_valid_documentation_metadata(self) -> None:
+        """Valid DocumentationChunkMetadata passes validation."""
+        _validate_type_metadata(
+            DocumentType.DOCUMENTATION,
+            {"page": "42", "section": "Setup"},
+        )
+
+    def test_rejects_invalid_documentation_metadata(self) -> None:
+        """Documentation metadata with missing section raises IngestionError."""
+        with pytest.raises(IngestionError):
+            _validate_type_metadata(
+                DocumentType.DOCUMENTATION,
+                {"page": "42"},
+            )
+
+
+# ── Pipeline-level validation integration tests ───────────────────────────
+
+
+class TestPipelineValidation:
+    """Integration tests verifying validation runs before DB writes."""
+
+    def test_pipeline_rejects_string_chapter_in_book(
+        self,
+        test_session: Session,
+        fake_embeddings_client: MagicMock,
+    ) -> None:
+        """Invalid type_metadata (string chapter) bubbles up as IngestionError.
+
+        This simulates a chunker bug (or a code path that bypasses Pydantic
+        construction) and verifies the pipeline catches it before persisting.
+        """
+        document = Document(
+            title="Bad Book",
+            document_type=DocumentType.BOOK,
+            source_filename="bad.pdf",
+        )
+        test_session.add(document)
+        test_session.flush()
+
+        with patch("ingestion.pipeline._chunk_document") as mock_chunk:
+            mock_chunk.return_value = [
+                ("content", {"chapter": "three", "heading": "Methods"}, 10),
+            ]
+            with pytest.raises(IngestionError):
+                run_ingestion(
+                    document_id=document.document_id,
+                    title="Bad Book",
+                    document_type=DocumentType.BOOK,
+                    source_filename="bad.pdf",
+                    file_bytes=b"irrelevant",
+                    session=test_session,
+                    embeddings_client=fake_embeddings_client,
+                    model_name="text-embedding-3-small",
+                )
+
+        # No chunks should have been persisted
+        chunks = test_session.query(Chunk).filter(Chunk.document_id == document.document_id).all()
+        assert chunks == []
+
+    def test_pipeline_rejects_string_page_in_paper(
+        self,
+        test_session: Session,
+        fake_embeddings_client: MagicMock,
+    ) -> None:
+        """Paper metadata with string page raises IngestionError."""
+        document = Document(
+            title="Bad Paper",
+            document_type=DocumentType.PAPER,
+            source_filename="bad.pdf",
+        )
+        test_session.add(document)
+        test_session.flush()
+
+        with patch("ingestion.pipeline._chunk_document") as mock_chunk:
+            mock_chunk.return_value = [
+                ("content", {"section": "Methods", "subsection": None, "page": "iv"}, 10),
+            ]
+            with pytest.raises(IngestionError):
+                run_ingestion(
+                    document_id=document.document_id,
+                    title="Bad Paper",
+                    document_type=DocumentType.PAPER,
+                    source_filename="bad.pdf",
+                    file_bytes=b"irrelevant",
+                    session=test_session,
+                    embeddings_client=fake_embeddings_client,
+                    model_name="text-embedding-3-small",
+                )
+
+        chunks = test_session.query(Chunk).filter(Chunk.document_id == document.document_id).all()
+        assert chunks == []
+
+    def test_happy_path_book_still_succeeds(
+        self,
+        test_session: Session,
+        fake_embeddings_client: MagicMock,
+        sample_book_pdf: bytes,
+    ) -> None:
+        """Existing book happy path is not broken by validation step."""
+        document = Document(
+            title="Sample Book",
+            document_type=DocumentType.BOOK,
+            source_filename="sample.pdf",
+        )
+        test_session.add(document)
+        test_session.flush()
+
+        run_ingestion(
+            document_id=document.document_id,
+            title="Sample Book",
+            document_type=DocumentType.BOOK,
+            source_filename="sample.pdf",
+            file_bytes=sample_book_pdf,
+            session=test_session,
+            embeddings_client=fake_embeddings_client,
+            model_name="text-embedding-3-small",
+        )
+
+        test_session.commit()
+        chunks = (
+            test_session.query(Chunk)
+            .filter(Chunk.document_id == document.document_id)
+            .order_by(Chunk.position)
+            .all()
+        )
+        assert len(chunks) >= 1
+        for chunk in chunks:
+            assert "chapter" in chunk.type_metadata
+            assert isinstance(chunk.type_metadata["chapter"], int)


### PR DESCRIPTION
… write (#38)

Add _validate_type_metadata() to ingestion/pipeline.py, called per-chunk before the SQLAlchemy write, making the 'before persisting to chunks.type_metadata' acceptance criterion literally true at the write boundary — not just at Pydantic construction time in the chunker.

This is a second layer of enforcement: the chunker still validates at Pydantic construction time, and the pipeline re-validates via model_validate() just before the row is persisted. Any code path that bypasses the chunker and constructs type_metadata as a raw dict will now be caught before writing to the JSONB column.

ADR-0014 is updated to document the two-layer enforcement model. check-review.md item 24 is resolved.