### PR TITLE
refactor(retrieval-qa): move deferred IngestionError import to module…

### DIFF
--- a/retrieval_qa/src/retrieval_qa/chunking/paper_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/paper_chunker.py
@@ -11,6 +11,7 @@ from io import BytesIO
 from pydantic import ConfigDict
 from pypdf import PdfReader
 
+from core.exceptions import IngestionError
 from core.types.chunk import Chunk, PaperChunkMetadata
 from core.types.document import DocumentType
 from retrieval_qa.chunking.base import DocumentChunker, register_chunker
@@ -94,8 +95,6 @@ def chunk_paper(pdf_bytes: bytes) -> list[PaperChunk]:
     Raises:
         IngestionError: The PDF could not be read.
     """
-    from core.exceptions import IngestionError
-
     try:
         reader = PdfReader(BytesIO(pdf_bytes))
     except Exception as exc:


### PR DESCRIPTION
… level

The from core.exceptions import IngestionError was inside the chunk_paper() function body, unlike the other chunkers which import exceptions at the top of the file. There is no circular-dependency or lazy-loading reason for the deferral.

Closes #48