### PR TITLE
refactor(retrieval-qa): extract duplicated _count_tokens into shared …

### DIFF
--- a/retrieval_qa/src/retrieval_qa/_utils.py
+++ b/retrieval_qa/src/retrieval_qa/_utils.py
@@ -1,0 +1,11 @@
+"""Internal shared utilities for the retrieval_qa package."""
+
+
+def count_tokens(text: str) -> int:
+    """Approximate token count for chunk sizing.
+
+    Uses a simple whitespace split; this is sufficient for MVP chunk ordering
+    and sanity checks. More precise counting can be swapped in later without
+    changing the chunker interface.
+    """
+    return max(1, len(text.split()))

--- a/retrieval_qa/src/retrieval_qa/chunking/book_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/book_chunker.py
@@ -19,6 +19,7 @@ from pypdf import PdfReader
 from core.exceptions import IngestionError
 from core.types.chunk import BookChunkMetadata, Chunk
 from core.types.document import DocumentType
+from retrieval_qa._utils import count_tokens
 from retrieval_qa.chunking.base import DocumentChunker, register_chunker
 
 
@@ -146,16 +147,6 @@ class _SectionExtractor(HTMLParser):
         """Return the list of ``(level, heading, body)`` tuples extracted."""
         self._flush_body_section()
         return self.sections
-
-
-def _count_tokens(text: str) -> int:
-    """Approximate token count for chunk sizing.
-
-    Uses a simple whitespace split; this is sufficient for MVP chunk ordering
-    and sanity checks. More precise counting can be swapped in later without
-    changing the chunker interface.
-    """
-    return max(1, len(text.split()))
 
 
 def _looks_like_heading(line: str) -> bool:
@@ -427,7 +418,7 @@ def chunk_book(file_bytes: bytes) -> list[BookChunk]:
             BookChunk(
                 content=body,
                 metadata=metadata,
-                token_count=_count_tokens(body),
+                token_count=count_tokens(body),
             )
         )
 
@@ -439,7 +430,7 @@ def chunk_book(file_bytes: bytes) -> list[BookChunk]:
             BookChunk(
                 content=full_text,
                 metadata=BookChunkMetadata(chapter=1, heading=None),
-                token_count=_count_tokens(full_text),
+                token_count=count_tokens(full_text),
             )
         )
 

--- a/retrieval_qa/src/retrieval_qa/chunking/documentation_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/documentation_chunker.py
@@ -20,6 +20,7 @@ from pypdf import PdfReader
 from core.exceptions import IngestionError
 from core.types.chunk import Chunk, DocumentationChunkMetadata
 from core.types.document import DocumentType
+from retrieval_qa._utils import count_tokens
 from retrieval_qa.chunking.base import DocumentChunker, register_chunker
 
 
@@ -85,16 +86,6 @@ class _HTMLTextExtractor(HTMLParser):
     def get_text(self) -> str:
         text = "".join(self._parts)
         return re.sub(r"\n\s*\n+", "\n\n", text).strip()
-
-
-def _count_tokens(text: str) -> int:
-    """Approximate token count for chunk sizing.
-
-    Uses a simple whitespace split; this is sufficient for MVP chunk ordering
-    and sanity checks. More precise counting can be swapped in later without
-    changing the chunker interface.
-    """
-    return max(1, len(text.split()))
 
 
 def _detect_format(file_bytes: bytes) -> DocumentationFormat:
@@ -242,7 +233,7 @@ def chunk_documentation(file_bytes: bytes) -> list[DocumentationChunk]:
             DocumentationChunk(
                 content=body,
                 metadata=metadata,
-                token_count=_count_tokens(body),
+                token_count=count_tokens(body),
             )
         )
 
@@ -253,7 +244,7 @@ def chunk_documentation(file_bytes: bytes) -> list[DocumentationChunk]:
             DocumentationChunk(
                 content=raw_text.strip(),
                 metadata=DocumentationChunkMetadata(page="Document", section=None),
-                token_count=_count_tokens(raw_text),
+                token_count=count_tokens(raw_text),
             )
         )
 

--- a/retrieval_qa/src/retrieval_qa/chunking/paper_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/paper_chunker.py
@@ -14,6 +14,7 @@ from pypdf import PdfReader
 from core.exceptions import IngestionError
 from core.types.chunk import Chunk, PaperChunkMetadata
 from core.types.document import DocumentType
+from retrieval_qa._utils import count_tokens
 from retrieval_qa.chunking.base import DocumentChunker, register_chunker
 
 # Matches lines that look like paper section headers, e.g.:
@@ -33,16 +34,6 @@ class PaperChunk(Chunk):
     model_config = ConfigDict(extra="forbid")
 
     metadata: PaperChunkMetadata
-
-
-def _count_tokens(text: str) -> int:
-    """Approximate token count for chunk sizing.
-
-    Uses a simple whitespace split; this is sufficient for MVP chunk ordering
-    and sanity checks. More precise counting can be swapped in later without
-    changing the chunker interface.
-    """
-    return max(1, len(text.split()))
 
 
 def _split_into_sections(text: str) -> list[tuple[str, str | None, str]]:
@@ -121,7 +112,7 @@ def chunk_paper(pdf_bytes: bytes) -> list[PaperChunk]:
                 PaperChunk(
                     content=body,
                     metadata=metadata,
-                    token_count=_count_tokens(body),
+                    token_count=count_tokens(body),
                 )
             )
 
@@ -139,7 +130,7 @@ def chunk_paper(pdf_bytes: bytes) -> list[PaperChunk]:
                     subsection=None,
                     page=1,
                 ),
-                token_count=_count_tokens(full_text),
+                token_count=count_tokens(full_text),
             )
         )
 


### PR DESCRIPTION
…_utils module

Remove byte-identical _count_tokens definitions from all three chunkers (book_chunker.py, documentation_chunker.py, paper_chunker.py) and replace with a single count_tokens function in retrieval_qa._utils imported by each chunker.

Closes #85