### PR TITLE
feat(retrieval-eval): add embedding_model field to eval_set.yaml with…

### DIFF
--- a/retrieval_qa/tests/retrieval_qa/retrieval/conftest.py
+++ b/retrieval_qa/tests/retrieval_qa/retrieval/conftest.py
@@ -59,11 +59,17 @@ def _validate_eval_integrity(
     - Every chunk content and query string hash matches its stored hash.
     - Every YAML content hash has a corresponding entry in the vector JSON.
     - Every vector in JSON has a corresponding YAML entry (no orphans).
-    - Model metadata matches ``settings.embedding_model`` (if provided).
+    - ``data["embedding_model"]`` matches ``settings.embedding_model``.
+    - Sidecar JSON model metadata matches ``settings.embedding_model`` (if provided).
     """
     yaml_hashes: set[str] = set()
 
     expected_model = Settings().embedding_model
+    assert data["embedding_model"] == expected_model, (
+        f"YAML embedding_model '{data['embedding_model']}' does not match "
+        f"settings.embedding_model '{expected_model}'. "
+        f"Update eval_set.yaml or settings."
+    )
     if sidecar_model is not None:
         assert sidecar_model == expected_model, (
             f"Sidecar JSON model '{sidecar_model}' does not match "
@@ -151,7 +157,7 @@ def _seed_eval_set(engine: Engine, vectors: dict[str, list[float]]) -> None:
                 session.add(
                     Embedding(
                         chunk_id=chunk.chunk_id,
-                        model_name="text-embedding-3-small",
+                        model_name=data["embedding_model"],
                         embedding=embedding_vec,
                     )
                 )

--- a/retrieval_qa/tests/retrieval_qa/retrieval/eval_set.yaml
+++ b/retrieval_qa/tests/retrieval_qa/retrieval/eval_set.yaml
@@ -1,3 +1,4 @@
+embedding_model: text-embedding-3-small
 documents:
 - title: RAG Architecture Guide
   document_type: documentation

--- a/retrieval_qa/tests/retrieval_qa/retrieval/test_eval.py
+++ b/retrieval_qa/tests/retrieval_qa/retrieval/test_eval.py
@@ -56,6 +56,7 @@ def _load_eval_data() -> dict[str, Any]:
 
 
 _EVAL_DATA = _load_eval_data()
+_EVAL_EMBEDDING_MODEL: str = _EVAL_DATA["embedding_model"]
 _EVAL_QUERIES: list[EvalQuery] = [EvalQuery.model_validate(q) for q in _EVAL_DATA["queries"]]
 
 
@@ -118,7 +119,7 @@ def test_recall_at_k_retrieves_expected_passages(
         query_vector=query_vector,
         session=eval_session,
         config=RetrievalConfig(
-            model_name="text-embedding-3-small",
+            model_name=_EVAL_EMBEDDING_MODEL,
             ef_search=Settings().hnsw_ef_search,
             top_k=top_k,
         ),

--- a/scripts/generate_eval_vectors.py
+++ b/scripts/generate_eval_vectors.py
@@ -6,10 +6,10 @@ Usage:
     uv run python scripts/generate_eval_vectors.py
 
 Reads ``retrieval_qa/tests/retrieval_qa/retrieval/eval_set.yaml``,
-calls the OpenAI embedding API (``text-embedding-3-small``) for **all** entries
-every run, writes the sidecar ``eval_vectors.json`` (keyed by SHA-256 hash)
-**and** updates ``content_sha256`` in the YAML so both files form a consistent
-snapshot.
+calls the configured embedding API (``Settings().embedding_model``) for **all**
+entries every run, writes the sidecar ``eval_vectors.json`` (keyed by SHA-256
+hash) **and** updates ``content_sha256`` in the YAML so both files form a
+consistent snapshot.
 
 Edit content in the YAML, run this script, and both files are in sync —
 no manual hash updates needed.
@@ -17,6 +17,7 @@ no manual hash updates needed.
 
 import hashlib
 import json
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any
 
@@ -53,6 +54,23 @@ def main() -> None:
 
     with open(EVAL_SET_PATH) as f:
         data = yaml.safe_load(f)
+
+    # Warn if YAML declares a different model than settings.
+    existing_model = data.get("embedding_model")
+    if existing_model is not None and existing_model != model_name:
+        print(
+            f"Warning: eval_set.yaml declares embedding_model={existing_model!r}, "
+            f"but Settings().embedding_model={model_name!r}. "
+            f"Overwriting YAML with {model_name!r}."
+        )
+
+    # Ensure embedding_model is the first key and matches settings.
+    ordered: OrderedDict[str, Any] = OrderedDict()
+    ordered["embedding_model"] = model_name
+    for k, v in data.items():
+        if k != "embedding_model":
+            ordered[k] = v
+    data = ordered
 
     _rewrite_content_hashes(data)
 


### PR DESCRIPTION
… cross-validation

- Add top-level embedding_model declaration to eval_set.yaml
- Validate YAML model against settings.embedding_model at load time
- Read model name from YAML in seed and query paths (not hardcoded)
- Update generate_eval_vectors.py to write/validate embedding_model in YAML

Closes #79