### PR TITLE
fix(tests): replace f-string SQL in _create_enums with SQLAlchemy ENU…

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -16,6 +16,7 @@ import pytest
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 from sqlalchemy import Engine, create_engine, text
+from sqlalchemy.dialects.postgresql import ENUM
 from sqlalchemy.orm import Session, sessionmaker
 
 # Pre-import workspace packages so their installed (src/) versions are cached
@@ -236,15 +237,8 @@ def _create_enums(engine: Engine) -> None:
     }
     with engine.connect() as conn:
         for name, values in enums.items():
-            vals = ", ".join(f"'{v}'" for v in values)
-            conn.execute(
-                text(
-                    f"DO $$ BEGIN "
-                    f"CREATE TYPE {name} AS ENUM ({vals}); "
-                    f"EXCEPTION WHEN duplicate_object THEN NULL; "
-                    f"END $$"
-                )
-            )
+            enum_type = ENUM(*values, name=name)
+            enum_type.create(bind=conn, checkfirst=True)
         conn.commit()
 
 

--- a/retrieval_qa/tests/retrieval_qa/retrieval/conftest.py
+++ b/retrieval_qa/tests/retrieval_qa/retrieval/conftest.py
@@ -20,6 +20,7 @@ from typing import Any
 import pytest
 import yaml
 from sqlalchemy import Engine, text
+from sqlalchemy.dialects.postgresql import ENUM
 from sqlalchemy.orm import Session, sessionmaker
 
 from core.config.settings import Settings
@@ -38,15 +39,8 @@ _ENUM_DEFS = {
 def _create_enums(engine: Engine) -> None:
     with engine.connect() as conn:
         for name, values in _ENUM_DEFS.items():
-            vals = ", ".join(f"'{v}'" for v in values)
-            conn.execute(
-                text(
-                    f"DO $$ BEGIN "
-                    f"CREATE TYPE {name} AS ENUM ({vals}); "
-                    f"EXCEPTION WHEN duplicate_object THEN NULL; "
-                    f"END $$"
-                )
-            )
+            enum_type = ENUM(*values, name=name)
+            enum_type.create(bind=conn, checkfirst=True)
         conn.commit()
 
 


### PR DESCRIPTION
…M DDL

Replace raw f-string interpolation in _create_enums with SQLAlchemy PostgreSQL ENUM.create() DDL. This eliminates the latent injection risk from dynamic SQL construction and aligns with the project's explicit-over-implicit philosophy.

Closes #78