### PR TITLE
refactor(retrieval-qa): extract duplicated _HTMLTextExtractor into sh…

### DIFF
--- a/retrieval_qa/src/retrieval_qa/chunking/_html_utils.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/_html_utils.py
@@ -1,0 +1,53 @@
+"""Shared HTML utilities for chunkers.
+
+Provides ``_BaseHTMLTextExtractor``, a foundation for HTML tag-stripping
+with structural newlines.  Chunkers extend or compose from it for their
+specific heading-awareness behaviour.
+"""
+
+import re
+from html.parser import HTMLParser
+
+
+class _BaseHTMLTextExtractor(HTMLParser):
+    """Strip HTML tags while preserving structural newlines.
+
+    Skips content inside ``<script>`` and ``<style>`` elements.  Inserts a
+    single ``\\n`` for block-level structural tags (``<p>``, ``<div>``,
+    ``<li>``, ``<br>``) and heading tags (``<h1>``--``<h4>``) so the
+    remaining text retains basic paragraph / list structure.
+    """
+
+    _SKIP_TAGS = frozenset({"script", "style"})
+    _UNSKIP_TAGS = frozenset({"script", "style"})
+    _STRUCTURAL_START_TAGS = frozenset({"p", "div", "li", "br", "h1", "h2", "h3", "h4"})
+    _STRUCTURAL_END_TAGS = frozenset({"p", "div", "li", "h1", "h2", "h3", "h4"})
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._parts: list[str] = []
+        self._skip = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in self._SKIP_TAGS:
+            self._skip = True
+        elif tag in self._STRUCTURAL_START_TAGS:
+            self._parts.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in self._UNSKIP_TAGS:
+            self._skip = False
+        elif tag in self._STRUCTURAL_END_TAGS:
+            self._parts.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if not self._skip:
+            self._parts.append(data)
+
+    def get_text(self) -> str:
+        """Join extracted parts and normalize whitespace."""
+        text = "".join(self._parts)
+        return re.sub(r"\n\s*\n+", "\n\n", text).strip()
+
+
+__all__ = ["_BaseHTMLTextExtractor"]

--- a/retrieval_qa/src/retrieval_qa/chunking/book_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/book_chunker.py
@@ -20,6 +20,7 @@ from core.exceptions import IngestionError
 from core.types.chunk import BookChunkMetadata, Chunk
 from core.types.document import DocumentType
 from retrieval_qa._utils import count_tokens
+from retrieval_qa.chunking._html_utils import _BaseHTMLTextExtractor
 from retrieval_qa.chunking.base import DocumentChunker, register_chunker
 
 
@@ -54,35 +55,6 @@ class BookChunk(Chunk):
     model_config = ConfigDict(extra="forbid")
 
     metadata: BookChunkMetadata
-
-
-class _HTMLTextExtractor(HTMLParser):
-    """Strip tags from EPUB HTML bodies while preserving some structure."""
-
-    def __init__(self) -> None:
-        super().__init__()
-        self._parts: list[str] = []
-        self._skip = False
-
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        if tag in {"script", "style"}:
-            self._skip = True
-        elif tag in {"p", "div", "h1", "h2", "h3", "h4", "li", "br"}:
-            self._parts.append("\n")
-
-    def handle_endtag(self, tag: str) -> None:
-        if tag in {"script", "style"}:
-            self._skip = False
-        elif tag in {"p", "div", "h1", "h2", "h3", "h4", "li"}:
-            self._parts.append("\n")
-
-    def handle_data(self, data: str) -> None:
-        if not self._skip:
-            self._parts.append(data)
-
-    def get_text(self) -> str:
-        text = "".join(self._parts)
-        return re.sub(r"\n\s*\n+", "\n\n", text).strip()
 
 
 class _SectionExtractor(HTMLParser):
@@ -303,7 +275,7 @@ def _extract_epub_text(
         except KeyError:
             raw = archive.read(href).decode("utf-8")
 
-        extractor = _HTMLTextExtractor()
+        extractor = _BaseHTMLTextExtractor()
         extractor.feed(raw)
         text = extractor.get_text()
         if text:

--- a/retrieval_qa/src/retrieval_qa/chunking/documentation_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/documentation_chunker.py
@@ -11,7 +11,6 @@ PDF page breaks). Sections include sub-headings and API endpoint lines such as
 import re
 from collections.abc import Sequence
 from enum import StrEnum
-from html.parser import HTMLParser
 from io import BytesIO
 
 from pydantic import ConfigDict
@@ -21,6 +20,7 @@ from core.exceptions import IngestionError
 from core.types.chunk import Chunk, DocumentationChunkMetadata
 from core.types.document import DocumentType
 from retrieval_qa._utils import count_tokens
+from retrieval_qa.chunking._html_utils import _BaseHTMLTextExtractor
 from retrieval_qa.chunking.base import DocumentChunker, register_chunker
 
 
@@ -51,41 +51,31 @@ class DocumentationChunk(Chunk):
     metadata: DocumentationChunkMetadata
 
 
-class _HTMLTextExtractor(HTMLParser):
+class _HTMLTextExtractor(_BaseHTMLTextExtractor):
     """Convert HTML to Markdown-style headings so the text splitter can run."""
 
     def __init__(self) -> None:
         super().__init__()
-        self._parts: list[str] = []
-        self._skip = False
         self._heading_level: int | None = None
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        if tag in {"script", "style", "head"}:
+        if tag == "head":
             self._skip = True
         elif tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
             self._heading_level = int(tag[1])
             self._parts.append("\n")
             self._parts.append("#" * self._heading_level + " ")
-        elif tag in {"p", "div", "br", "li"}:
-            self._parts.append("\n")
+        else:
+            super().handle_starttag(tag, attrs)
 
     def handle_endtag(self, tag: str) -> None:
-        if tag in {"script", "style", "head"}:
+        if tag == "head":
             self._skip = False
         elif tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
             self._heading_level = None
             self._parts.append("\n")
-        elif tag in {"p", "div", "li"}:
-            self._parts.append("\n")
-
-    def handle_data(self, data: str) -> None:
-        if not self._skip:
-            self._parts.append(data)
-
-    def get_text(self) -> str:
-        text = "".join(self._parts)
-        return re.sub(r"\n\s*\n+", "\n\n", text).strip()
+        else:
+            super().handle_endtag(tag)
 
 
 def _detect_format(file_bytes: bytes) -> DocumentationFormat:

--- a/retrieval_qa/tests/retrieval_qa/test_html_utils.py
+++ b/retrieval_qa/tests/retrieval_qa/test_html_utils.py
@@ -1,0 +1,135 @@
+"""Tests for shared HTML utilities used by chunkers."""
+
+from html.parser import HTMLParser
+
+from retrieval_qa.chunking._html_utils import _BaseHTMLTextExtractor
+
+
+def _extract(html: str) -> str:
+    """Helper to feed HTML and return extracted text."""
+    extractor = _BaseHTMLTextExtractor()
+    extractor.feed(html)
+    extractor.close()
+    return extractor.get_text()
+
+
+def test_strips_script_content() -> None:
+    """Content inside <script> tags is removed."""
+    html = "<p>Hello</p><script>var x = 1;</script><p>World</p>"
+    assert _extract(html) == "Hello\n\nWorld"
+
+
+def test_strips_style_content() -> None:
+    """Content inside <style> tags is removed."""
+    html = "<p>Hello</p><style>body { color: red; }</style><p>World</p>"
+    assert _extract(html) == "Hello\n\nWorld"
+
+
+def test_structural_newlines_for_block_tags() -> None:
+    """Block-level tags produce newlines around their content."""
+    html = "<p>First</p><div>Second</div><li>Third</li>"
+    result = _extract(html)
+    # Each block tag body should be separated by newlines
+    assert "First" in result
+    assert "Second" in result
+    assert "Third" in result
+    assert result.startswith("First")
+    assert "Second" in result
+
+
+def test_br_tag_inserts_newline() -> None:
+    """<br> tags insert a newline."""
+    html = "Line1<br>Line2"
+    assert _extract(html) == "Line1\nLine2"
+
+
+def test_heading_tags_preserve_content() -> None:
+    """Heading content is preserved as-is (no heading markers in base)."""
+    html = "<h1>Title</h1><p>Body</p><h2>Subtitle</h2><p>More</p>"
+    result = _extract(html)
+    assert "Title" in result
+    assert "Subtitle" in result
+    assert "Body" in result
+    assert "More" in result
+
+
+def test_get_text_normalizes_whitespace() -> None:
+    """Multiple consecutive newlines are collapsed to two."""
+    html = "<p>A</p><p>B</p><p>C</p>"
+    assert _extract(html) == "A\n\nB\n\nC"
+
+
+def test_empty_html_returns_empty_string() -> None:
+    """Empty or whitespace-only HTML returns an empty string."""
+    assert _extract("") == ""
+    assert _extract("<html><body></body></html>") == ""
+
+
+def test_plain_text_passes_through() -> None:
+    """HTML with no tags returns the raw text unchanged."""
+    assert _extract("Hello, World!") == "Hello, World!"
+
+
+def test_subclass_can_override_heading_behavior() -> None:
+    """Subclassing works: a heading-aware subclass can add markers."""
+
+    class _HeadingExtractor(_BaseHTMLTextExtractor):
+        def __init__(self) -> None:
+            super().__init__()
+            self._heading_level: int | None = None
+
+        def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+            if tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+                self._heading_level = int(tag[1])
+                self._parts.append("\n")
+                self._parts.append("#" * self._heading_level + " ")
+            else:
+                super().handle_starttag(tag, attrs)
+
+        def handle_endtag(self, tag: str) -> None:
+            if tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+                self._heading_level = None
+                self._parts.append("\n")
+            else:
+                super().handle_endtag(tag)
+
+    extractor = _HeadingExtractor()
+    extractor.feed("<h1>Title</h1><p>Body</p><h2>Sub</h2><p>Text</p>")
+    extractor.close()
+    result = extractor.get_text()
+
+    assert result.startswith("# Title")
+    assert "Body" in result
+    assert "## Sub" in result
+
+
+def test_subclass_can_skip_head_tag() -> None:
+    """Subclassing works for adding <head> tag skipping."""
+
+    class _HeadSkippingExtractor(_BaseHTMLTextExtractor):
+        def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+            if tag == "head":
+                self._skip = True
+            else:
+                super().handle_starttag(tag, attrs)
+
+        def handle_endtag(self, tag: str) -> None:
+            if tag == "head":
+                self._skip = False
+            else:
+                super().handle_endtag(tag)
+
+    html = "<p>Before</p><head><title>Title</title></head><p>After</p>"
+    assert _HeadSkippingExtractor().get_text() is not None  # smoke-test construction
+    extractor = _HeadSkippingExtractor()
+    extractor.feed(html)
+    extractor.close()
+    result = extractor.get_text()
+    assert "Before" in result
+    assert "After" in result
+    assert "Title" not in result
+
+
+def test_inherits_from_htmlparser() -> None:
+    """_BaseHTMLTextExtractor is a genuine HTMLParser subclass."""
+    assert issubclass(_BaseHTMLTextExtractor, HTMLParser)


### PR DESCRIPTION
…ared _html_utils base

Both documentation_chunker and book_chunker had near-identical _HTMLTextExtractor classes with shared __init__, handle_data, and get_text logic. Extract the common tag-stripping foundation into _BaseHTMLTextExtractor in a new _html_utils module, then have each chunker extend or compose from it.

- _BaseHTMLTextExtractor provides structural newlines for block-level and heading tags, plus script/style skipping and whitespace normalization.
- documentation_chunker._HTMLTextExtractor subclasses it for Markdown- style heading markers and <head> skipping.
- book_chunker._HTMLTextExtractor is replaced by direct use of the base class (identical behavior).

Closes #86