### PR TITLE
feat(chunking): implement page/API-entry-aware documentation chunker …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,4 +14,4 @@ HNSW_EF_SEARCH=40
 MAX_UPLOAD_BYTES=104857600
 
 # Allowed file extensions (placeholder).
-ALLOWED_FILE_EXTENSIONS=["pdf"]
+ALLOWED_FILE_EXTENSIONS=["pdf", "epub", "md", "html"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 
 ## Current state
 
-This repository is in **early implementation (tracer bullet complete)**. ADRs, stack decisions, coding standards, and the monorepo layout are in place, plus the build/CI scaffolding: root + per-module `pyproject.toml` (uv workspace), `uv.lock`, `.github/workflows/` (`ci.yml`, `cd.yml`, `security.yml`, `dependabot-auto-merge.yml`), `commitlint.config.mjs`, and `Dockerfile`. Four of five packages have real implementation code (~4720 lines total); only `depth_dive/` still has just placeholders. The toolchain is green: `uv sync` installs all deps; `uv run ruff check`, `uv run ruff format --check`, `uv run mypy`, `uv run lint-imports`, and `uv run pytest` all pass.
+This repository is in **early implementation (tracer bullet complete)**. ADRs, stack decisions, coding standards, and the monorepo layout are in place, plus the build/CI scaffolding: root + per-module `pyproject.toml` (uv workspace), `uv.lock`, `.github/workflows/` (`ci.yml`, `cd.yml`, `security.yml`, `dependabot-auto-merge.yml`), `commitlint.config.mjs`, and `Dockerfile`. Four of five packages have real implementation code (~5470 lines total); only `depth_dive/` still has just placeholders. The toolchain is green: `uv sync` installs all deps; `uv run ruff check`, `uv run ruff format --check`, `uv run mypy`, `uv run lint-imports`, and `uv run pytest` all pass.
 
 ## Authoritative sources — read before acting
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A hand-rolled RAG study tool for learning AI/ML from papers, books, and document
 | Post-MVP 1 | **Depth Dive** — richer explanations (text + diagrams + code) with agentic web search | 🔧 Scaffold |
 | Post-MVP 2 | **Synapse** — multi-sensory interactive learning with gamification and neuroplasticity triggers | 📅 Planned |
 
-> **Status:** Early implementation — tracer bullet complete. Four of five packages (`core/`, `retrieval_qa/`, `api/`, `ingestion/`) have implementation code (~4720 lines total). Only `depth_dive/` remains as a scaffold. Ingestion pipeline, Harness A query pipeline, and three API endpoints (`POST /ingest`, `GET /documents/{id}`, `POST /query`) are operational. See [docs/](./docs/) for architecture decisions and plans.
+> **Status:** Early implementation — tracer bullet complete. Four of five packages (`core/`, `retrieval_qa/`, `api/`, `ingestion/`) have implementation code (~5470 lines total). Only `depth_dive/` remains as a scaffold. Ingestion pipeline, Harness A query pipeline, and three API endpoints (`POST /ingest`, `GET /documents/{id}`, `POST /query`) are operational. See [docs/](./docs/) for architecture decisions and plans.
 
 ## Architecture
 
@@ -51,7 +51,7 @@ Structured monorepo with extractable module boundaries:
 
 ## Challenges solved
 
-**Multi-format document chunking.** Papers, books, and documentation have different structures. Each gets a structure-aware chunker (section boundaries for papers, chapter boundaries for books) that produces typed metadata via a JSONB registry — keeping each doc type's schema explicit and extensible.
+**Multi-format document chunking.** Papers, books, and documentation have different structures. Each gets a structure-aware chunker (section boundaries for papers, chapter boundaries for books, page/API-entry boundaries for documentation) that produces typed metadata via a JSONB registry — keeping each doc type's schema explicit and extensible.
 
 **Module boundary enforcement.** A five-package monorepo needs real boundaries or they become fictional. `import-linter` in CI (`uv run lint-imports`) catches cross-package leaks before merge — e.g., `retrieval_qa` and `depth_dive` must never import each other.
 

--- a/api/tests/api/test_ingest.py
+++ b/api/tests/api/test_ingest.py
@@ -79,6 +79,23 @@ def test_ingest_book_epub_pipeline_transitions_to_ready(
     assert status == "ready"
 
 
+def test_ingest_documentation_pipeline_transitions_to_ready(
+    client: TestClient,
+    sample_documentation_md: bytes,
+) -> None:
+    """A Markdown documentation upload reaches ready after the background task runs."""
+    response = client.post(
+        "/ingest",
+        files={"file": ("docs.md", sample_documentation_md, "text/markdown")},
+        data={"title": "Sample Docs", "document_type": "documentation"},
+    )
+    assert response.status_code == 202
+    document_id = response.json()["document_id"]
+
+    status = client.get(f"/documents/{document_id}").json()["status"]
+    assert status == "ready"
+
+
 def test_ingest_oversized_file_returns_413(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/api/tests/api/test_query.py
+++ b/api/tests/api/test_query.py
@@ -356,3 +356,37 @@ def test_query_end_to_end_cross_document_returns_paper_citation(
     cited_ids = {passage["chunk_id"] for passage in body["cited_passages"]}
     assert cited_ids & paper_chunk_ids
     assert not (cited_ids - paper_chunk_ids - book_chunk_ids)
+
+
+def test_query_end_to_end_cross_document_returns_documentation_citation(
+    client: TestClient,
+    test_session: Session,
+    ingest_a_paper: Callable[[str], str],
+    ingest_a_documentation: Callable[[str], str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A query answered by documentation returns a cited passage from the docs."""
+    monkeypatch.setattr("api.routes.retrieval_qa.LLMClient", _default_fake_llm_client)
+    # Raise top_k so the tied fake embeddings return chunks from both documents.
+    monkeypatch.setattr("api.routes.retrieval_qa.settings.query_top_k", 100)
+
+    paper_id = ingest_a_paper("RAG Paper")
+    docs_id = ingest_a_documentation("API Docs")
+
+    docs_chunk_ids = {
+        str(chunk.chunk_id)
+        for chunk in test_session.query(Chunk).filter(Chunk.document_id == docs_id).all()
+    }
+    paper_chunk_ids = {
+        str(chunk.chunk_id)
+        for chunk in test_session.query(Chunk).filter(Chunk.document_id == paper_id).all()
+    }
+
+    response = client.post("/query", json={"query": "Tell me about users."})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["grounded"] is True
+    cited_ids = {passage["chunk_id"] for passage in body["cited_passages"]}
+    assert cited_ids & docs_chunk_ids
+    assert not (cited_ids - paper_chunk_ids - docs_chunk_ids)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -105,6 +105,25 @@ def ingest_a_book(client: TestClient, sample_book_pdf: bytes) -> IngestADocument
     return _ingest
 
 
+@pytest.fixture
+def ingest_a_documentation(client: TestClient, sample_documentation_md: bytes) -> IngestADocument:
+    """Fixture returning a callable that ingests documentation and awaits ready."""
+
+    def _ingest(title: str = "Docs") -> str:
+        response = client.post(
+            "/ingest",
+            files={"file": ("docs.md", sample_documentation_md, "text/markdown")},
+            data={"title": title, "document_type": "documentation"},
+        )
+        assert response.status_code == 202
+        document_id = response.json()["document_id"]
+        status = client.get(f"/documents/{document_id}").json()["status"]
+        assert status == "ready", f"document never reached ready: {status}"
+        return str(document_id)
+
+    return _ingest
+
+
 def _default_fake_client(*args: object, **kwargs: object) -> MagicMock:
     client = MagicMock()
 

--- a/conftest.py
+++ b/conftest.py
@@ -26,6 +26,7 @@ import api.controllers.qa_controller
 import api.server  # noqa: F401
 import ingestion.tasks  # noqa: F401
 import retrieval_qa.chunking.book_chunker
+import retrieval_qa.chunking.documentation_chunker
 import retrieval_qa.chunking.paper_chunker
 import retrieval_qa.retrieval.query  # noqa: F401
 
@@ -210,6 +211,21 @@ def sample_book_epub() -> bytes:
         )
     buffer.seek(0)
     return buffer.read()
+
+
+@pytest.fixture
+def sample_documentation_md() -> bytes:
+    """Generate a small Markdown documentation file with pages and API entries."""
+    return (
+        b"# Installation\n\n"
+        b"Install the package with pip.\n\n"
+        b"# API Reference\n\n"
+        b"## Users\n\n"
+        b"GET /api/v1/users\n\n"
+        b"Returns a list of users.\n\n"
+        b"POST /api/v1/users\n\n"
+        b"Creates a new user.\n"
+    )
 
 
 def _create_enums(engine: Engine) -> None:

--- a/core/src/core/config/settings.py
+++ b/core/src/core/config/settings.py
@@ -39,7 +39,7 @@ class Settings(BaseSettings):
     query_top_k: int = 5
     inference_model: str = "gpt-4o-mini"
     max_upload_bytes: int = 100 * 1024 * 1024  # 100 MB placeholder
-    allowed_file_extensions: set[str] = {"pdf", "epub"}
+    allowed_file_extensions: set[str] = {"pdf", "epub", "md", "html"}
 
 
 # Global singleton used by the application. Tests override via monkeypatch or

--- a/ingestion/src/ingestion/pipeline.py
+++ b/ingestion/src/ingestion/pipeline.py
@@ -17,9 +17,10 @@ from core.types.chunk import (
 )
 from core.types.document import DocumentStatus, DocumentType
 from retrieval_qa.chunking.book_chunker import BookChunk, chunk_book
+from retrieval_qa.chunking.documentation_chunker import DocumentationChunk, chunk_documentation
 from retrieval_qa.chunking.paper_chunker import PaperChunk, chunk_paper
 
-_Chunk = PaperChunk | BookChunk
+_Chunk = PaperChunk | BookChunk | DocumentationChunk
 
 
 def _validate_type_metadata(
@@ -78,7 +79,7 @@ def _chunk_document(
         case DocumentType.BOOK:
             return _chunk_inputs(chunk_book(file_bytes))
         case DocumentType.DOCUMENTATION:
-            raise IngestionError(f"Chunker not implemented for document type: {document_type}")
+            return _chunk_inputs(chunk_documentation(file_bytes))
         case _ as unreachable:
             assert_never(unreachable)
 

--- a/ingestion/tests/ingestion/test_pipeline.py
+++ b/ingestion/tests/ingestion/test_pipeline.py
@@ -152,30 +152,47 @@ def test_pipeline_book_happy_path_reaches_ready(
     assert len(embeddings) == len(chunks)
 
 
-def test_pipeline_rejects_unsupported_document_type(
+def test_pipeline_documentation_happy_path_reaches_ready(
     test_session: Session,
     fake_embeddings_client: MagicMock,
+    sample_documentation_md: bytes,
 ) -> None:
-    """A document type without a chunker raises IngestionError."""
+    """A documentation ingestion advances validating -> chunking -> embedding -> ready."""
     document = Document(
-        title="Unknown",
+        title="Sample Docs",
         document_type=DocumentType.DOCUMENTATION,
         source_filename="docs.md",
     )
     test_session.add(document)
     test_session.flush()
 
-    with pytest.raises(IngestionError):
-        run_ingestion(
-            document_id=document.document_id,
-            title="Unknown",
-            document_type=DocumentType.DOCUMENTATION,
-            source_filename="docs.md",
-            file_bytes=b"contents",
-            session=test_session,
-            embeddings_client=fake_embeddings_client,
-            model_name="text-embedding-3-small",
-        )
+    run_ingestion(
+        document_id=document.document_id,
+        title="Sample Docs",
+        document_type=DocumentType.DOCUMENTATION,
+        source_filename="docs.md",
+        file_bytes=sample_documentation_md,
+        session=test_session,
+        embeddings_client=fake_embeddings_client,
+        model_name="text-embedding-3-small",
+    )
+
+    test_session.commit()
+    refreshed = test_session.get(Document, document.document_id)
+    assert refreshed is not None
+    assert refreshed.status == DocumentStatus.READY
+    assert refreshed.error_message is None
+
+    chunks = (
+        test_session.query(Chunk)
+        .filter(Chunk.document_id == document.document_id)
+        .order_by(Chunk.position)
+        .all()
+    )
+    assert len(chunks) >= 1
+    for chunk in chunks:
+        assert "page" in chunk.type_metadata
+        assert isinstance(chunk.type_metadata["page"], str)
 
 
 def test_reingestion_creates_new_document_id(

--- a/retrieval_qa/src/retrieval_qa/chunking/__init__.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/__init__.py
@@ -1,6 +1,14 @@
 """Document-type chunkers."""
 
 from retrieval_qa.chunking.book_chunker import BookChunk, chunk_book
+from retrieval_qa.chunking.documentation_chunker import DocumentationChunk, chunk_documentation
 from retrieval_qa.chunking.paper_chunker import PaperChunk, chunk_paper
 
-__all__ = ["BookChunk", "PaperChunk", "chunk_book", "chunk_paper"]
+__all__ = [
+    "BookChunk",
+    "DocumentationChunk",
+    "PaperChunk",
+    "chunk_book",
+    "chunk_documentation",
+    "chunk_paper",
+]

--- a/retrieval_qa/src/retrieval_qa/chunking/documentation_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/documentation_chunker.py
@@ -1,0 +1,262 @@
+"""Document-type chunker for documentation (Markdown, HTML, PDF).
+
+Extracts text from a documentation file and splits it into page/section-aware
+chunks, emitting ``DocumentationChunkMetadata`` for each chunk.
+
+Pages are identified by top-level headings (Markdown ``#``, HTML ``<h1>``, or
+PDF page breaks). Sections include sub-headings and API endpoint lines such as
+``GET /api/v1/users``.
+"""
+
+import re
+from enum import StrEnum
+from html.parser import HTMLParser
+from io import BytesIO
+
+from pydantic import BaseModel, ConfigDict
+from pypdf import PdfReader
+
+from core.exceptions import IngestionError
+from core.types.chunk import DocumentationChunkMetadata
+
+
+class DocumentationFormat(StrEnum):
+    """Supported documentation file formats for ingestion."""
+
+    PDF = "pdf"
+    HTML = "html"
+    MARKDOWN = "markdown"
+
+
+_HTTP_METHODS = ("GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS")
+
+# Matches Markdown headings like ``# Page`` or ``## Section``.
+_HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+?)$")
+
+# Matches API endpoint lines like ``GET /api/v1/users`` or ``POST /items``.
+_API_ENTRY_PATTERN = re.compile(
+    r"^(" + "|".join(_HTTP_METHODS) + r")\s+(/\S+)$",
+)
+
+
+class DocumentationChunk(BaseModel):
+    """A single chunk produced by the documentation chunker."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    content: str
+    metadata: DocumentationChunkMetadata
+    token_count: int
+
+
+class _HTMLTextExtractor(HTMLParser):
+    """Convert HTML to Markdown-style headings so the text splitter can run."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._parts: list[str] = []
+        self._skip = False
+        self._heading_level: int | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in {"script", "style", "head"}:
+            self._skip = True
+        elif tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            self._heading_level = int(tag[1])
+            self._parts.append("\n")
+            self._parts.append("#" * self._heading_level + " ")
+        elif tag in {"p", "div", "br", "li"}:
+            self._parts.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"script", "style", "head"}:
+            self._skip = False
+        elif tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            self._heading_level = None
+            self._parts.append("\n")
+        elif tag in {"p", "div", "li"}:
+            self._parts.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if not self._skip:
+            self._parts.append(data)
+
+    def get_text(self) -> str:
+        text = "".join(self._parts)
+        return re.sub(r"\n\s*\n+", "\n\n", text).strip()
+
+
+def _count_tokens(text: str) -> int:
+    """Approximate token count for chunk sizing.
+
+    Uses a simple whitespace split; this is sufficient for MVP chunk ordering
+    and sanity checks. More precise counting can be swapped in later without
+    changing the chunker interface.
+    """
+    return max(1, len(text.split()))
+
+
+def _detect_format(file_bytes: bytes) -> DocumentationFormat:
+    """Detect whether ``file_bytes`` is PDF, HTML, or Markdown/text."""
+    if file_bytes.startswith(b"%PDF"):
+        return DocumentationFormat.PDF
+
+    head = file_bytes[:2048].lower()
+    if b"<!doctype html" in head or b"<html" in head:
+        return DocumentationFormat.HTML
+
+    return DocumentationFormat.MARKDOWN
+
+
+def _extract_text_from_html(html_bytes: bytes) -> str:
+    """Strip HTML tags and convert headings to Markdown-style markers."""
+    try:
+        text = html_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise IngestionError(f"Failed to decode HTML as UTF-8: {exc}") from exc
+
+    extractor = _HTMLTextExtractor()
+    extractor.feed(text)
+    extractor.close()
+    return extractor.get_text()
+
+
+def _extract_text_from_pdf(pdf_bytes: bytes) -> str:
+    """Extract text from a PDF, inserting a page marker before each page.
+
+    The page markers let the Markdown-style splitter treat each PDF page as a
+    top-level documentation page.
+    """
+    try:
+        reader = PdfReader(BytesIO(pdf_bytes))
+    except Exception as exc:
+        raise IngestionError(f"Failed to parse PDF: {exc}") from exc
+
+    parts: list[str] = []
+    for page_index, page in enumerate(reader.pages, start=1):
+        try:
+            page_text = page.extract_text() or ""
+        except Exception as exc:
+            raise IngestionError(f"Failed to extract text from page {page_index}: {exc}") from exc
+
+        stripped = page_text.strip()
+        if stripped:
+            parts.append(f"# Page {page_index}\n\n{stripped}")
+
+    return "\n\n".join(parts)
+
+
+def _split_documentation(text: str) -> list[tuple[str, str | None, str]]:
+    """Split documentation text into page/section-aware pieces.
+
+    Returns a list of ``(page, section, body)`` tuples. ``page`` is the current
+    top-level heading (or ``"Document"`` if none is found). ``section`` is the
+    most recent sub-heading or API endpoint line, or ``None`` when none has been
+    seen within the current page.
+    """
+    sections: list[tuple[str, str | None, str]] = []
+    current_page = "Document"
+    current_section: str | None = None
+    buffer_parts: list[str] = []
+
+    def flush() -> None:
+        if buffer_parts:
+            body = "\n".join(buffer_parts).strip()
+            if body:
+                sections.append((current_page, current_section, body))
+            buffer_parts.clear()
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        heading_match = _HEADING_PATTERN.match(line)
+        if heading_match:
+            flush()
+            level = len(heading_match.group(1))
+            title = heading_match.group(2).strip()
+            if level == 1:
+                current_page = title
+                current_section = None
+            else:
+                current_section = title
+            continue
+
+        api_match = _API_ENTRY_PATTERN.match(line)
+        if api_match:
+            flush()
+            current_section = f"{api_match.group(1).upper()} {api_match.group(2)}"
+            buffer_parts.append(line)
+            continue
+
+        buffer_parts.append(raw_line)
+
+    flush()
+    return sections
+
+
+def _extract_text(file_bytes: bytes, document_format: DocumentationFormat) -> str:
+    """Extract plain text from a documentation file in the given format."""
+    match document_format:
+        case DocumentationFormat.PDF:
+            return _extract_text_from_pdf(file_bytes)
+        case DocumentationFormat.HTML:
+            return _extract_text_from_html(file_bytes)
+        case DocumentationFormat.MARKDOWN:
+            try:
+                return file_bytes.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise IngestionError(f"Failed to decode Markdown as UTF-8: {exc}") from exc
+        case _ as unreachable:
+            raise IngestionError(f"Unsupported documentation format: {unreachable}")
+
+
+def chunk_documentation(file_bytes: bytes) -> list[DocumentationChunk]:
+    """Extract text from a documentation file and split it into chunks.
+
+    Args:
+        file_bytes: Raw Markdown, HTML, or PDF file contents.
+
+    Returns:
+        A list of chunks ordered by their appearance in the document.
+
+    Raises:
+        IngestionError: The file could not be parsed or contains no extractable
+            text.
+    """
+    document_format = _detect_format(file_bytes)
+    raw_text = _extract_text(file_bytes, document_format)
+
+    if not raw_text.strip():
+        raise IngestionError("Documentation contains no extractable text")
+
+    sections = _split_documentation(raw_text)
+    if not sections:
+        raise IngestionError("Documentation contains no extractable text")
+
+    chunks: list[DocumentationChunk] = []
+    for page, section, body in sections:
+        if not body.strip():
+            continue
+        metadata = DocumentationChunkMetadata(page=page, section=section)
+        chunks.append(
+            DocumentationChunk(
+                content=body,
+                metadata=metadata,
+                token_count=_count_tokens(body),
+            )
+        )
+
+    # If no section produced usable content, emit the whole document as a single
+    # chunk so the pipeline never produces zero chunks.
+    if not chunks:
+        chunks.append(
+            DocumentationChunk(
+                content=raw_text.strip(),
+                metadata=DocumentationChunkMetadata(page="Document", section=None),
+                token_count=_count_tokens(raw_text),
+            )
+        )
+
+    return chunks
+
+
+__all__ = ["DocumentationChunk", "chunk_documentation"]

--- a/retrieval_qa/tests/retrieval_qa/test_documentation_chunker.py
+++ b/retrieval_qa/tests/retrieval_qa/test_documentation_chunker.py
@@ -1,0 +1,112 @@
+"""Tests for the documentation chunker."""
+
+import io
+
+import pytest
+
+from core.exceptions import IngestionError
+from core.types.chunk import DocumentationChunkMetadata
+from retrieval_qa.chunking.documentation_chunker import chunk_documentation
+
+
+def _make_pdf_from_text(text: str) -> bytes:
+    """Build a minimal PDF containing the given text using reportlab."""
+    from reportlab.lib.pagesizes import letter
+    from reportlab.pdfgen import canvas
+
+    buffer = io.BytesIO()
+    canva = canvas.Canvas(buffer, pagesize=letter)
+    y = 720
+    for line in text.splitlines():
+        canva.drawString(72, y, line)
+        y -= 20
+    canva.showPage()
+    canva.save()
+    buffer.seek(0)
+    return buffer.read()
+
+
+def test_documentation_chunker_splits_markdown_by_headings() -> None:
+    """Markdown headings create page/section boundaries."""
+    markdown = (
+        "# Installation\n\n"
+        "Install the package with pip.\n\n"
+        "## Quick start\n\n"
+        "Run the init command.\n\n"
+        "# API Reference\n\n"
+        "Endpoints are described below.\n\n"
+        "## Users\n\n"
+        "Manage users.\n"
+    )
+    chunks = chunk_documentation(markdown.encode("utf-8"))
+
+    assert len(chunks) >= 2
+    pages = {chunk.metadata.page for chunk in chunks}
+    assert "Installation" in pages
+    assert "API Reference" in pages
+
+
+def test_documentation_chunker_detects_api_entries() -> None:
+    """API endpoint lines become section boundaries."""
+    markdown = (
+        "# API Reference\n\n"
+        "## Users\n\n"
+        "GET /api/v1/users\n\n"
+        "Returns a list of users.\n\n"
+        "POST /api/v1/users\n\n"
+        "Creates a new user.\n"
+    )
+    chunks = chunk_documentation(markdown.encode("utf-8"))
+
+    sections = [chunk.metadata.section for chunk in chunks]
+    assert any(section == "GET /api/v1/users" for section in sections)
+    assert any(section == "POST /api/v1/users" for section in sections)
+
+
+def test_documentation_chunker_parses_html_headings() -> None:
+    """HTML ``<h1>`` / ``<h2>`` tags are converted to page/section boundaries."""
+    html = (
+        "<!DOCTYPE html><html><body>"
+        "<h1>Installation</h1><p>Install with pip.</p>"
+        "<h2>Quick start</h2><p>Run init.</p>"
+        "<h1>API Reference</h1><p>Endpoints below.</p>"
+        "</body></html>"
+    )
+    chunks = chunk_documentation(html.encode("utf-8"))
+
+    assert len(chunks) >= 2
+    pages = {chunk.metadata.page for chunk in chunks}
+    assert "Installation" in pages
+    assert "API Reference" in pages
+
+
+def test_documentation_chunker_parses_pdf_pages() -> None:
+    """PDF pages are treated as documentation pages."""
+    pdf_bytes = _make_pdf_from_text(
+        "# Installation\nInstall the package.\n\n## Quick start\nRun init."
+    )
+    chunks = chunk_documentation(pdf_bytes)
+
+    assert len(chunks) >= 1
+    assert all(chunk.metadata.page for chunk in chunks)
+
+
+def test_documentation_chunker_rejects_empty_bytes() -> None:
+    """Empty byte streams raise IngestionError."""
+    with pytest.raises(IngestionError):
+        chunk_documentation(b"")
+
+
+def test_documentation_chunker_rejects_invalid_bytes() -> None:
+    """Byte streams that are not valid text raise IngestionError."""
+    with pytest.raises(IngestionError):
+        chunk_documentation(b"\xff\xfe not valid utf-8")
+
+
+def test_documentation_chunk_metadata_validates_at_boundary() -> None:
+    """Chunks emitted by the documentation chunker validate against the metadata model."""
+    markdown = "# Installation\n\nInstall with pip.\n"
+    chunks = chunk_documentation(markdown.encode("utf-8"))
+
+    for chunk in chunks:
+        assert DocumentationChunkMetadata.model_validate(chunk.metadata.model_dump())


### PR DESCRIPTION
…(#10)

- Add documentation_chunker for Markdown, HTML, and PDF inputs
- Detect pages via top-level headings and API entries via METHOD /path lines
- Wire documentation chunker into ingestion pipeline dispatch
- Extend allowed_file_extensions to include md and html
- Add unit, pipeline, and end-to-end cross-document retrieval tests
- Update README/AGENTS line counts and chunking description