### PR TITLE
refactor: solidify dependency inversion and chunker extensibility

### DIFF
--- a/api/src/api/__init__.py
+++ b/api/src/api/__init__.py
@@ -1,0 +1,3 @@
+"""Learning Hub API package."""
+
+__all__ = ["controllers", "dependencies", "prompt", "routes", "server"]

--- a/api/src/api/controllers/__init__.py
+++ b/api/src/api/controllers/__init__.py
@@ -1,0 +1,3 @@
+"""API controllers."""
+
+__all__ = ["qa_controller"]

--- a/api/src/api/controllers/qa_controller.py
+++ b/api/src/api/controllers/qa_controller.py
@@ -17,59 +17,21 @@ to 502 / 503 (ADR-0014 § Error contract). DB-level failures propagate
 verbatim; the route's catch-all maps them to 500.
 """
 
-from collections.abc import Sequence
-
 from sqlalchemy.orm import Session
 
-from core.clients.embeddings_client import EmbeddingsClient
-from core.clients.llm_client import LLMClient
-from core.types.chat import ChatMessage
-from core.types.responses import CitedPassage, HarnessAResponse
+from api.prompt import build_messages
+from core.clients import CompletionProvider, Embedder
+from core.types.responses import HarnessAResponse
 from core.types.retrieval_config import RetrievalConfig
 from retrieval_qa.retrieval.query import retrieve_relevant_chunks
-
-_SYSTEM_PROMPT = (
-    "You answer the user's question using only the provided passages. "
-    "If no passages are provided, or if the answer is not contained in them, "
-    "say you cannot answer from the current corpus. Do not invent information."
-)
-
-
-def _build_messages(
-    query: str,
-    chunks: Sequence[CitedPassage],
-) -> list[ChatMessage]:
-    """Assemble the chat-completions message list for the inference call.
-
-    Args:
-        query: The user's raw query string.
-        chunks: Retrieved chunks (objects with a ``text`` attribute). Empty
-            for the not-found branch, in which case the user message carries
-            the query alone (no fake passages) so the model emits a refusal.
-
-    Returns:
-        A two-message list: a system message setting the grounding contract,
-        and a user message containing passages (when present) plus the query.
-    """
-    user_parts: list[str] = []
-    if chunks:
-        passages = "\n\n".join(f"[{i}] {chunk.text}" for i, chunk in enumerate(chunks, start=1))
-        user_parts.append("Passages:\n")
-        user_parts.append(passages)
-    user_parts.append(f"Question: {query}")
-    user_message = "\n\n".join(p for p in user_parts if p)
-    return [
-        ChatMessage(role="system", content=_SYSTEM_PROMPT),
-        ChatMessage(role="user", content=user_message),
-    ]
 
 
 def run_query(
     *,
     query: str,
     session: Session,
-    embeddings_client: EmbeddingsClient,
-    llm_client: LLMClient,
+    embeddings_client: Embedder,
+    llm_client: CompletionProvider,
     config: RetrievalConfig,
 ) -> HarnessAResponse:
     """Run the full Harness A query flow and return a ``HarnessAResponse``.
@@ -79,8 +41,8 @@ def run_query(
         session: SQLAlchemy session bound to the documents database. The
             retrieval step issues ``SET LOCAL hnsw.ef_search`` scoped to this
             session's transaction.
-        embeddings_client: Client used to embed the query (1536-dim).
-        llm_client: Client used to generate the answer.
+        embeddings_client: Provider used to embed the query (1536-dim).
+        llm_client: Provider used to generate the answer.
         config: Retrieval configuration (model name, ef_search, top_k).
 
     Returns:
@@ -103,7 +65,7 @@ def run_query(
         config=config,
     )
 
-    messages = _build_messages(query, chunks)
+    messages = build_messages(query, chunks)
     answer = llm_client.chat(messages)
 
     return HarnessAResponse(

--- a/api/src/api/dependencies.py
+++ b/api/src/api/dependencies.py
@@ -1,0 +1,33 @@
+"""FastAPI dependency providers.
+
+Factories here let route handlers depend on protocols (``Embedder``,
+``CompletionProvider``) rather than concrete clients, following the dependency
+inversion principle (ADR-0011, SOLID review).
+"""
+
+from core.clients import (
+    CompletionProvider,
+    Embedder,
+    EmbeddingsClient,
+    LLMClient,
+)
+from core.config.settings import settings
+
+
+def get_embedder() -> Embedder:
+    """Return the configured synchronous embeddings provider."""
+    return EmbeddingsClient(
+        api_key=settings.openai_api_key,
+        model=settings.embedding_model,
+    )
+
+
+def get_completion_provider() -> CompletionProvider:
+    """Return the configured synchronous chat-completion provider."""
+    return LLMClient(
+        api_key=settings.openai_api_key,
+        model=settings.inference_model,
+    )
+
+
+__all__ = ["get_completion_provider", "get_embedder"]

--- a/api/src/api/prompt.py
+++ b/api/src/api/prompt.py
@@ -1,0 +1,46 @@
+"""Prompt assembly for Harness A."""
+
+from collections.abc import Sequence
+
+from core.types.chat import ChatMessage
+from core.types.responses import CitedPassage
+
+SYSTEM_PROMPT = (
+    "You answer the user's question using only the provided passages. "
+    "If no passages are provided, or if the answer is not contained in them, "
+    "say you cannot answer from the current corpus. Do not invent information."
+)
+
+
+def build_messages(
+    query: str,
+    chunks: Sequence[CitedPassage],
+) -> list[ChatMessage]:
+    """Assemble the chat-completions message list for the inference call.
+
+    Args:
+        query: The user's raw query string.
+        chunks: Retrieved chunks (objects with a ``text`` attribute). Empty
+            for the not-found branch, in which case the user message carries
+            the query alone (no fake injected context) so the model emits a
+            refusal.
+
+    Returns:
+        A two-message list: a system message setting the grounding contract,
+        and a user message containing the injected context (when present) plus
+        the query.
+    """
+    user_parts: list[str] = []
+    if chunks:
+        context = "\n\n".join(f"[{i}] {chunk.text}" for i, chunk in enumerate(chunks, start=1))
+        user_parts.append("Injected Context:\n")
+        user_parts.append(context)
+    user_parts.append(f"Question: {query}")
+    user_message = "\n\n".join(p for p in user_parts if p)
+    return [
+        ChatMessage(role="system", content=SYSTEM_PROMPT),
+        ChatMessage(role="user", content=user_message),
+    ]
+
+
+__all__ = ["SYSTEM_PROMPT", "build_messages"]

--- a/api/src/api/routes/ingest.py
+++ b/api/src/api/routes/ingest.py
@@ -4,8 +4,19 @@ from pathlib import Path
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, BackgroundTasks, Form, HTTPException, Request, Response, UploadFile
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    Form,
+    HTTPException,
+    Request,
+    Response,
+    UploadFile,
+)
 
+from api.dependencies import get_embedder
+from core.clients import Embedder
 from core.config.settings import settings
 from core.database.connection import db_session
 from core.database.schema import Document
@@ -46,6 +57,7 @@ async def ingest_document(
     file: UploadFile,
     title: Annotated[str, Form(...)],
     document_type: Annotated[DocumentType, Form(...)],
+    embedder: Annotated[Embedder, Depends(get_embedder)],
 ) -> DocumentStatusResponse:
     """Accept a document for background ingestion.
 
@@ -83,6 +95,8 @@ async def ingest_document(
         document_type=document_type,
         source_filename=source_filename,
         file_bytes=file_bytes,
+        embedder=embedder,
+        model_name=settings.embedding_model,
     )
 
     location = request.url_for("get_document", document_id=str(document_id))

--- a/api/src/api/routes/retrieval_qa.py
+++ b/api/src/api/routes/retrieval_qa.py
@@ -1,10 +1,12 @@
 """Query route: POST /query (ADR-0014)."""
 
-from fastapi import APIRouter
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
 
 from api.controllers.qa_controller import run_query
-from core.clients.embeddings_client import EmbeddingsClient
-from core.clients.llm_client import LLMClient
+from api.dependencies import get_completion_provider, get_embedder
+from core.clients import CompletionProvider, Embedder
 from core.config.settings import settings
 from core.database.connection import db_session
 from core.types.responses import HarnessARequest, HarnessAResponse
@@ -14,7 +16,11 @@ router = APIRouter(tags=["query"])
 
 
 @router.post("/query", response_model=HarnessAResponse)
-def query(body: HarnessARequest) -> HarnessAResponse:
+def query(
+    body: HarnessARequest,
+    embeddings_client: Annotated[Embedder, Depends(get_embedder)],
+    llm_client: Annotated[CompletionProvider, Depends(get_completion_provider)],
+) -> HarnessAResponse:
     """Answer a query against the ingested corpus.
 
     Returns 200 with a ``HarnessAResponse`` on both grounded and not-found
@@ -27,14 +33,8 @@ def query(body: HarnessARequest) -> HarnessAResponse:
         return run_query(
             query=body.query,
             session=session,
-            embeddings_client=EmbeddingsClient(
-                api_key=settings.openai_api_key,
-                model=settings.embedding_model,
-            ),
-            llm_client=LLMClient(
-                api_key=settings.openai_api_key,
-                model=settings.inference_model,
-            ),
+            embeddings_client=embeddings_client,
+            llm_client=llm_client,
             config=RetrievalConfig(
                 model_name=settings.embedding_model,
                 ef_search=settings.hnsw_ef_search,

--- a/api/tests/api/controllers/test_qa_controller.py
+++ b/api/tests/api/controllers/test_qa_controller.py
@@ -270,4 +270,4 @@ def test_run_query_no_chunks_prompt_does_not_include_passage_text(
     sent_messages = llm_client.chat.call_args.args[0]
     user_msg = next(m for m in sent_messages if m.role == "user")
     assert "topic the corpus does not cover" in user_msg.content
-    assert "Passages:" not in user_msg.content
+    assert "Injected Context:" not in user_msg.content

--- a/api/tests/api/test_ingest.py
+++ b/api/tests/api/test_ingest.py
@@ -7,6 +7,15 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi.testclient import TestClient
 
+from api.dependencies import get_completion_provider, get_embedder
+from api.tests.conftest import set_dependency_override
+from core.clients import MockCompletionProvider
+
+
+def _default_fake_llm_provider() -> MockCompletionProvider:
+    """A mocked completion provider that returns a fixed grounded answer."""
+    return MockCompletionProvider("Grounded answer derived from retrieved passages.")
+
 
 def test_ingest_returns_202_with_location_header(
     client: TestClient,
@@ -152,17 +161,16 @@ def test_ingest_missing_document_type_returns_422(
 
 def test_ingest_pipeline_failure_marks_failed(
     client: TestClient,
-    monkeypatch: pytest.MonkeyPatch,
     sample_paper_pdf: bytes,
 ) -> None:
-    """A mocked embeddings client that raises surfaces as status=failed."""
+    """A mocked embeddings provider that raises surfaces as status=failed."""
 
-    def _failing_client(*args: object, **kwargs: object) -> MagicMock:
-        client = MagicMock()
-        client.embed.side_effect = RuntimeError("upstream down")
-        return client
+    def _failing_embedder() -> MagicMock:
+        embedder = MagicMock()
+        embedder.embed.side_effect = RuntimeError("upstream down")
+        return embedder
 
-    monkeypatch.setattr("ingestion.tasks.EmbeddingsClient", _failing_client)
+    set_dependency_override(client, get_embedder, _failing_embedder)
 
     response = client.post(
         "/ingest",
@@ -179,20 +187,12 @@ def test_ingest_pipeline_failure_marks_failed(
     assert body["error_message"] is not None
 
 
-def _default_fake_llm_client(*args: object, **kwargs: object) -> MagicMock:
-    """A mocked LLM client that returns a fixed grounded answer."""
-    client = MagicMock()
-    client.chat.return_value = "Grounded answer derived from retrieved passages."
-    return client
-
-
 def test_ingest_then_query_end_to_end(
     client: TestClient,
     ingest_a_paper: Callable[[str], str],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Ingest a paper, then query it expecting grounded=true with cited passages."""
-    monkeypatch.setattr("api.routes.retrieval_qa.LLMClient", _default_fake_llm_client)
+    set_dependency_override(client, get_completion_provider, _default_fake_llm_provider)
 
     ingest_a_paper("RAG Paper")
 
@@ -214,7 +214,7 @@ def test_ingest_book_then_query_end_to_end(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Ingest a book, then query it expecting grounded=true with cited passages."""
-    monkeypatch.setattr("api.routes.retrieval_qa.LLMClient", _default_fake_llm_client)
+    set_dependency_override(client, get_completion_provider, _default_fake_llm_provider)
     # Raise top_k so all tied fake-embedding chunks are returned.
     monkeypatch.setattr("api.routes.retrieval_qa.settings.query_top_k", 100)
 

--- a/api/tests/api/test_prompt.py
+++ b/api/tests/api/test_prompt.py
@@ -1,0 +1,51 @@
+"""Tests for Harness A prompt assembly."""
+
+from uuid import uuid4
+
+from api.prompt import SYSTEM_PROMPT, build_messages
+from core.types.chat import ChatMessage
+from core.types.responses import CitedPassage
+
+
+def test_build_messages_includes_system_prompt() -> None:
+    """The system message sets the grounding contract."""
+    messages = build_messages("q", [])
+    system = next(m for m in messages if m.role == "system")
+    assert system.content == SYSTEM_PROMPT
+
+
+def test_build_messages_includes_context_when_present() -> None:
+    """The user message includes enumerated context when chunks are provided."""
+    chunks = [
+        CitedPassage(chunk_id=uuid4(), text="first passage"),
+        CitedPassage(chunk_id=uuid4(), text="second passage"),
+    ]
+    messages = build_messages("what is RAG?", chunks)
+    user = next(m for m in messages if m.role == "user")
+    assert "first passage" in user.content
+    assert "second passage" in user.content
+    assert "[1] first passage" in user.content
+    assert "[2] second passage" in user.content
+    assert "what is RAG?" in user.content
+
+
+def test_build_messages_omits_context_when_empty() -> None:
+    """The user message omits the Injected Context block when no chunks are retrieved."""
+    messages = build_messages("what is RAG?", [])
+    user = next(m for m in messages if m.role == "user")
+    assert "what is RAG?" in user.content
+    assert "Injected Context:" not in user.content
+
+
+def test_build_messages_returns_two_messages() -> None:
+    """Prompt assembly returns exactly a system and a user message."""
+    messages = build_messages("q", [])
+    assert len(messages) == 2
+    assert messages[0].role == "system"
+    assert messages[1].role == "user"
+
+
+def test_build_messages_returns_chat_message_models() -> None:
+    """All returned messages are typed ChatMessage instances."""
+    messages = build_messages("q", [])
+    assert all(isinstance(m, ChatMessage) for m in messages)

--- a/api/tests/api/test_query.py
+++ b/api/tests/api/test_query.py
@@ -18,23 +18,22 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from api.dependencies import get_completion_provider, get_embedder
+from api.tests.conftest import set_dependency_override
+from core.clients import MockCompletionProvider
 from core.database.schema import Chunk
 from core.exceptions import UpstreamBadResponse, UpstreamUnavailable
 from core.types.responses import CitedPassage
 
 
-def _default_fake_llm_client(*args: object, **kwargs: object) -> MagicMock:
-    """A mocked LLM client that returns a fixed grounded answer."""
-    client = MagicMock()
-    client.chat.return_value = "Grounded answer derived from retrieved passages."
-    return client
+def _default_fake_llm_provider() -> MockCompletionProvider:
+    """A mocked completion provider that returns a fixed grounded answer."""
+    return MockCompletionProvider("Grounded answer derived from retrieved passages.")
 
 
-def _refusal_fake_llm_client(*args: object, **kwargs: object) -> MagicMock:
-    """A mocked LLM client that returns a refusal answer."""
-    client = MagicMock()
-    client.chat.return_value = "I could not find anything relevant in the corpus."
-    return client
+def _refusal_fake_llm_provider() -> MockCompletionProvider:
+    """A mocked completion provider that returns a refusal answer."""
+    return MockCompletionProvider("I could not find anything relevant in the corpus.")
 
 
 def _fake_chunk(*, text: str = "chunk text") -> CitedPassage:
@@ -70,19 +69,17 @@ def test_query_non_string_query_returns_422(mock_client: TestClient) -> None:
 # ============================================================
 
 
-def test_query_embeddings_bad_response_returns_502(
-    mock_client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A mocked embeddings client returning a bad response maps to 502."""
+def test_query_embeddings_bad_response_returns_502(client: TestClient) -> None:
+    """A mocked embeddings provider returning a bad response maps to 502."""
 
-    def _raises_bad_client(*args: object, **kwargs: object) -> MagicMock:
-        client = MagicMock()
-        client.embed.side_effect = UpstreamBadResponse("bad upstream response")
-        return client
+    def _bad_embedder() -> MagicMock:
+        embedder = MagicMock()
+        embedder.embed.side_effect = UpstreamBadResponse("bad upstream response")
+        return embedder
 
-    monkeypatch.setattr("api.routes.retrieval_qa.EmbeddingsClient", _raises_bad_client)
+    set_dependency_override(client, get_embedder, _bad_embedder)
 
-    response = mock_client.post("/query", json={"query": "anything"})
+    response = client.post("/query", json={"query": "anything"})
 
     assert response.status_code == 502
     body = response.json()
@@ -91,19 +88,17 @@ def test_query_embeddings_bad_response_returns_502(
     assert body["detail"]
 
 
-def test_query_embeddings_unavailable_returns_503(
-    mock_client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A mocked embeddings client that's unreachable/timeout maps to 503."""
+def test_query_embeddings_unavailable_returns_503(client: TestClient) -> None:
+    """A mocked embeddings provider that's unreachable/timeout maps to 503."""
 
-    def _raises_unavailable_client(*args: object, **kwargs: object) -> MagicMock:
-        client = MagicMock()
-        client.embed.side_effect = UpstreamUnavailable("timeout")
-        return client
+    def _unavailable_embedder() -> MagicMock:
+        embedder = MagicMock()
+        embedder.embed.side_effect = UpstreamUnavailable("timeout")
+        return embedder
 
-    monkeypatch.setattr("api.routes.retrieval_qa.EmbeddingsClient", _raises_unavailable_client)
+    set_dependency_override(client, get_embedder, _unavailable_embedder)
 
-    response = mock_client.post("/query", json={"query": "anything"})
+    response = client.post("/query", json={"query": "anything"})
 
     assert response.status_code == 503
     body = response.json()
@@ -113,22 +108,22 @@ def test_query_embeddings_unavailable_returns_503(
 
 
 def test_query_inference_bad_response_returns_502(
-    mock_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A mocked inference client returning a bad response maps to 502."""
+    """A mocked inference provider returning a bad response maps to 502."""
 
-    def _raises_bad_llm(*args: object, **kwargs: object) -> MagicMock:
-        client = MagicMock()
-        client.chat.side_effect = UpstreamBadResponse("bad upstream response")
-        return client
+    def _bad_llm() -> MagicMock:
+        llm = MagicMock()
+        llm.chat.side_effect = UpstreamBadResponse("bad upstream response")
+        return llm
 
-    monkeypatch.setattr("api.routes.retrieval_qa.LLMClient", _raises_bad_llm)
+    set_dependency_override(client, get_completion_provider, _bad_llm)
     monkeypatch.setattr(
         "api.controllers.qa_controller.retrieve_relevant_chunks",
         lambda **kwargs: [_fake_chunk(text="some chunk")],
     )
 
-    response = mock_client.post("/query", json={"query": "anything"})
+    response = client.post("/query", json={"query": "anything"})
 
     assert response.status_code == 502
     body = response.json()
@@ -137,22 +132,22 @@ def test_query_inference_bad_response_returns_502(
 
 
 def test_query_inference_unavailable_returns_503(
-    mock_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A mocked inference client that's unreachable/timeout maps to 503."""
+    """A mocked inference provider that's unreachable/timeout maps to 503."""
 
-    def _raises_unavailable_llm(*args: object, **kwargs: object) -> MagicMock:
-        client = MagicMock()
-        client.chat.side_effect = UpstreamUnavailable("timeout")
-        return client
+    def _unavailable_llm() -> MagicMock:
+        llm = MagicMock()
+        llm.chat.side_effect = UpstreamUnavailable("timeout")
+        return llm
 
-    monkeypatch.setattr("api.routes.retrieval_qa.LLMClient", _raises_unavailable_llm)
+    set_dependency_override(client, get_completion_provider, _unavailable_llm)
     monkeypatch.setattr(
         "api.controllers.qa_controller.retrieve_relevant_chunks",
         lambda **kwargs: [_fake_chunk(text="some chunk")],
     )
 
-    response = mock_client.post("/query", json={"query": "anything"})
+    response = client.post("/query", json={"query": "anything"})
 
     assert response.status_code == 503
     body = response.json()
@@ -166,16 +161,16 @@ def test_query_inference_unavailable_returns_503(
 
 
 def test_query_empty_corpus_returns_not_grounded(
-    mock_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """An empty retrieval result yields 200 grounded=false with empty passages."""
-    monkeypatch.setattr("api.routes.retrieval_qa.LLMClient", _refusal_fake_llm_client)
+    set_dependency_override(client, get_completion_provider, _refusal_fake_llm_provider)
     monkeypatch.setattr(
         "api.controllers.qa_controller.retrieve_relevant_chunks",
         lambda **kwargs: [],
     )
 
-    response = mock_client.post("/query", json={"query": "What is pgvector?"})
+    response = client.post("/query", json={"query": "What is pgvector?"})
 
     assert response.status_code == 200
     body = response.json()
@@ -186,33 +181,33 @@ def test_query_empty_corpus_returns_not_grounded(
 
 
 def test_query_response_has_exactly_three_fields(
-    mock_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The 200 body exposes only answer, cited_passages, grounded (per ADR-0014)."""
-    monkeypatch.setattr("api.routes.retrieval_qa.LLMClient", _refusal_fake_llm_client)
+    set_dependency_override(client, get_completion_provider, _refusal_fake_llm_provider)
     monkeypatch.setattr(
         "api.controllers.qa_controller.retrieve_relevant_chunks",
         lambda **kwargs: [],
     )
 
-    response = mock_client.post("/query", json={"query": "anything"})
+    response = client.post("/query", json={"query": "anything"})
 
     assert response.status_code == 200
     assert set(response.json().keys()) == {"answer", "cited_passages", "grounded"}
 
 
 def test_query_grounds_with_mocked_retrieval(
-    mock_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The route glue produces grounded=True and cited_passages from the retrieved chunks."""
-    monkeypatch.setattr("api.routes.retrieval_qa.LLMClient", _default_fake_llm_client)
+    set_dependency_override(client, get_completion_provider, _default_fake_llm_provider)
     chunk = _fake_chunk(text="relevant passage text")
     monkeypatch.setattr(
         "api.controllers.qa_controller.retrieve_relevant_chunks",
         lambda **kwargs: [chunk],
     )
 
-    response = mock_client.post("/query", json={"query": "Tell me about retrieval strategies."})
+    response = client.post("/query", json={"query": "Tell me about retrieval strategies."})
 
     assert response.status_code == 200
     body = response.json()
@@ -235,7 +230,7 @@ def test_query_end_to_end_grounds_with_real_chunks(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A relevant query against a ready corpus returns 200 grounded=true with citations."""
-    monkeypatch.setattr("api.routes.retrieval_qa.LLMClient", _default_fake_llm_client)
+    set_dependency_override(client, get_completion_provider, _default_fake_llm_provider)
     ingest_a_paper("RAG Paper")
 
     response = client.post("/query", json={"query": "Tell me about retrieval strategies."})
@@ -259,7 +254,7 @@ def test_query_end_to_end_irrelevant_returns_not_grounded(
     """Asking an irrelevant question yields 200 grounded=false with empty passages."""
     # Force the not-found branch even against a ready corpus by returning []
     # from retrieval; the LLM stub returns a refusal.
-    monkeypatch.setattr("api.routes.retrieval_qa.LLMClient", _refusal_fake_llm_client)
+    set_dependency_override(client, get_completion_provider, _refusal_fake_llm_provider)
     monkeypatch.setattr(
         "api.controllers.qa_controller.retrieve_relevant_chunks",
         lambda **kwargs: [],
@@ -279,7 +274,7 @@ def test_query_end_to_end_empty_corpus_returns_not_grounded(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Querying an empty corpus yields 200 grounded=false with empty passages."""
-    monkeypatch.setattr("api.routes.retrieval_qa.LLMClient", _refusal_fake_llm_client)
+    set_dependency_override(client, get_completion_provider, _refusal_fake_llm_provider)
 
     response = client.post("/query", json={"query": "What is pgvector?"})
 
@@ -298,7 +293,7 @@ def test_query_end_to_end_cross_document_returns_book_citation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A query answered by the book returns a cited passage from the book."""
-    monkeypatch.setattr("api.routes.retrieval_qa.LLMClient", _default_fake_llm_client)
+    set_dependency_override(client, get_completion_provider, _default_fake_llm_provider)
     # Raise top_k so the tied fake embeddings return chunks from both documents.
     monkeypatch.setattr("api.routes.retrieval_qa.settings.query_top_k", 100)
 
@@ -332,7 +327,7 @@ def test_query_end_to_end_cross_document_returns_paper_citation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A query answered by the paper returns a cited passage from the paper."""
-    monkeypatch.setattr("api.routes.retrieval_qa.LLMClient", _default_fake_llm_client)
+    set_dependency_override(client, get_completion_provider, _default_fake_llm_provider)
     # Raise top_k so the tied fake embeddings return chunks from both documents.
     monkeypatch.setattr("api.routes.retrieval_qa.settings.query_top_k", 100)
 
@@ -366,7 +361,7 @@ def test_query_end_to_end_cross_document_returns_documentation_citation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A query answered by documentation returns a cited passage from the docs."""
-    monkeypatch.setattr("api.routes.retrieval_qa.LLMClient", _default_fake_llm_client)
+    set_dependency_override(client, get_completion_provider, _default_fake_llm_provider)
     # Raise top_k so the tied fake embeddings return chunks from both documents.
     monkeypatch.setattr("api.routes.retrieval_qa.settings.query_top_k", 100)
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -2,37 +2,51 @@
 
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
+from api.dependencies import get_completion_provider, get_embedder
+from api.server import create_app
+from core.clients import InMemoryEmbedder, MockCompletionProvider
 
 IngestADocument = Callable[[str], str]
 
 
-def _patch_clients(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Patch embeddings + LLM clients with defaults for all test fixtures."""
-    monkeypatch.setattr("ingestion.tasks.EmbeddingsClient", _default_fake_client)
-    monkeypatch.setattr("api.routes.retrieval_qa.EmbeddingsClient", _default_fake_client)
-    monkeypatch.setattr("api.routes.retrieval_qa.LLMClient", _default_fake_llm_refusal_client)
+def _default_fake_embedder() -> InMemoryEmbedder:
+    """A deterministic embedder that returns fixed 1536-dim vectors."""
+    return InMemoryEmbedder(dimension=1536, scale=0.01)
+
+
+def _default_fake_llm_refusal_provider() -> MockCompletionProvider:
+    """A mocked completion provider returning a fixed refusal answer."""
+    return MockCompletionProvider("I could not find anything relevant in the corpus.")
+
+
+def set_dependency_override(client: TestClient, dependency: Any, override: Any) -> None:
+    """Set a FastAPI dependency override on ``client.app``.
+
+    ``TestClient.app`` is typed as a generic ASGI callable, so this helper
+    casts it to ``FastAPI`` before touching ``dependency_overrides``.
+    """
+    cast(FastAPI, client.app).dependency_overrides[dependency] = override
 
 
 @pytest.fixture
 def client(override_route_db_session: object, monkeypatch: pytest.MonkeyPatch) -> TestClient:
-    """A TestClient with DB sessions and embeddings client mocked.
+    """A TestClient with DB sessions and provider dependencies mocked.
 
-    Override ``monkeypatch`` again in a test to swap the embeddings client
-    behaviour (e.g. make it raise).
+    Real API calls belong only in the eval job (coding-standards.md). Both
+    the ingestion task and the query route get mocked ``Embedder`` and
+    ``CompletionProvider`` dependencies via FastAPI dependency overrides.
     """
-    # Default: a mocked embeddings client that returns fixed 1536-dim vectors.
-    # Real API calls belong only in the eval job (coding-standards.md); both
-    # the ingestion task and the query route get a mocked embeddings + LLM
-    # client. Tests override ``LLMClient`` / ``EmbeddingsClient`` to swap
-    # behaviour (e.g. make them raise, or return a grounded answer).
-    _patch_clients(monkeypatch)
-    from api.server import create_app
-
-    return TestClient(create_app())
+    app = create_app()
+    app.dependency_overrides[get_embedder] = _default_fake_embedder
+    app.dependency_overrides[get_completion_provider] = _default_fake_llm_refusal_provider
+    return TestClient(app)
 
 
 @pytest.fixture
@@ -41,10 +55,9 @@ def mock_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
 
     For tests that exercise request validation or upstream-error mapping
     where the DB session is opened but not meaningfully used (the embeddings
-    call raise, or retrieval is monkeypatched away). Lets the HTTP-level
+    call raises, or retrieval is monkeypatched away). Lets the HTTP-level
     behaviour run without a real Postgres+pgvector instance.
     """
-    _patch_clients(monkeypatch)
 
     @contextmanager
     def _mock_db_session() -> Generator[MagicMock, None, None]:
@@ -62,9 +75,10 @@ def mock_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.setattr("api.routes.documents.db_session", _mock_db_session)
     monkeypatch.setattr("api.routes.retrieval_qa.db_session", _mock_db_session)
 
-    from api.server import create_app
-
-    return TestClient(create_app())
+    app = create_app()
+    app.dependency_overrides[get_embedder] = _default_fake_embedder
+    app.dependency_overrides[get_completion_provider] = _default_fake_llm_refusal_provider
+    return TestClient(app)
 
 
 @pytest.fixture
@@ -122,20 +136,3 @@ def ingest_a_documentation(client: TestClient, sample_documentation_md: bytes) -
         return str(document_id)
 
     return _ingest
-
-
-def _default_fake_client(*args: object, **kwargs: object) -> MagicMock:
-    client = MagicMock()
-
-    def _embed(texts: list[str]) -> list[list[float]]:
-        return [[0.01 * (i + 1)] * 1536 for i in range(len(texts))]
-
-    client.embed.side_effect = _embed
-    return client
-
-
-def _default_fake_llm_refusal_client(*args: object, **kwargs: object) -> MagicMock:
-    """A mocked LLM client returning a fixed refusal (not-grounded) answer."""
-    client = MagicMock()
-    client.chat.return_value = "I could not find anything relevant in the corpus."
-    return client

--- a/core/src/core/__init__.py
+++ b/core/src/core/__init__.py
@@ -1,0 +1,3 @@
+"""Shared core package for the Learning Hub monorepo."""
+
+__all__ = ["clients", "config", "database", "exceptions", "types"]

--- a/core/src/core/clients/__init__.py
+++ b/core/src/core/clients/__init__.py
@@ -1,5 +1,21 @@
-"""Hosted API clients."""
+"""Hosted API clients and provider protocols."""
 
-from core.clients.embeddings_client import EmbeddingsClient
+from core.clients.embeddings_client import (
+    Embedder,
+    EmbeddingsClient,
+    InMemoryEmbedder,
+)
+from core.clients.llm_client import (
+    CompletionProvider,
+    LLMClient,
+    MockCompletionProvider,
+)
 
-__all__ = ["EmbeddingsClient"]
+__all__ = [
+    "CompletionProvider",
+    "Embedder",
+    "EmbeddingsClient",
+    "InMemoryEmbedder",
+    "LLMClient",
+    "MockCompletionProvider",
+]

--- a/core/src/core/clients/embeddings_client.py
+++ b/core/src/core/clients/embeddings_client.py
@@ -1,11 +1,33 @@
 """Client for the hosted OpenAI embeddings API."""
 
 from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
 
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, OpenAI
 
 from core.config.settings import settings
 from core.exceptions import UpstreamBadResponse, UpstreamUnavailable
+
+
+@runtime_checkable
+class Embedder(Protocol):
+    """Protocol for synchronous text embedding providers.
+
+    Consumers depend on this protocol rather than a concrete client so that
+    hosted API clients, in-memory test doubles, and future provider
+    implementations are interchangeable.
+    """
+
+    def embed(self, texts: Sequence[str]) -> list[list[float]]:
+        """Embed a batch of texts synchronously.
+
+        Args:
+            texts: Input strings to embed.
+
+        Returns:
+            One vector per input string, with a consistent dimensionality.
+        """
+        ...
 
 
 class EmbeddingsClient:
@@ -84,3 +106,35 @@ class EmbeddingsClient:
             raise UpstreamBadResponse(
                 f"Embeddings API returned unexpected response shape: {exc}"
             ) from exc
+
+
+class InMemoryEmbedder:
+    """Deterministic, in-memory embedder for tests and local development.
+
+    Implements ``Embedder`` without calling a hosted API. Each input text
+    receives a deterministic vector based on its position in the batch.
+    """
+
+    def __init__(self, *, dimension: int = 1536, scale: float = 0.01) -> None:
+        """Initialize the embedder.
+
+        Args:
+            dimension: Vector dimensionality.
+            scale: Multiplier used to vary vectors per input position.
+        """
+        self._dimension = dimension
+        self._scale = scale
+
+    def embed(self, texts: Sequence[str]) -> list[list[float]]:
+        """Return one deterministic vector per input text.
+
+        Args:
+            texts: Input strings to embed.
+
+        Returns:
+            A vector of length ``dimension`` for each input string.
+        """
+        return [[self._scale * (i + 1)] * self._dimension for i in range(len(texts))]
+
+
+__all__ = ["Embedder", "EmbeddingsClient", "InMemoryEmbedder"]

--- a/core/src/core/clients/llm_client.py
+++ b/core/src/core/clients/llm_client.py
@@ -7,12 +7,34 @@ narrow: one model, plain chat-completions shape, no streaming/tools.
 """
 
 from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
 
 from openai import APIConnectionError, APIStatusError, OpenAI
 
 from core.config.settings import settings
 from core.exceptions import UpstreamBadResponse, UpstreamUnavailable
 from core.types.chat import ChatMessage
+
+
+@runtime_checkable
+class CompletionProvider(Protocol):
+    """Protocol for synchronous chat-completion providers.
+
+    Consumers depend on this protocol rather than a concrete client so that
+    hosted API clients, deterministic test doubles, and future provider
+    implementations are interchangeable.
+    """
+
+    def chat(self, messages: Sequence[ChatMessage]) -> str:
+        """Generate a chat completion and return the message content.
+
+        Args:
+            messages: Chat messages (role/content) to send to the model.
+
+        Returns:
+            The generated message content as a string.
+        """
+        ...
 
 
 class LLMClient:
@@ -74,3 +96,32 @@ class LLMClient:
         if content is None:
             raise UpstreamBadResponse("Inference API returned empty message content")
         return content
+
+
+class MockCompletionProvider:
+    """Deterministic chat-completion test double.
+
+    Implements ``CompletionProvider`` without calling a hosted inference API.
+    """
+
+    def __init__(self, response: str = "Mocked answer.") -> None:
+        """Initialize the provider.
+
+        Args:
+            response: The fixed string to return from ``chat()``.
+        """
+        self._response = response
+
+    def chat(self, messages: Sequence[ChatMessage]) -> str:
+        """Return the configured response.
+
+        Args:
+            messages: Messages that would be sent to the model (ignored).
+
+        Returns:
+            The configured response string.
+        """
+        return self._response
+
+
+__all__ = ["CompletionProvider", "LLMClient", "MockCompletionProvider"]

--- a/core/src/core/types/__init__.py
+++ b/core/src/core/types/__init__.py
@@ -3,6 +3,7 @@
 from core.types.chat import ChatMessage
 from core.types.chunk import (
     BookChunkMetadata,
+    Chunk,
     DocumentationChunkMetadata,
     PaperChunkMetadata,
 )
@@ -11,15 +12,24 @@ from core.types.document import (
     DocumentStatusResponse,
     DocumentType,
 )
+from core.types.responses import (
+    CitedPassage,
+    HarnessARequest,
+    HarnessAResponse,
+)
 from core.types.retrieval_config import RetrievalConfig
 
 __all__ = [
     "BookChunkMetadata",
     "ChatMessage",
+    "Chunk",
+    "CitedPassage",
     "DocumentStatus",
     "DocumentStatusResponse",
     "DocumentType",
     "DocumentationChunkMetadata",
+    "HarnessARequest",
+    "HarnessAResponse",
     "PaperChunkMetadata",
     "RetrievalConfig",
 ]

--- a/core/src/core/types/chunk.py
+++ b/core/src/core/types/chunk.py
@@ -7,6 +7,19 @@ in Python before persisting (ADR-0014).
 from pydantic import BaseModel, ConfigDict
 
 
+class Chunk(BaseModel):
+    """Base model for a chunk produced by a document-type chunker.
+
+    All concrete chunker outputs share ``content``, ``metadata``, and
+    ``token_count``. The base model lets the ingestion pipeline treat them
+    uniformly without importing concrete chunker classes.
+    """
+
+    content: str
+    metadata: BaseModel
+    token_count: int
+
+
 class PaperChunkMetadata(BaseModel):
     """Metadata for a paper chunk."""
 
@@ -33,3 +46,11 @@ class DocumentationChunkMetadata(BaseModel):
 
     page: str
     section: str | None
+
+
+__all__ = [
+    "BookChunkMetadata",
+    "Chunk",
+    "DocumentationChunkMetadata",
+    "PaperChunkMetadata",
+]

--- a/core/tests/core/test_embeddings_client.py
+++ b/core/tests/core/test_embeddings_client.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from core.clients.embeddings_client import EmbeddingsClient
+from core.clients.embeddings_client import Embedder, EmbeddingsClient, InMemoryEmbedder
 
 
 def test_embed_returns_one_vector_per_input(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -30,3 +30,26 @@ def test_embed_returns_one_vector_per_input(monkeypatch: pytest.MonkeyPatch) -> 
         input=["hello", "world"],
         model="text-embedding-3-small",
     )
+
+
+def test_embeddings_client_satisfies_embedder_protocol() -> None:
+    """EmbeddingsClient is a structural ``Embedder`` implementation."""
+    client = EmbeddingsClient(api_key="sk-test", model="text-embedding-3-small")
+    assert isinstance(client, Embedder)
+
+
+def test_in_memory_embedder_returns_one_vector_per_text() -> None:
+    """InMemoryEmbedder returns one deterministic vector per input."""
+    embedder = InMemoryEmbedder(dimension=8, scale=0.1)
+    vectors = embedder.embed(["alpha", "beta"])
+
+    assert len(vectors) == 2
+    assert len(vectors[0]) == 8
+    assert vectors[0] == [0.1] * 8
+    assert vectors[1] == [0.2] * 8
+
+
+def test_in_memory_embedder_satisfies_embedder_protocol() -> None:
+    """InMemoryEmbedder is a structural ``Embedder`` implementation."""
+    embedder = InMemoryEmbedder()
+    assert isinstance(embedder, Embedder)

--- a/core/tests/core/test_llm_client.py
+++ b/core/tests/core/test_llm_client.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 from openai import APIConnectionError, APIStatusError
 
-from core.clients.llm_client import LLMClient
+from core.clients.llm_client import CompletionProvider, LLMClient, MockCompletionProvider
 from core.exceptions import UpstreamBadResponse, UpstreamUnavailable
 from core.types.chat import ChatMessage
 
@@ -121,3 +121,22 @@ def test_chat_raises_upstream_bad_response_when_content_missing(
 
     with pytest.raises(UpstreamBadResponse):
         client.chat(messages=[ChatMessage(role="user", content="x")])
+
+
+def test_llm_client_satisfies_completion_provider_protocol() -> None:
+    """LLMClient is a structural ``CompletionProvider`` implementation."""
+    client = LLMClient(api_key="sk-test", model="gpt-4o-mini")
+    assert isinstance(client, CompletionProvider)
+
+
+def test_mock_completion_provider_returns_configured_response() -> None:
+    """MockCompletionProvider returns the response configured at construction."""
+    provider = MockCompletionProvider("Fixed answer.")
+    result = provider.chat([ChatMessage(role="user", content="question")])
+    assert result == "Fixed answer."
+
+
+def test_mock_completion_provider_satisfies_protocol() -> None:
+    """MockCompletionProvider is a structural ``CompletionProvider`` implementation."""
+    provider = MockCompletionProvider()
+    assert isinstance(provider, CompletionProvider)

--- a/depth_dive/src/depth_dive/__init__.py
+++ b/depth_dive/src/depth_dive/__init__.py
@@ -1,0 +1,3 @@
+"""Depth Dive package (Harness B)."""
+
+__all__: list[str] = []

--- a/ingestion/src/ingestion/__init__.py
+++ b/ingestion/src/ingestion/__init__.py
@@ -1,0 +1,3 @@
+"""Ingestion package."""
+
+__all__ = ["pipeline", "tasks"]

--- a/ingestion/src/ingestion/pipeline.py
+++ b/ingestion/src/ingestion/pipeline.py
@@ -1,26 +1,18 @@
 """Background ingestion pipeline for uploaded documents."""
 
 from collections.abc import Sequence
-from typing import assert_never
 from uuid import UUID
 
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
-from core.clients.embeddings_client import EmbeddingsClient
-from core.database.schema import Chunk, Document, Embedding
+from core.clients import Embedder
+from core.database.schema import Chunk as ChunkRow
+from core.database.schema import Document, Embedding
 from core.exceptions import IngestionError
-from core.types.chunk import (
-    BookChunkMetadata,
-    DocumentationChunkMetadata,
-    PaperChunkMetadata,
-)
+from core.types.chunk import Chunk
 from core.types.document import DocumentStatus, DocumentType
-from retrieval_qa.chunking.book_chunker import BookChunk, chunk_book
-from retrieval_qa.chunking.documentation_chunker import DocumentationChunk, chunk_documentation
-from retrieval_qa.chunking.paper_chunker import PaperChunk, chunk_paper
-
-_Chunk = PaperChunk | BookChunk | DocumentationChunk
+from retrieval_qa.chunking import chunker_registry, get_chunker_class
 
 
 def _validate_type_metadata(
@@ -37,15 +29,11 @@ def _validate_type_metadata(
     Raises ``IngestionError`` when validation fails.
     """
     try:
-        match document_type:
-            case DocumentType.PAPER:
-                PaperChunkMetadata.model_validate(type_metadata)
-            case DocumentType.BOOK:
-                BookChunkMetadata.model_validate(type_metadata)
-            case DocumentType.DOCUMENTATION:
-                DocumentationChunkMetadata.model_validate(type_metadata)
-            case _ as unreachable:
-                assert_never(unreachable)
+        chunker_class = chunker_registry[document_type]
+    except KeyError as exc:
+        raise IngestionError(f"No chunker registered for {document_type.value}") from exc
+    try:
+        chunker_class.metadata_model.model_validate(type_metadata)
     except ValidationError as exc:
         raise IngestionError(
             f"type_metadata validation failed for {document_type.value}: {exc}"
@@ -53,12 +41,12 @@ def _validate_type_metadata(
 
 
 def _chunk_inputs(
-    chunks: Sequence[_Chunk],
+    chunks: Sequence[Chunk],
 ) -> list[tuple[str, dict[str, object], int]]:
     """Convert chunker output to the (content, type_metadata, token_count) shape.
 
-    Both paper and book chunkers expose the same interface, so this helper
-    avoids repeating the tuple construction.
+    All chunkers expose the same ``Chunk`` protocol, so this helper avoids
+    repeating the tuple construction for each document type.
     """
     return [(chunk.content, chunk.metadata.model_dump(), chunk.token_count) for chunk in chunks]
 
@@ -69,27 +57,20 @@ def _chunk_document(
 ) -> list[tuple[str, dict[str, object], int]]:
     """Return (content, type_metadata, token_count) tuples for a document.
 
-    Dispatches to the document-type-specific chunker. The ``match`` /
-    ``assert_never`` pair provides compile-time exhaustiveness: adding a new
-    ``DocumentType`` member produces a type-check error at every dispatch site.
+    Dispatches to the document-type-specific chunker via the registry. Adding
+    a new ``DocumentType`` only requires registering a new chunker; this
+    function does not need to change.
     """
-    match document_type:
-        case DocumentType.PAPER:
-            return _chunk_inputs(chunk_paper(file_bytes))
-        case DocumentType.BOOK:
-            return _chunk_inputs(chunk_book(file_bytes))
-        case DocumentType.DOCUMENTATION:
-            return _chunk_inputs(chunk_documentation(file_bytes))
-        case _ as unreachable:
-            assert_never(unreachable)
+    chunker_class = get_chunker_class(document_type)
+    return _chunk_inputs(chunker_class().chunk(file_bytes))
 
 
 def _embed_chunks(
     session: Session,
-    client: EmbeddingsClient,
-    chunks: Sequence[Chunk],
+    client: Embedder,
+    chunks: Sequence[ChunkRow],
     model_name: str,
-) -> list[tuple[Chunk, list[float]]]:
+) -> list[tuple[ChunkRow, list[float]]]:
     """Embed chunk contents and return (chunk, vector) pairs."""
     if not chunks:
         return []
@@ -115,7 +96,7 @@ def run_ingestion(
     source_filename: str,
     file_bytes: bytes,
     session: Session,
-    embeddings_client: EmbeddingsClient,
+    embeddings_client: Embedder,
     model_name: str,
 ) -> None:
     """Run the ingestion pipeline inside an open transaction.
@@ -132,7 +113,7 @@ def run_ingestion(
         source_filename: Original upload filename.
         file_bytes: Raw uploaded file contents.
         session: SQLAlchemy session bound to the documents database.
-        embeddings_client: Client that produces one vector per chunk text.
+        embeddings_client: Provider that produces one vector per chunk text.
         model_name: Model name to store alongside each embedding row.
     """
     _ = title, source_filename  # retained for future metadata use; not needed now
@@ -148,10 +129,10 @@ def run_ingestion(
         document.status = DocumentStatus.CHUNKING
         session.flush()
 
-        db_chunks: list[Chunk] = []
+        db_chunks: list[ChunkRow] = []
         for position, (content, type_metadata, token_count) in enumerate(chunk_inputs):
             _validate_type_metadata(document_type, type_metadata)
-            chunk = Chunk(
+            chunk = ChunkRow(
                 document_id=document_id,
                 position=position,
                 content=content,

--- a/ingestion/src/ingestion/tasks.py
+++ b/ingestion/src/ingestion/tasks.py
@@ -9,8 +9,7 @@ from uuid import UUID
 
 from fastapi import BackgroundTasks
 
-from core.clients.embeddings_client import EmbeddingsClient
-from core.config.settings import settings
+from core.clients import Embedder
 from core.database.connection import SessionLocal
 from core.database.schema import Document
 from core.exceptions import IngestionError
@@ -23,6 +22,8 @@ def _execute_ingestion_task(
     document_type: DocumentType,
     source_filename: str,
     file_bytes: bytes,
+    embedder: Embedder,
+    model_name: str,
 ) -> None:
     """Synchronous wrapper run by ``BackgroundTasks``.
 
@@ -31,10 +32,6 @@ def _execute_ingestion_task(
     """
     session = SessionLocal()
     try:
-        embeddings_client = EmbeddingsClient(
-            api_key=settings.openai_api_key,
-            model=settings.embedding_model,
-        )
         title = ""
         document = session.get(Document, document_id)
         if document is not None:
@@ -47,8 +44,8 @@ def _execute_ingestion_task(
             source_filename=source_filename,
             file_bytes=file_bytes,
             session=session,
-            embeddings_client=embeddings_client,
-            model_name=settings.embedding_model,
+            embeddings_client=embedder,
+            model_name=model_name,
         )
         session.commit()
     except Exception as exc:
@@ -78,6 +75,8 @@ def schedule_ingestion(
     document_type: DocumentType,
     source_filename: str,
     file_bytes: bytes,
+    embedder: Embedder,
+    model_name: str,
 ) -> None:
     """Schedule the ingestion pipeline as a background task.
 
@@ -87,6 +86,8 @@ def schedule_ingestion(
         document_type: Document type (e.g. ``DocumentType.PAPER``).
         source_filename: Original upload filename.
         file_bytes: Raw uploaded file contents.
+        embedder: Provider used to embed chunk contents.
+        model_name: Model name to store alongside each embedding row.
     """
     background_tasks.add_task(
         _execute_ingestion_task,
@@ -94,6 +95,8 @@ def schedule_ingestion(
         document_type,
         source_filename,
         file_bytes,
+        embedder,
+        model_name,
     )
 
 

--- a/ingestion/tests/ingestion/test_tasks.py
+++ b/ingestion/tests/ingestion/test_tasks.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+from core.clients import InMemoryEmbedder
 from core.types.document import DocumentType
 from ingestion.tasks import schedule_ingestion
 
@@ -11,6 +12,8 @@ def test_schedule_ingestion_adds_background_task() -> None:
     """schedule_ingestion registers _execute_ingestion_task on BackgroundTasks."""
     mock_bg = MagicMock()
     doc_id = uuid4()
+    embedder = InMemoryEmbedder()
+    model_name = "text-embedding-3-small"
 
     schedule_ingestion(
         background_tasks=mock_bg,
@@ -18,6 +21,8 @@ def test_schedule_ingestion_adds_background_task() -> None:
         document_type=DocumentType.PAPER,
         source_filename="test.pdf",
         file_bytes=b"fake-pdf-bytes",
+        embedder=embedder,
+        model_name=model_name,
     )
 
     mock_bg.add_task.assert_called_once()
@@ -29,6 +34,8 @@ def test_schedule_ingestion_adds_background_task() -> None:
     assert args[0][2] == DocumentType.PAPER
     assert args[0][3] == "test.pdf"
     assert args[0][4] == b"fake-pdf-bytes"
+    assert args[0][5] is embedder
+    assert args[0][6] == model_name
 
 
 def test_schedule_ingestion_is_public_api() -> None:

--- a/retrieval_qa/src/retrieval_qa/__init__.py
+++ b/retrieval_qa/src/retrieval_qa/__init__.py
@@ -1,0 +1,3 @@
+"""Retrieval QA package (Harness A)."""
+
+__all__ = ["chunking", "retrieval"]

--- a/retrieval_qa/src/retrieval_qa/chunking/__init__.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/__init__.py
@@ -1,14 +1,41 @@
-"""Document-type chunkers."""
+"""Document-type chunkers.
 
-from retrieval_qa.chunking.book_chunker import BookChunk, chunk_book
-from retrieval_qa.chunking.documentation_chunker import DocumentationChunk, chunk_documentation
-from retrieval_qa.chunking.paper_chunker import PaperChunk, chunk_paper
+Provides a registry-based extension point for new document types. Adding a
+chunker for a new ``DocumentType`` only requires implementing
+``DocumentChunker`` and calling ``register_chunker``; no existing chunker or
+pipeline code needs to change.
+"""
+
+from core.types.chunk import Chunk
+from retrieval_qa.chunking.base import (
+    DocumentChunker,
+    chunker_registry,
+    get_chunker,
+    get_chunker_class,
+    register_chunker,
+)
+from retrieval_qa.chunking.book_chunker import BookChunk, BookChunker, chunk_book
+from retrieval_qa.chunking.documentation_chunker import (
+    DocumentationChunk,
+    DocumentationChunker,
+    chunk_documentation,
+)
+from retrieval_qa.chunking.paper_chunker import PaperChunk, PaperChunker, chunk_paper
 
 __all__ = [
     "BookChunk",
+    "BookChunker",
+    "Chunk",
+    "DocumentChunker",
     "DocumentationChunk",
+    "DocumentationChunker",
     "PaperChunk",
+    "PaperChunker",
     "chunk_book",
     "chunk_documentation",
     "chunk_paper",
+    "chunker_registry",
+    "get_chunker",
+    "get_chunker_class",
+    "register_chunker",
 ]

--- a/retrieval_qa/src/retrieval_qa/chunking/base.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/base.py
@@ -1,0 +1,75 @@
+"""Base document-type chunker abstraction and registry."""
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from typing import ClassVar
+
+from pydantic import BaseModel
+
+from core.exceptions import IngestionError
+from core.types.chunk import Chunk
+from core.types.document import DocumentType
+
+
+class DocumentChunker(ABC):
+    """Abstract base for a document-type chunker."""
+
+    metadata_model: ClassVar[type[BaseModel]]
+
+    @abstractmethod
+    def chunk(self, file_bytes: bytes) -> Sequence[Chunk]:
+        """Chunk ``file_bytes`` into a sequence of ``Chunk`` objects.
+
+        Args:
+            file_bytes: Raw uploaded file contents.
+
+        Returns:
+            Chunks ordered by their appearance in the document.
+        """
+        ...
+
+
+chunker_registry: dict[DocumentType, type[DocumentChunker]] = {}
+
+
+def register_chunker(
+    document_type: DocumentType,
+    chunker_class: type[DocumentChunker],
+) -> type[DocumentChunker]:
+    """Register a chunker class for a document type.
+
+    Returns:
+        The registered chunker class (so it can be used as a decorator).
+    """
+    chunker_registry[document_type] = chunker_class
+    return chunker_class
+
+
+def get_chunker_class(document_type: DocumentType) -> type[DocumentChunker]:
+    """Return the chunker class registered for ``document_type``.
+
+    Raises:
+        IngestionError: No chunker is registered for ``document_type``.
+    """
+    try:
+        return chunker_registry[document_type]
+    except KeyError as exc:
+        raise IngestionError(f"No chunker registered for {document_type.value}") from exc
+
+
+def get_chunker(document_type: DocumentType) -> DocumentChunker:
+    """Return a chunker instance for ``document_type``.
+
+    Raises:
+        IngestionError: No chunker is registered for ``document_type``.
+    """
+    return get_chunker_class(document_type)()
+
+
+__all__ = [
+    "DocumentChunker",
+    "chunker_registry",
+    "get_chunker",
+    "get_chunker_class",
+    "register_chunker",
+]

--- a/retrieval_qa/src/retrieval_qa/chunking/book_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/book_chunker.py
@@ -8,15 +8,18 @@ import os
 import re
 import xml.etree.ElementTree as ET
 import zipfile
+from collections.abc import Sequence
 from enum import StrEnum
 from html.parser import HTMLParser
 from io import BytesIO
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
 from pypdf import PdfReader
 
 from core.exceptions import IngestionError
-from core.types.chunk import BookChunkMetadata
+from core.types.chunk import BookChunkMetadata, Chunk
+from core.types.document import DocumentType
+from retrieval_qa.chunking.base import DocumentChunker, register_chunker
 
 
 class BookFormat(StrEnum):
@@ -44,14 +47,12 @@ _HEADING_PATTERN = re.compile(
 )
 
 
-class BookChunk(BaseModel):
+class BookChunk(Chunk):
     """A single chunk produced by the book chunker."""
 
     model_config = ConfigDict(extra="forbid")
 
-    content: str
     metadata: BookChunkMetadata
-    token_count: int
 
 
 class _HTMLTextExtractor(HTMLParser):
@@ -445,4 +446,17 @@ def chunk_book(file_bytes: bytes) -> list[BookChunk]:
     return chunks
 
 
-__all__ = ["BookChunk", "chunk_book"]
+class BookChunker(DocumentChunker):
+    """Chunker for books."""
+
+    metadata_model = BookChunkMetadata
+
+    def chunk(self, file_bytes: bytes) -> Sequence[Chunk]:
+        """Chunk a book PDF or EPUB into chapter-aware pieces."""
+        return chunk_book(file_bytes)
+
+
+register_chunker(DocumentType.BOOK, BookChunker)
+
+
+__all__ = ["BookChunk", "BookChunker", "chunk_book"]

--- a/retrieval_qa/src/retrieval_qa/chunking/documentation_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/documentation_chunker.py
@@ -9,15 +9,18 @@ PDF page breaks). Sections include sub-headings and API endpoint lines such as
 """
 
 import re
+from collections.abc import Sequence
 from enum import StrEnum
 from html.parser import HTMLParser
 from io import BytesIO
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
 from pypdf import PdfReader
 
 from core.exceptions import IngestionError
-from core.types.chunk import DocumentationChunkMetadata
+from core.types.chunk import Chunk, DocumentationChunkMetadata
+from core.types.document import DocumentType
+from retrieval_qa.chunking.base import DocumentChunker, register_chunker
 
 
 class DocumentationFormat(StrEnum):
@@ -39,14 +42,12 @@ _API_ENTRY_PATTERN = re.compile(
 )
 
 
-class DocumentationChunk(BaseModel):
+class DocumentationChunk(Chunk):
     """A single chunk produced by the documentation chunker."""
 
     model_config = ConfigDict(extra="forbid")
 
-    content: str
     metadata: DocumentationChunkMetadata
-    token_count: int
 
 
 class _HTMLTextExtractor(HTMLParser):
@@ -259,4 +260,17 @@ def chunk_documentation(file_bytes: bytes) -> list[DocumentationChunk]:
     return chunks
 
 
-__all__ = ["DocumentationChunk", "chunk_documentation"]
+class DocumentationChunker(DocumentChunker):
+    """Chunker for documentation."""
+
+    metadata_model = DocumentationChunkMetadata
+
+    def chunk(self, file_bytes: bytes) -> Sequence[Chunk]:
+        """Chunk a Markdown/HTML/PDF documentation file into page-aware pieces."""
+        return chunk_documentation(file_bytes)
+
+
+register_chunker(DocumentType.DOCUMENTATION, DocumentationChunker)
+
+
+__all__ = ["DocumentationChunk", "DocumentationChunker", "chunk_documentation"]

--- a/retrieval_qa/src/retrieval_qa/chunking/paper_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/paper_chunker.py
@@ -5,12 +5,15 @@ emitting ``PaperChunkMetadata`` for each chunk.
 """
 
 import re
+from collections.abc import Sequence
 from io import BytesIO
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
 from pypdf import PdfReader
 
-from core.types.chunk import PaperChunkMetadata
+from core.types.chunk import Chunk, PaperChunkMetadata
+from core.types.document import DocumentType
+from retrieval_qa.chunking.base import DocumentChunker, register_chunker
 
 # Matches lines that look like paper section headers, e.g.:
 #   "1 Introduction"
@@ -23,14 +26,12 @@ _SECTION_PATTERN = re.compile(
 )
 
 
-class PaperChunk(BaseModel):
+class PaperChunk(Chunk):
     """A single chunk produced by the paper chunker."""
 
     model_config = ConfigDict(extra="forbid")
 
-    content: str
     metadata: PaperChunkMetadata
-    token_count: int
 
 
 def _count_tokens(text: str) -> int:
@@ -144,3 +145,19 @@ def chunk_paper(pdf_bytes: bytes) -> list[PaperChunk]:
         )
 
     return chunks
+
+
+class PaperChunker(DocumentChunker):
+    """Chunker for academic papers."""
+
+    metadata_model = PaperChunkMetadata
+
+    def chunk(self, file_bytes: bytes) -> Sequence[Chunk]:
+        """Chunk a paper PDF into section-aware pieces."""
+        return chunk_paper(file_bytes)
+
+
+register_chunker(DocumentType.PAPER, PaperChunker)
+
+
+__all__ = ["PaperChunk", "PaperChunker", "chunk_paper"]

--- a/retrieval_qa/tests/retrieval_qa/test_chunker_registry.py
+++ b/retrieval_qa/tests/retrieval_qa/test_chunker_registry.py
@@ -1,0 +1,133 @@
+"""Tests for the document-type chunker registry."""
+
+from collections.abc import Sequence
+
+import pytest
+from pydantic import BaseModel
+
+from core.exceptions import IngestionError
+from core.types.chunk import (
+    BookChunkMetadata,
+    Chunk,
+    DocumentationChunkMetadata,
+    PaperChunkMetadata,
+)
+from core.types.document import DocumentType
+from retrieval_qa.chunking import (
+    BookChunker,
+    DocumentationChunker,
+    DocumentChunker,
+    PaperChunker,
+    chunker_registry,
+    get_chunker,
+    get_chunker_class,
+    register_chunker,
+)
+from retrieval_qa.chunking.book_chunker import BookChunk
+from retrieval_qa.chunking.documentation_chunker import DocumentationChunk
+from retrieval_qa.chunking.paper_chunker import PaperChunk
+
+
+def test_registry_contains_all_document_types() -> None:
+    """Every known DocumentType has a registered chunker."""
+    assert set(chunker_registry.keys()) == set(DocumentType)
+
+
+def test_get_chunker_class_returns_registered_class() -> None:
+    """get_chunker_class returns the registered chunker class for each type."""
+    assert get_chunker_class(DocumentType.PAPER) is PaperChunker
+    assert get_chunker_class(DocumentType.BOOK) is BookChunker
+    assert get_chunker_class(DocumentType.DOCUMENTATION) is DocumentationChunker
+
+
+def test_get_chunker_returns_instance_for_each_type() -> None:
+    """get_chunker returns a usable chunker instance for each document type."""
+    assert isinstance(get_chunker(DocumentType.PAPER), PaperChunker)
+    assert isinstance(get_chunker(DocumentType.BOOK), BookChunker)
+    assert isinstance(get_chunker(DocumentType.DOCUMENTATION), DocumentationChunker)
+
+
+def test_chunker_classes_implement_abstract_base() -> None:
+    """Each concrete chunker is a subclass of DocumentChunker."""
+    assert issubclass(PaperChunker, DocumentChunker)
+    assert issubclass(BookChunker, DocumentChunker)
+    assert issubclass(DocumentationChunker, DocumentChunker)
+
+
+def test_chunker_classes_declare_metadata_model() -> None:
+    """Each concrete chunker declares a Pydantic metadata model."""
+    assert issubclass(PaperChunker.metadata_model, BaseModel)
+    assert issubclass(BookChunker.metadata_model, BaseModel)
+    assert issubclass(DocumentationChunker.metadata_model, BaseModel)
+
+
+def test_chunker_returns_chunk_base_model_objects(sample_paper_pdf: bytes) -> None:
+    """Chunker instances return objects that inherit from the Chunk base model."""
+    chunker = get_chunker(DocumentType.PAPER)
+    result = chunker.chunk(sample_paper_pdf)
+    assert isinstance(result, Sequence)
+    assert len(result) >= 1
+    for chunk in result:
+        assert isinstance(chunk, Chunk)
+
+
+def test_get_chunker_class_raises_for_unknown_document_type() -> None:
+    """An unregistered document type raises IngestionError."""
+    # Remove the paper chunker temporarily to simulate an unknown type.
+    original = chunker_registry.pop(DocumentType.PAPER)
+    try:
+        with pytest.raises(IngestionError):
+            get_chunker_class(DocumentType.PAPER)
+    finally:
+        chunker_registry[DocumentType.PAPER] = original
+
+
+def test_register_chunker_allows_extension_without_editing_existing() -> None:
+    """A new chunker can be registered without touching existing chunkers."""
+
+    class FakeMetadata(BaseModel):
+        value: int
+
+    class FakeChunker(DocumentChunker):
+        metadata_model = FakeMetadata
+
+        def chunk(self, file_bytes: bytes) -> Sequence[Chunk]:
+            return []
+
+    # Temporarily swap the paper chunker to simulate adding a new document type.
+    custom_type = DocumentType.PAPER
+    original = chunker_registry[custom_type]
+    try:
+        register_chunker(custom_type, FakeChunker)
+        assert chunker_registry[custom_type] is FakeChunker
+        assert isinstance(get_chunker(custom_type), FakeChunker)
+    finally:
+        chunker_registry[custom_type] = original
+
+
+def test_concrete_chunk_types_are_chunk_subclasses() -> None:
+    """PaperChunk, BookChunk, and DocumentationChunk inherit from Chunk."""
+    assert issubclass(PaperChunk, Chunk)
+    assert issubclass(BookChunk, Chunk)
+    assert issubclass(DocumentationChunk, Chunk)
+
+    paper = PaperChunk(
+        content="c",
+        metadata=PaperChunkMetadata(section="Intro", subsection=None, page=1),
+        token_count=1,
+    )
+    assert isinstance(paper, Chunk)
+
+    book = BookChunk(
+        content="c",
+        metadata=BookChunkMetadata(chapter=1, heading=None),
+        token_count=1,
+    )
+    assert isinstance(book, Chunk)
+
+    doc = DocumentationChunk(
+        content="c",
+        metadata=DocumentationChunkMetadata(page="p", section=None),
+        token_count=1,
+    )
+    assert isinstance(doc, Chunk)


### PR DESCRIPTION
Implement the SOLID review actions:

- Add Embedder and CompletionProvider protocols in core.clients.
- Add InMemoryEmbedder and MockCompletionProvider test doubles.
- Wire Embedder/CompletionProvider into API routes via FastAPI Depends() factory providers in api.dependencies.
- Pass the embedder and model name through ingestion.tasks instead of instantiating a concrete client inside the task.
- Extract a Chunk base model and DocumentChunker ABC/registry.
- Move chunker implementations into their respective modules.
- Refactor ingestion.pipeline to dispatch via the registry and validate metadata via the registered chunker's metadata_model.
- Extract prompt assembly into api.prompt.
- Add __all__ public surfaces to package __init__.py files.
- Update tests to use dependency overrides and cover the registry/protocols.