### PR TITLE
refactor(retrieval-qa): remove speculative HTTP methods from _HTTP_METHODS

### DIFF
--- a/retrieval_qa/src/retrieval_qa/chunking/documentation_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/documentation_chunker.py
@@ -32,7 +32,7 @@ class DocumentationFormat(StrEnum):
     MARKDOWN = "markdown"
 
 
-_HTTP_METHODS = ("GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS")
+_HTTP_METHODS = ("GET", "POST")
 
 # Matches Markdown headings like ``# Page`` or ``## Section``.
 _HEADING_PATTERN = re.compile(r"^(#{1,6})\s+(.+?)$")


### PR DESCRIPTION
Closes #87

Reduces `_HTTP_METHODS` to only `GET` and `POST` — the HTTP methods actually tested and used. Removes untested `PUT`, `DELETE`, `PATCH`, `HEAD`, `OPTIONS`.