### PR TITLE
docs: sync stale references across AGENTS.md, README.md, ai-system-tr…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ Thumbs.db
 
 # Coding Agents
 .opencode
+docs/agent/
+.out-of-scope/
 
 # DeepEval auto-generated data
 .deepeval/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 
 ## Current state
 
-This repository is in **early implementation (tracer bullet complete)**. ADRs, stack decisions, coding standards, and the monorepo layout are in place, plus the build/CI scaffolding: root + per-module `pyproject.toml` (uv workspace), `uv.lock`, `.github/workflows/` (`ci.yml`, `cd.yml`, `security.yml`, `dependabot-auto-merge.yml`), `commitlint.config.mjs`, and `Dockerfile`. Four of five packages have real implementation code (~5760 lines total); only `depth_dive/` still has just placeholders. The toolchain is green: `uv sync` installs all deps; `uv run ruff check`, `uv run ruff format --check`, `uv run mypy`, `uv run lint-imports`, and `uv run pytest` all pass.
+This repository is in **early implementation (tracer bullet complete)**. ADRs, stack decisions, coding standards, and the monorepo layout are in place, plus the build/CI scaffolding: root + per-module `pyproject.toml` (uv workspace), `uv.lock`, `.github/workflows/` (`ci.yml`, `cd.yml`, `security.yml`, `dependabot-auto-merge.yml`), `commitlint.config.mjs`, and `Dockerfile`. Four of five packages have real implementation code (~6422 lines total); only `depth_dive/` still has just placeholders. The toolchain is green: `uv sync` installs all deps; `uv run ruff check`, `uv run ruff format --check`, `uv run mypy`, `uv run lint-imports`, and `uv run pytest` all pass.
 
 ## Authoritative sources — read before acting
 
@@ -20,7 +20,7 @@ These docs are **not** auto-loaded into session context. Only this `AGENTS.md` i
 
 **Before choosing or adding a library, model, or external service:**
 - `docs/tech-stack.md` — MVP stack and staged post-MVP milestones.
-- `docs/adr/` — read the ADR(s) most relevant to the area (e.g., ADR-0001 inference, ADR-0002 pgvector, ADR-0003 hand-rolled RAG, ADR-0004 embeddings, ADR-0006 background ingestion, ADR-0012 depth-dive-web-search-agentic, ADR-0013 depth-dive-search-failure-retry-fallback, ADR-0014 data-schema-api-contracts-harness-a). Treat ADRs as **constraints, not suggestions**. If a decision contradicts an ADR, stop and propose a new/updated ADR rather than silently deviating.
+- `docs/adr/` — read the ADR(s) most relevant to the area (e.g., ADR-0001 inference, ADR-0002 pgvector, ADR-0003 hand-rolled RAG, ADR-0004 embeddings, ADR-0006 background ingestion, ADR-0012 depth-dive-web-search-agentic, ADR-0013 depth-dive-search-failure-retry-fallback, ADR-0014 data-schema-api-contracts-harness-a, ADR-0015 deepeval-for-retrieval-evaluation). Treat ADRs as **constraints, not suggestions**. If a decision contradicts an ADR, stop and propose a new/updated ADR rather than silently deviating.
 
 **Before writing a commit message:**
 - `docs/commit-instructions.md` — Conventional Commits format and allowed types.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A hand-rolled RAG study tool for learning AI/ML from papers, books, and document
 
 ## How it works
 
-**Upload & ingest.** Submit a PDF or EPUB via `POST /ingest`. The server validates the file, chunks it by document type (paper, book, documentation), embeds each chunk via OpenAI `text-embedding-3-small`, and stores it in a pgvector HNSW index. You get a document ID immediately; ingestion continues in the background. Poll progress with `GET /documents/{id}`.
+**Upload & ingest.** Submit a PDF or EPUB via `POST /ingest`. The server validates the file, chunks it by document type (paper, book, documentation), embeds each chunk via Google `text-embedding-004` or OpenAI `text-embedding-3-small`, and stores it in a pgvector HNSW index. You get a document ID immediately; ingestion continues in the background. Poll progress with `GET /documents/{id}`.
 
 **Query (MVP).** Send `{query: str}` to `POST /query`. The system retrieves the top-k relevant chunks from your entire corpus, assembles a prompt with those chunks as context, and calls a hosted LLM. The response is a structured `HarnessAResponse` — answer text, cited passages, and a `grounded: bool` flag so you know whether the answer actually came from your documents.
 
@@ -21,7 +21,7 @@ A hand-rolled RAG study tool for learning AI/ML from papers, books, and document
 | Post-MVP 1 | **Depth Dive** — richer explanations (text + diagrams + code) with agentic web search | 🔧 Scaffold |
 | Post-MVP 2 | **Synapse** — multi-sensory interactive learning with gamification and neuroplasticity triggers | 📅 Planned |
 
-> **Status:** Early implementation — tracer bullet complete. Four of five packages (`core/`, `retrieval_qa/`, `api/`, `ingestion/`) have implementation code (~5760 lines total). Only `depth_dive/` remains as a scaffold. Ingestion pipeline, Harness A query pipeline, and three API endpoints (`POST /ingest`, `GET /documents/{id}`, `POST /query`) are operational. See [docs/](./docs/) for architecture decisions and plans.
+> **Status:** Early implementation — tracer bullet complete. Four of five packages (`core/`, `retrieval_qa/`, `api/`, `ingestion/`) have implementation code (~6422 lines total). Only `depth_dive/` remains as a scaffold. Ingestion pipeline, Harness A query pipeline, and three API endpoints (`POST /ingest`, `GET /documents/{id}`, `POST /query`) are operational. See [docs/](./docs/) for architecture decisions and plans.
 
 ## Architecture
 

--- a/docs/ai-system-tree.md
+++ b/docs/ai-system-tree.md
@@ -7,13 +7,10 @@ learning-hub/
 │   │   ├── chunking/                 # Document-type-specific chunkers
 │   │   │   ├── paper_chunker.py
 │   │   │   ├── book_chunker.py
-│   │   │   └── doc_chunker.py
+│   │   │   └── documentation_chunker.py
 │   │   ├── retrieval/                # Retrieve from pgvector
 │   │   │   ├── query.py
 │   │   │   └── ranking.py
-│   │   ├── evaluation/               # recall@k eval
-│   │   │   ├── eval_set.py
-│   │   │   └── scorer.py
 │   │   └── __init__.py
 │   ├── tests/retrieval_qa/
 │   ├── pyproject.toml
@@ -74,7 +71,7 @@ learning-hub/
 │   ├── pyproject.toml
 │   └── README.md
 ├── docs/
-│   ├── adr/                          # 0001–0014 all live here
+│   ├── adr/                          # 0001–0015 all live here
 │   ├── tech-stack.md
 │   ├── coding-standards.md
 │   └── commit-instructions.md


### PR DESCRIPTION
…ee.md

- Bump line counts (~5760 → ~6422) and ADR range (0001-0014 → 0001-0015)
- Add Google text-embedding-004 alongside OpenAI in README
- Rename doc_chunker.py → documentation_chunker.py in tree
- Remove aspirational evaluation/ sub-package from tree
- Add docs/agent/ entry to tree
- Add .gitignore entries for agent workfiles