### PR TITLE
refactor(api): consolidate repeated monkeypatch.setattr for retrieve_…

### DIFF
--- a/api/tests/api/controllers/test_qa_controller.py
+++ b/api/tests/api/controllers/test_qa_controller.py
@@ -1,5 +1,6 @@
 """Unit tests for the QA controller (clients + retrieval mocked)."""
 
+from collections.abc import Callable, Sequence
 from typing import cast
 from unittest.mock import MagicMock
 from uuid import uuid4
@@ -36,18 +37,17 @@ def _vector(value: float = 0.5) -> list[float]:
     return [value] * 1536
 
 
-def test_run_query_grounds_when_retrieval_returns_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_query_grounds_when_retrieval_returns_chunks(
+    patched_retrieve_chunks: Callable[[Sequence[object]], None],
+) -> None:
     """Relevant chunks yield grounded=True with cited_passages populated."""
     retrieved_chunks = [
         CitedPassage(chunk_id=uuid4(), text="pgvector supports HNSW indexes."),
         CitedPassage(chunk_id=uuid4(), text="Cosine distance uses the <=> operator."),
     ]
+    patched_retrieve_chunks(retrieved_chunks)
 
     fake_session = MagicMock()
-    monkeypatch.setattr(
-        "api.controllers.qa_controller.retrieve_relevant_chunks",
-        lambda **kwargs: retrieved_chunks,
-    )
 
     response = run_query(
         query="How does pgvector rank chunks?",
@@ -66,12 +66,8 @@ def test_run_query_grounds_when_retrieval_returns_chunks(monkeypatch: pytest.Mon
     assert response.answer == "Cosine distance via <=> against an HNSW index."
 
 
-def test_run_query_not_grounded_when_retrieval_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_query_not_grounded_when_retrieval_empty(patched_empty_retrieval: None) -> None:
     """An empty retrieval result yields grounded=False with empty passages and a refusal answer."""
-    monkeypatch.setattr(
-        "api.controllers.qa_controller.retrieve_relevant_chunks",
-        lambda **kwargs: [],
-    )
 
     response = run_query(
         query="an irrelevant question",
@@ -86,12 +82,8 @@ def test_run_query_not_grounded_when_retrieval_empty(monkeypatch: pytest.MonkeyP
     assert response.answer == "I couldn't find anything relevant in the corpus."
 
 
-def test_run_query_answer_field_always_populated(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_query_answer_field_always_populated(patched_empty_retrieval: None) -> None:
     """The answer field is non-empty on both grounded and not-grounded branches."""
-    monkeypatch.setattr(
-        "api.controllers.qa_controller.retrieve_relevant_chunks",
-        lambda **kwargs: [],
-    )
 
     response = run_query(
         query="another irrelevant question",
@@ -136,13 +128,9 @@ def test_run_query_embeds_query_before_retrieval(monkeypatch: pytest.MonkeyPatch
 
 
 def test_run_query_propagates_upstream_unavailable_from_embeddings(
-    monkeypatch: pytest.MonkeyPatch,
+    patched_empty_retrieval: None,
 ) -> None:
     """Embeddings client unreachable surfaces UpstreamUnavailable for the route to map to 503."""
-    monkeypatch.setattr(
-        "api.controllers.qa_controller.retrieve_relevant_chunks",
-        lambda **kwargs: [],
-    )
 
     with pytest.raises(UpstreamUnavailable):
         run_query(
@@ -158,13 +146,9 @@ def test_run_query_propagates_upstream_unavailable_from_embeddings(
 
 
 def test_run_query_propagates_upstream_bad_response_from_embeddings(
-    monkeypatch: pytest.MonkeyPatch,
+    patched_empty_retrieval: None,
 ) -> None:
     """Embeddings bad response surfaces UpstreamBadResponse for the route to map to 502."""
-    monkeypatch.setattr(
-        "api.controllers.qa_controller.retrieve_relevant_chunks",
-        lambda **kwargs: [],
-    )
 
     with pytest.raises(UpstreamBadResponse):
         run_query(
@@ -180,13 +164,10 @@ def test_run_query_propagates_upstream_bad_response_from_embeddings(
 
 
 def test_run_query_propagates_upstream_unavailable_from_inference(
-    monkeypatch: pytest.MonkeyPatch,
+    patched_retrieve_chunks: Callable[[Sequence[object]], None],
 ) -> None:
     """Inference client unreachable surfaces UpstreamUnavailable for the route to map to 503."""
-    monkeypatch.setattr(
-        "api.controllers.qa_controller.retrieve_relevant_chunks",
-        lambda **kwargs: [MagicMock(chunk_id=uuid4(), text="chunk text")],
-    )
+    patched_retrieve_chunks([MagicMock(chunk_id=uuid4(), text="chunk text")])
 
     with pytest.raises(UpstreamUnavailable):
         run_query(
@@ -202,13 +183,10 @@ def test_run_query_propagates_upstream_unavailable_from_inference(
 
 
 def test_run_query_propagates_upstream_bad_response_from_inference(
-    monkeypatch: pytest.MonkeyPatch,
+    patched_retrieve_chunks: Callable[[Sequence[object]], None],
 ) -> None:
     """Inference bad response surfaces UpstreamBadResponse for the route to map to 502."""
-    monkeypatch.setattr(
-        "api.controllers.qa_controller.retrieve_relevant_chunks",
-        lambda **kwargs: [MagicMock(chunk_id=uuid4(), text="chunk text")],
-    )
+    patched_retrieve_chunks([MagicMock(chunk_id=uuid4(), text="chunk text")])
 
     with pytest.raises(UpstreamBadResponse):
         run_query(
@@ -223,14 +201,12 @@ def test_run_query_propagates_upstream_bad_response_from_inference(
         )
 
 
-def test_run_query_passes_chunks_to_llm_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_query_passes_chunks_to_llm_prompt(
+    patched_retrieve_chunks: Callable[[Sequence[object]], None],
+) -> None:
     """The injected-context prompt embeds referenced chunk text into the user message."""
     retrieved = [CitedPassage(chunk_id=uuid4(), text="chunk A text")]
-
-    monkeypatch.setattr(
-        "api.controllers.qa_controller.retrieve_relevant_chunks",
-        lambda **kwargs: retrieved,
-    )
+    patched_retrieve_chunks(retrieved)
 
     llm_client = _fake_llm_client("answer")
     run_query(
@@ -249,13 +225,9 @@ def test_run_query_passes_chunks_to_llm_prompt(monkeypatch: pytest.MonkeyPatch) 
 
 
 def test_run_query_no_chunks_prompt_does_not_include_passage_text(
-    monkeypatch: pytest.MonkeyPatch,
+    patched_empty_retrieval: None,
 ) -> None:
     """When no chunks are retrieved the prompt asks for a refusal, without fake passages."""
-    monkeypatch.setattr(
-        "api.controllers.qa_controller.retrieve_relevant_chunks",
-        lambda **kwargs: [],
-    )
 
     llm_client = _fake_llm_client("refusal")
     run_query(

--- a/api/tests/api/test_query.py
+++ b/api/tests/api/test_query.py
@@ -11,7 +11,7 @@ Two fixture variants are used:
 """
 
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from unittest.mock import MagicMock
 
 import pytest
@@ -101,7 +101,7 @@ def test_query_embeddings_unavailable_returns_503(client: TestClient) -> None:
 
 
 def test_query_inference_bad_response_returns_502(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    client: TestClient, patched_retrieve_chunks: Callable[[Sequence[object]], None]
 ) -> None:
     """A mocked inference provider returning a bad response maps to 502."""
 
@@ -111,10 +111,7 @@ def test_query_inference_bad_response_returns_502(
         return llm
 
     set_dependency_override(client, get_completion_provider, _bad_llm)
-    monkeypatch.setattr(
-        "api.controllers.qa_controller.retrieve_relevant_chunks",
-        lambda **kwargs: [_fake_chunk(text="some chunk")],
-    )
+    patched_retrieve_chunks([_fake_chunk(text="some chunk")])
 
     response = client.post("/query", json={"query": "anything"})
 
@@ -125,7 +122,7 @@ def test_query_inference_bad_response_returns_502(
 
 
 def test_query_inference_unavailable_returns_503(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    client: TestClient, patched_retrieve_chunks: Callable[[Sequence[object]], None]
 ) -> None:
     """A mocked inference provider that's unreachable/timeout maps to 503."""
 
@@ -135,10 +132,7 @@ def test_query_inference_unavailable_returns_503(
         return llm
 
     set_dependency_override(client, get_completion_provider, _unavailable_llm)
-    monkeypatch.setattr(
-        "api.controllers.qa_controller.retrieve_relevant_chunks",
-        lambda **kwargs: [_fake_chunk(text="some chunk")],
-    )
+    patched_retrieve_chunks([_fake_chunk(text="some chunk")])
 
     response = client.post("/query", json={"query": "anything"})
 
@@ -154,14 +148,10 @@ def test_query_inference_unavailable_returns_503(
 
 
 def test_query_empty_corpus_returns_not_grounded(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    client: TestClient, patched_empty_retrieval: None
 ) -> None:
     """An empty retrieval result yields 200 grounded=false with empty passages."""
     set_dependency_override(client, get_completion_provider, _default_fake_llm_refusal_provider)
-    monkeypatch.setattr(
-        "api.controllers.qa_controller.retrieve_relevant_chunks",
-        lambda **kwargs: [],
-    )
 
     response = client.post("/query", json={"query": "What is pgvector?"})
 
@@ -174,14 +164,10 @@ def test_query_empty_corpus_returns_not_grounded(
 
 
 def test_query_response_has_exactly_three_fields(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    client: TestClient, patched_empty_retrieval: None
 ) -> None:
     """The 200 body exposes only answer, cited_passages, grounded (per ADR-0014)."""
     set_dependency_override(client, get_completion_provider, _default_fake_llm_refusal_provider)
-    monkeypatch.setattr(
-        "api.controllers.qa_controller.retrieve_relevant_chunks",
-        lambda **kwargs: [],
-    )
 
     response = client.post("/query", json={"query": "anything"})
 
@@ -190,15 +176,12 @@ def test_query_response_has_exactly_three_fields(
 
 
 def test_query_grounds_with_mocked_retrieval(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    client: TestClient, patched_retrieve_chunks: Callable[[Sequence[object]], None]
 ) -> None:
     """The route glue produces grounded=True and cited_passages from the retrieved chunks."""
     set_dependency_override(client, get_completion_provider, _default_fake_llm_provider)
     chunk = _fake_chunk(text="relevant passage text")
-    monkeypatch.setattr(
-        "api.controllers.qa_controller.retrieve_relevant_chunks",
-        lambda **kwargs: [chunk],
-    )
+    patched_retrieve_chunks([chunk])
 
     response = client.post("/query", json={"query": "Tell me about retrieval strategies."})
 
@@ -242,16 +225,12 @@ def test_query_end_to_end_grounds_with_real_chunks(
 def test_query_end_to_end_irrelevant_returns_not_grounded(
     client: TestClient,
     ingest_a_paper: Callable[[str], str],
-    monkeypatch: pytest.MonkeyPatch,
+    patched_empty_retrieval: None,
 ) -> None:
     """Asking an irrelevant question yields 200 grounded=false with empty passages."""
     # Force the not-found branch even against a ready corpus by returning []
     # from retrieval; the LLM stub returns a refusal.
     set_dependency_override(client, get_completion_provider, _default_fake_llm_refusal_provider)
-    monkeypatch.setattr(
-        "api.controllers.qa_controller.retrieve_relevant_chunks",
-        lambda **kwargs: [],
-    )
     ingest_a_paper("RAG Paper")
 
     response = client.post("/query", json={"query": "What is the capital of France?"})

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,6 +1,11 @@
-"""Shared fixtures and utilities for api tests."""
+"""Shared fixtures and utilities for api tests.
 
-from collections.abc import Callable, Generator
+Test fixtures:
+* ``patched_empty_retrieval`` — patches ``retrieve_relevant_chunks`` to return ``[]``.
+* ``patched_retrieve_chunks`` — factory that patches retrieval with caller-supplied chunks.
+"""
+
+from collections.abc import Callable, Generator, Sequence
 from contextlib import contextmanager
 from typing import Any, cast
 from unittest.mock import MagicMock
@@ -29,6 +34,36 @@ def _default_fake_llm_provider() -> MockCompletionProvider:
 def _default_fake_llm_refusal_provider() -> MockCompletionProvider:
     """A mocked completion provider returning a fixed refusal answer."""
     return MockCompletionProvider("I could not find anything relevant in the corpus.")
+
+
+@pytest.fixture
+def patched_empty_retrieval(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch ``retrieve_relevant_chunks`` to return an empty list (not-grounded)."""
+    monkeypatch.setattr(
+        "api.controllers.qa_controller.retrieve_relevant_chunks",
+        lambda **kwargs: [],
+    )
+
+
+@pytest.fixture
+def patched_retrieve_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[Sequence[object]], None]:
+    """Return a factory that patches retrieval with the given chunks.
+
+    Usage in a test::
+
+        def test_foo(patched_retrieve_chunks: ...) -> None:
+            patched_retrieve_chunks([CitedPassage(chunk_id=uuid4(), text="...")])
+    """
+
+    def _factory(chunks: Sequence[object]) -> None:
+        monkeypatch.setattr(
+            "api.controllers.qa_controller.retrieve_relevant_chunks",
+            lambda **kwargs: chunks,
+        )
+
+    return _factory
 
 
 def set_dependency_override(client: TestClient, dependency: Any, override: Any) -> None:


### PR DESCRIPTION
…relevant_chunks in query tests

Create two reusable pytest fixtures in api/tests/conftest.py:
- patched_empty_retrieval — patches retrieval to return []
- patched_retrieve_chunks — factory that patches retrieval with caller-supplied chunks

Updates 15 of 16 call sites across test_query.py and test_qa_controller.py to use the new fixtures. The remaining site (test_run_query_embeds_query_before_retrieval) needs a custom capture function and is kept as-is.

Closes #56