### PR TITLE
refactor(ingestion): replace data clump with PendingIngestion model

### DIFF
--- a/api/src/api/routes/ingest.py
+++ b/api/src/api/routes/ingest.py
@@ -21,6 +21,7 @@ from core.config.settings import settings
 from core.database.connection import db_session
 from core.database.schema import Document
 from core.types.document import DocumentStatusResponse, DocumentType
+from ingestion.models import PendingIngestion
 from ingestion.tasks import schedule_ingestion
 
 router = APIRouter(tags=["ingestion"])
@@ -91,10 +92,13 @@ async def ingest_document(
 
     schedule_ingestion(
         background_tasks,
-        document_id=document_id,
-        document_type=document_type,
-        source_filename=source_filename,
-        file_bytes=file_bytes,
+        pending=PendingIngestion(
+            document_id=document_id,
+            title=title,
+            document_type=document_type,
+            source_filename=source_filename,
+            file_bytes=file_bytes,
+        ),
         embedder=embedder,
         model_name=settings.embedding_model,
     )

--- a/ingestion/src/ingestion/models.py
+++ b/ingestion/src/ingestion/models.py
@@ -1,0 +1,23 @@
+"""Pydantic models for the ingestion package."""
+
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from core.types.document import DocumentType
+
+
+class PendingIngestion(BaseModel):
+    """Document-identity fields grouped for the ingestion pipeline.
+
+    This model replaces individual parameters threaded through
+    ``run_ingestion()``, ``schedule_ingestion()``, and
+    ``_execute_ingestion_task()``. Carries the fields needed to identify
+    and process a single document upload.
+    """
+
+    document_id: UUID
+    title: str
+    document_type: DocumentType
+    source_filename: str
+    file_bytes: bytes

--- a/ingestion/src/ingestion/pipeline.py
+++ b/ingestion/src/ingestion/pipeline.py
@@ -1,7 +1,6 @@
 """Background ingestion pipeline for uploaded documents."""
 
 from collections.abc import Sequence
-from uuid import UUID
 
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
@@ -12,6 +11,7 @@ from core.database.schema import Document, Embedding
 from core.exceptions import IngestionError
 from core.types.chunk import Chunk
 from core.types.document import DocumentStatus, DocumentType
+from ingestion.models import PendingIngestion
 from retrieval_qa.chunking import chunker_registry, get_chunker_class
 
 
@@ -90,11 +90,7 @@ def _embed_chunks(
 
 
 def run_ingestion(
-    document_id: UUID,
-    title: str,
-    document_type: DocumentType,
-    source_filename: str,
-    file_bytes: bytes,
+    pending: PendingIngestion,
     session: Session,
     embeddings_client: Embedder,
     model_name: str,
@@ -107,33 +103,27 @@ def run_ingestion(
     and the caller should roll back.
 
     Args:
-        document_id: UUID of the document row created at upload time.
-        title: Document title supplied by the user.
-        document_type: Document type (e.g. ``DocumentType.PAPER``).
-        source_filename: Original upload filename.
-        file_bytes: Raw uploaded file contents.
+        pending: Document-identity fields for the ingestion.
         session: SQLAlchemy session bound to the documents database.
         embeddings_client: Provider that produces one vector per chunk text.
         model_name: Model name to store alongside each embedding row.
     """
-    _ = title, source_filename  # retained for future metadata use; not needed now
-
-    document = session.get(Document, document_id)
+    document = session.get(Document, pending.document_id)
     if document is None:
-        raise IngestionError(f"Document {document_id} not found")
+        raise IngestionError(f"Document {pending.document_id} not found")
 
     try:
         # validating phase: ensure the file is parseable for the document type.
-        chunk_inputs = _chunk_document(document_type, file_bytes)
+        chunk_inputs = _chunk_document(pending.document_type, pending.file_bytes)
 
         document.status = DocumentStatus.CHUNKING
         session.flush()
 
         db_chunks: list[ChunkRow] = []
         for position, (content, type_metadata, token_count) in enumerate(chunk_inputs):
-            _validate_type_metadata(document_type, type_metadata)
+            _validate_type_metadata(pending.document_type, type_metadata)
             chunk = ChunkRow(
-                document_id=document_id,
+                document_id=pending.document_id,
                 position=position,
                 content=content,
                 token_count=token_count,

--- a/ingestion/src/ingestion/tasks.py
+++ b/ingestion/src/ingestion/tasks.py
@@ -5,23 +5,19 @@ This module is the only place that couples the pipeline to the task runner;
 ``ingestion/pipeline.py`` remains a plain function.
 """
 
-from uuid import UUID
-
 from fastapi import BackgroundTasks
 
 from core.clients import Embedder
 from core.database.connection import SessionLocal
 from core.database.schema import Document
 from core.exceptions import IngestionError
-from core.types.document import DocumentStatus, DocumentType
+from core.types.document import DocumentStatus
+from ingestion.models import PendingIngestion
 from ingestion.pipeline import run_ingestion
 
 
 def _execute_ingestion_task(
-    document_id: UUID,
-    document_type: DocumentType,
-    source_filename: str,
-    file_bytes: bytes,
+    pending: PendingIngestion,
     embedder: Embedder,
     model_name: str,
 ) -> None:
@@ -33,16 +29,13 @@ def _execute_ingestion_task(
     session = SessionLocal()
     try:
         title = ""
-        document = session.get(Document, document_id)
+        document = session.get(Document, pending.document_id)
         if document is not None:
             title = document.title
 
+        resolved = pending.model_copy(update={"title": title})
         run_ingestion(
-            document_id=document_id,
-            title=title,
-            document_type=document_type,
-            source_filename=source_filename,
-            file_bytes=file_bytes,
+            pending=resolved,
             session=session,
             embeddings_client=embedder,
             model_name=model_name,
@@ -58,7 +51,7 @@ def _execute_ingestion_task(
         # reason is retained after the main transaction rolls back.
         try:
             failure_session = SessionLocal()
-            failure_document = failure_session.get(Document, document_id)
+            failure_document = failure_session.get(Document, pending.document_id)
             if failure_document is not None:
                 failure_document.status = DocumentStatus.FAILED
                 failure_document.error_message = error_message
@@ -71,10 +64,7 @@ def _execute_ingestion_task(
 
 def schedule_ingestion(
     background_tasks: BackgroundTasks,
-    document_id: UUID,
-    document_type: DocumentType,
-    source_filename: str,
-    file_bytes: bytes,
+    pending: PendingIngestion,
     embedder: Embedder,
     model_name: str,
 ) -> None:
@@ -82,19 +72,13 @@ def schedule_ingestion(
 
     Args:
         background_tasks: FastAPI's background task container.
-        document_id: UUID of the newly created document row.
-        document_type: Document type (e.g. ``DocumentType.PAPER``).
-        source_filename: Original upload filename.
-        file_bytes: Raw uploaded file contents.
+        pending: Document-identity fields for the ingestion.
         embedder: Provider used to embed chunk contents.
         model_name: Model name to store alongside each embedding row.
     """
     background_tasks.add_task(
         _execute_ingestion_task,
-        document_id,
-        document_type,
-        source_filename,
-        file_bytes,
+        pending,
         embedder,
         model_name,
     )

--- a/ingestion/tests/ingestion/test_pipeline.py
+++ b/ingestion/tests/ingestion/test_pipeline.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 from core.database.schema import Chunk, Document, Embedding
 from core.exceptions import IngestionError
 from core.types.document import DocumentStatus, DocumentType
+from ingestion.models import PendingIngestion
 from ingestion.pipeline import _validate_type_metadata, run_ingestion
 
 
@@ -38,11 +39,13 @@ def test_pipeline_happy_path_reaches_ready(
     test_session.flush()
 
     run_ingestion(
-        document_id=document.document_id,
-        title="Sample Paper",
-        document_type=DocumentType.PAPER,
-        source_filename="sample.pdf",
-        file_bytes=sample_paper_pdf,
+        pending=PendingIngestion(
+            document_id=document.document_id,
+            title="Sample Paper",
+            document_type=DocumentType.PAPER,
+            source_filename="sample.pdf",
+            file_bytes=sample_paper_pdf,
+        ),
         session=test_session,
         embeddings_client=fake_embeddings_client,
         model_name="text-embedding-3-small",
@@ -89,11 +92,13 @@ def test_pipeline_failure_marks_failed_with_error(
 
     with pytest.raises(IngestionError):
         run_ingestion(
-            document_id=document.document_id,
-            title="Failing Paper",
-            document_type=DocumentType.PAPER,
-            source_filename="fail.pdf",
-            file_bytes=sample_paper_pdf,
+            pending=PendingIngestion(
+                document_id=document.document_id,
+                title="Failing Paper",
+                document_type=DocumentType.PAPER,
+                source_filename="fail.pdf",
+                file_bytes=sample_paper_pdf,
+            ),
             session=test_session,
             embeddings_client=failing_client,
             model_name="text-embedding-3-small",
@@ -121,11 +126,13 @@ def test_pipeline_book_happy_path_reaches_ready(
     test_session.flush()
 
     run_ingestion(
-        document_id=document.document_id,
-        title="Sample Book",
-        document_type=DocumentType.BOOK,
-        source_filename="sample.pdf",
-        file_bytes=sample_book_pdf,
+        pending=PendingIngestion(
+            document_id=document.document_id,
+            title="Sample Book",
+            document_type=DocumentType.BOOK,
+            source_filename="sample.pdf",
+            file_bytes=sample_book_pdf,
+        ),
         session=test_session,
         embeddings_client=fake_embeddings_client,
         model_name="text-embedding-3-small",
@@ -167,11 +174,13 @@ def test_pipeline_documentation_happy_path_reaches_ready(
     test_session.flush()
 
     run_ingestion(
-        document_id=document.document_id,
-        title="Sample Docs",
-        document_type=DocumentType.DOCUMENTATION,
-        source_filename="docs.md",
-        file_bytes=sample_documentation_md,
+        pending=PendingIngestion(
+            document_id=document.document_id,
+            title="Sample Docs",
+            document_type=DocumentType.DOCUMENTATION,
+            source_filename="docs.md",
+            file_bytes=sample_documentation_md,
+        ),
         session=test_session,
         embeddings_client=fake_embeddings_client,
         model_name="text-embedding-3-small",
@@ -209,11 +218,13 @@ def test_reingestion_creates_new_document_id(
     test_session.add(first)
     test_session.flush()
     run_ingestion(
-        document_id=first.document_id,
-        title="Paper",
-        document_type=DocumentType.PAPER,
-        source_filename="sample.pdf",
-        file_bytes=sample_paper_pdf,
+        pending=PendingIngestion(
+            document_id=first.document_id,
+            title="Paper",
+            document_type=DocumentType.PAPER,
+            source_filename="sample.pdf",
+            file_bytes=sample_paper_pdf,
+        ),
         session=test_session,
         embeddings_client=fake_embeddings_client,
         model_name="text-embedding-3-small",
@@ -232,11 +243,13 @@ def test_reingestion_creates_new_document_id(
     test_session.add(second)
     test_session.flush()
     run_ingestion(
-        document_id=second.document_id,
-        title="Paper",
-        document_type=DocumentType.PAPER,
-        source_filename="sample.pdf",
-        file_bytes=sample_paper_pdf,
+        pending=PendingIngestion(
+            document_id=second.document_id,
+            title="Paper",
+            document_type=DocumentType.PAPER,
+            source_filename="sample.pdf",
+            file_bytes=sample_paper_pdf,
+        ),
         session=test_session,
         embeddings_client=fake_embeddings_client,
         model_name="text-embedding-3-small",
@@ -338,11 +351,13 @@ class TestPipelineValidation:
             ]
             with pytest.raises(IngestionError):
                 run_ingestion(
-                    document_id=document.document_id,
-                    title="Bad Book",
-                    document_type=DocumentType.BOOK,
-                    source_filename="bad.pdf",
-                    file_bytes=b"irrelevant",
+                    pending=PendingIngestion(
+                        document_id=document.document_id,
+                        title="Bad Book",
+                        document_type=DocumentType.BOOK,
+                        source_filename="bad.pdf",
+                        file_bytes=b"irrelevant",
+                    ),
                     session=test_session,
                     embeddings_client=fake_embeddings_client,
                     model_name="text-embedding-3-small",
@@ -372,11 +387,13 @@ class TestPipelineValidation:
             ]
             with pytest.raises(IngestionError):
                 run_ingestion(
-                    document_id=document.document_id,
-                    title="Bad Paper",
-                    document_type=DocumentType.PAPER,
-                    source_filename="bad.pdf",
-                    file_bytes=b"irrelevant",
+                    pending=PendingIngestion(
+                        document_id=document.document_id,
+                        title="Bad Paper",
+                        document_type=DocumentType.PAPER,
+                        source_filename="bad.pdf",
+                        file_bytes=b"irrelevant",
+                    ),
                     session=test_session,
                     embeddings_client=fake_embeddings_client,
                     model_name="text-embedding-3-small",
@@ -401,11 +418,13 @@ class TestPipelineValidation:
         test_session.flush()
 
         run_ingestion(
-            document_id=document.document_id,
-            title="Sample Book",
-            document_type=DocumentType.BOOK,
-            source_filename="sample.pdf",
-            file_bytes=sample_book_pdf,
+            pending=PendingIngestion(
+                document_id=document.document_id,
+                title="Sample Book",
+                document_type=DocumentType.BOOK,
+                source_filename="sample.pdf",
+                file_bytes=sample_book_pdf,
+            ),
             session=test_session,
             embeddings_client=fake_embeddings_client,
             model_name="text-embedding-3-small",

--- a/ingestion/tests/ingestion/test_tasks.py
+++ b/ingestion/tests/ingestion/test_tasks.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 from core.clients import InMemoryEmbedder
 from core.types.document import DocumentType
+from ingestion.models import PendingIngestion
 from ingestion.tasks import schedule_ingestion
 
 
@@ -15,12 +16,17 @@ def test_schedule_ingestion_adds_background_task() -> None:
     embedder = InMemoryEmbedder()
     model_name = "text-embedding-3-small"
 
-    schedule_ingestion(
-        background_tasks=mock_bg,
+    pending = PendingIngestion(
         document_id=doc_id,
+        title="Test Document",
         document_type=DocumentType.PAPER,
         source_filename="test.pdf",
         file_bytes=b"fake-pdf-bytes",
+    )
+
+    schedule_ingestion(
+        background_tasks=mock_bg,
+        pending=pending,
         embedder=embedder,
         model_name=model_name,
     )
@@ -29,13 +35,11 @@ def test_schedule_ingestion_adds_background_task() -> None:
     args = mock_bg.add_task.call_args
     # First positional arg is the callable
     assert callable(args[0][0])
-    # Remaining positional args match the arguments passed through
-    assert args[0][1] == doc_id
-    assert args[0][2] == DocumentType.PAPER
-    assert args[0][3] == "test.pdf"
-    assert args[0][4] == b"fake-pdf-bytes"
-    assert args[0][5] is embedder
-    assert args[0][6] == model_name
+    # Second positional arg is the PendingIngestion model
+    assert args[0][1] is pending
+    # Remaining positional args match infrastructure args
+    assert args[0][2] is embedder
+    assert args[0][3] == model_name
 
 
 def test_schedule_ingestion_is_public_api() -> None:


### PR DESCRIPTION
Introduce a PendingIngestion Pydantic v2 model to group the five document-identity fields (document_id, title, document_type, source_filename, file_bytes) that were threaded individually through run_ingestion(), schedule_ingestion(), and _execute_ingestion_task().

- New file ingestion/src/ingestion/models.py with PendingIngestion
- run_ingestion() accepts pending: PendingIngestion as first param
- schedule_ingestion() and _execute_ingestion_task() use the model
- Remove dead _ = title, source_filename line from run_ingestion()
- Update all call sites including API route and tests

Closes: #49