### PR TITLE
docs: add retrieval-gap ADRs and update stale references

### DIFF
--- a/.out-of-scope/custom-deepeval-metric-async.md
+++ b/.out-of-scope/custom-deepeval-metric-async.md
@@ -1,0 +1,36 @@
+# Custom Deepeval Metric `a_measure`
+
+This project does not treat `a_measure` on custom deepeval metrics as speculative generality or dead code.
+
+## Why this is in scope / not speculative
+
+Deepeval's `BaseMetric` pattern expects custom metrics to implement **both** `measure` (sync) and `a_measure` (async). All official examples include both methods:
+
+```python
+from deepeval.metrics import BaseMetric
+from deepeval.test_case import LLMTestCase
+
+class CustomMetric(BaseMetric):
+    def measure(self, test_case: LLMTestCase) -> float:
+        # sync scoring logic
+        ...
+
+    async def a_measure(self, test_case: LLMTestCase) -> float:
+        # async counterpart — delegates to same scoring logic
+        ...
+```
+
+The `a_measure` method is invoked when `assert_test` is called with `run_async=True`. Since deepeval may call `a_measure` depending on configuration, the method is required for interface compliance — not speculative generality.
+
+The current implementation in `RecallAtKMetric` delegates synchronously:
+
+```python
+async def a_measure(self, test_case: LLMTestCase, *args: object, **kwargs: object) -> float:
+    return self.measure(test_case, *args, **kwargs)
+```
+
+This is the correct pattern for a metric that has no actual async work (no IO-bound operations in the scoring logic).
+
+## Prior requests
+
+- #92 — "Speculative Generality — RecallAtKMetric.a_measure (Code Review #57, Item 44)"

--- a/.out-of-scope/docker-compose.md
+++ b/.out-of-scope/docker-compose.md
@@ -1,0 +1,16 @@
+# Docker Compose and Dockerfile
+
+This project does not provide Docker Compose files or production Dockerfiles for local development or deployment.
+
+## Why this is out of scope
+
+ADR-0014 explicitly states "no compose file" as a premise (L46). The project's CI/CD pipeline uses GitHub Actions for testing and relies on a managed PostgreSQL service (Supabase) with pgvector for the database layer. Docker Compose was never part of the schema/contract scope for either the ingestion or query tracer bullets.
+
+Adding Docker Compose would introduce a secondary, unmanaged development path that:
+- Duplicates the CI workflow's database setup (which uses service containers)
+- Creates a maintenance burden for keeping Compose files in sync with the actual deployment target
+- Implies a local-first development model that conflicts with the project's Supabase-hosted architecture
+
+## Prior requests
+
+- #19 — `docker-compose.yml` + `Dockerfile` present in the ingestion tracer bullet PR (PR #7), flagged as scope creep in code review

--- a/.out-of-scope/pytest-module-level-test-data.md
+++ b/.out-of-scope/pytest-module-level-test-data.md
@@ -1,0 +1,28 @@
+# Pytest Module-Level Test Data
+
+This project does not treat module-level YAML/JSON I/O in test files as a defect, provided the side effect is confined to that test file.
+
+## Why this is accepted
+
+Pytest's `@pytest.mark.parametrize` requires its values at decoration (import) time — there is no native way to defer parametrize arguments to fixture resolution. Loading test data at module level is the standard, idiomatic pattern:
+
+```python
+_EVAL_DATA = _load_eval_data()           # YAML I/O at import time
+_EVAL_QUERIES = [EvalQuery(...) for ...] # validated at import time
+
+@pytest.mark.parametrize("query_data", _EVAL_QUERIES)
+def test_something(query_data):
+    ...
+```
+
+Fixing this "cosmetic concern" would require one of:
+
+- **Isolating eval tests in `tests/eval/`** — directory restructure for one file's import order
+- **`pytest-lazy-fixtures` dependency** — new third-party dep to defer parametrize resolution
+- **`pytest_generate_tests` hook** — metafunc-based parametrization, significantly more complex
+
+None of these add meaningful value. The side effect is confined to one test file, runs only during test collection, and causes no runtime failures.
+
+## Prior requests
+
+- #93 — "Module-level side effects — test_eval.py YAML I/O at import time (Code Review #57, Item 45)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ These docs are **not** auto-loaded into session context. Only this `AGENTS.md` i
 
 **Before choosing or adding a library, model, or external service:**
 - `docs/tech-stack.md` — MVP stack and staged post-MVP milestones.
-- `docs/adr/` — read the ADR(s) most relevant to the area (e.g., ADR-0001 inference, ADR-0002 pgvector, ADR-0003 hand-rolled RAG, ADR-0004 embeddings, ADR-0006 background ingestion, ADR-0012 depth-dive-web-search-agentic, ADR-0013 depth-dive-search-failure-retry-fallback, ADR-0014 data-schema-api-contracts-harness-a, ADR-0015 deepeval-for-retrieval-evaluation). Treat ADRs as **constraints, not suggestions**. If a decision contradicts an ADR, stop and propose a new/updated ADR rather than silently deviating.
+- `docs/adr/` — read the ADR(s) most relevant to the area (e.g., ADR-0001 inference, ADR-0002 pgvector, ADR-0003 hand-rolled RAG, ADR-0004 embeddings, ADR-0006 background ingestion, ADR-0012 depth-dive-web-search-agentic, ADR-0013 depth-dive-search-failure-retry-fallback, ADR-0014 data-schema-api-contracts-harness-a, ADR-0015 deepeval-for-retrieval-evaluation, ADR-0016 retrieval-qa-critical-gaps-parent-child-hybrid-rerank, ADR-0017 important-but-gatable-retrieval-phase). Treat ADRs as **constraints, not suggestions**. If a decision contradicts an ADR, stop and propose a new/updated ADR rather than silently deviating.
 
 **Before writing a commit message:**
 - `docs/commit-instructions.md` — Conventional Commits format and allowed types.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -30,3 +30,30 @@ The explicit, query-independent capability of proactively surfacing relationship
 
 ## Retrieval Practice / Spaced Repetition (post-MVP)
 Testing-effect and scheduling-based learning mechanisms (quizzes on captured passages, scheduled resurfacing of concepts) considered part of the "neuroscience-backed" goal but explicitly out of MVP. Requires durable per-concept state (long-term memory), unlike dual coding which is stateless per-request.
+
+## Parent Chunk
+The enclosing structural unit (section, chapter, API page) produced by a Document-Type Chunker. Not embedded directly. Contains one or more Child Chunks. At retrieval time, the parent replaces matched child chunks before being handed to the LLM for generation.
+
+## Child Chunk
+A fixed-size (~512 tokens, 15% overlap) recursive split of a Parent Chunk. Embedded and indexed for retrieval (both dense pgvector and sparse tsvector). A child points to its parent via `parent_chunk_id`. Only children are matched by the query; the parent is what reaches generation.
+
+## Hybrid Search
+A retrieval strategy combining dense (embedding-based pgvector cosine search) and sparse (PostgreSQL `tsvector` full-text search) passes, fused via Reciprocal Rank Fusion. Recovers exact-match queries (function names, API endpoints, error codes, symbols) that pure dense retrieval misses.
+
+## Reranking
+A second-pass relevance filter that scores the top-K candidates from hybrid search using a cross-encoder (Cohere Rerank for prototyping, planned swap to local BGE-reranker). Keeps the top-5 for generation. Implemented after hybrid search per the RAG reference guide's priority order.
+
+## Query Decomposition (post-MVP)
+The technique of splitting a complex multi-hop question into simpler sub-queries, retrieving for each, then synthesizing the results. Deferred until parent-child chunking, hybrid search, and reranking are implemented and evaluated.
+
+## Evaluation
+
+**Content-Signature Labeling**:
+A ground-truth labeling strategy for retrieval evaluation where expected passages are identified by a distinctive substring of their text (or a SHA-256 of that substring). Invariant to chunk boundaries — unlike position ranges or page numbers — so the same labeled queries work across any chunk-size configuration without re-labeling.
+
+**Eval Query Taxonomy**:
+Four-stratum classification of eval queries:
+- *Concept lookup* (dense-friendly) — single-fact lookup ("What is attention?")
+- *Exact-match / keyword* (sparse-friendly) — API names, error codes, CLI flags
+- *Context-dependent* (parent-child matters) — requires the enclosing section to answer precisely
+- *Multi-hop / reasoning* (decomposition prep) — relates two or more concepts across different parts of the corpus

--- a/docs/adr/0016-retrieval-qa-critical-gaps-parent-child-hybrid-rerank.md
+++ b/docs/adr/0016-retrieval-qa-critical-gaps-parent-child-hybrid-rerank.md
@@ -1,0 +1,41 @@
+# 0016 — Retrieval QA Critical Gaps: Parent-Child Chunking, Hybrid Search, and Cross-Encoder Reranking
+
+## Status
+Accepted
+
+## Context
+Retrieval QA's existing pipeline (per-type structure-aware chunkers, pure dense pgvector retrieval, and direct top-K generation) has been proven in its tracer-bullet form. Before Depth Dive can be built on top of it, three systemic gaps from the RAG reference guide were identified during a structured audit against current 2025–2026 consensus practices (see `RAG-reference-guide.md`):
+
+1. **No parent-child chunk linkage.** Chunks are the atomic unit for both retrieval and generation. Retrieving a small, precise chunk but handing its enclosing section to the LLM — the most widely adopted production pattern — is impossible.
+2. **No hybrid search.** The system is dense-only (pgvector cosine distance). Exact-match queries (function names, API endpoints, error codes, LaTeX symbols) that the embedding model glosses over are silently lost.
+3. **No cross-encoder reranking.** The system retrieves top-5 raw cosine distance and passes them directly to generation. There is no second-pass relevance filter, which the reference identifies as the single highest-leverage accuracy addition after hybrid search.
+
+All three are independent of each other in design but sequential in implementation: parent-child changes the data model and ingestion pipeline (foundation), hybrid search and reranking sit on top of retrieval.
+
+## Decision
+
+### 1. Parent-child hierarchical chunking
+Each existing structure-aware chunk (section, chapter, API page) becomes a **parent**. Children are produced by a recursive fixed-size text splitter at **512 tokens with 15% contextual overlap**, applied uniformly across all document types. Only child chunks are embedded (pgvector) and indexed (tsvector). At retrieval time, child matches are swapped to their parent via `parent_chunk_id` before generation.
+
+Schema: self-referential `parent_chunk_id` nullable foreign key on the existing `chunks` table. Parent rows have `parent_chunk_id = NULL`.
+
+Rationale for fixed-size (not semantic) splitting: the reference notes that some benchmarks find fixed-size splitting beats semantic chunking once cost is factored in. It also avoids adding a training-dependent step to the hand-rolled pipeline (ADR-0003).
+
+### 2. Hybrid search (dense + sparse)
+Add a PostgreSQL `tsvector` column and GIN index on child chunk content. At query time, run both a pgvector cosine search (unchanged) and a `ts_rank` full-text search against the same child chunk rows. Fuse results via Reciprocal Rank Fusion (RRF). Retrieve top-20 from each path, fuse into a single ranked set, then swap to parents.
+
+Rationale for tsvector over pg_bm25/pg_textsearch: zero new infrastructure. The existing `pgvector/pgvector:pg16` Docker image works unchanged. No custom Docker image, no C extension build, no CI pipeline changes. Postgres FTS (`ts_rank`) is sufficient for MVP-level exact-match recovery; BM25-level scoring is a quantitative improvement that can be swapped in later if the eval set shows it matters.
+
+### 3. Cross-encoder reranking
+After RRF fusion and parent swap, pass the top-20 parent chunks through **Cohere Rerank** (trial API key for prototyping). Keep the top-5 for generation. This is a staged dependency: the Cohere free tier (1,000 calls/month, 10 req/min) is sufficient for prototyping and eval-set iteration. Replacement with a local `BAAI/bge-reranker-v2-m3` (CPU or GPU) is planned as a post-PoC optimization to cut the API dependency and monthly call cap.
+
+### Execution order
+The implementation follows dependency order: parent-child schema and ingestion changes first (foundation), then hybrid search, then reranking. Each stage is individually testable and can be evaluated against the existing eval set (ADR-0015) before proceeding to the next.
+
+## Consequences
+- The `chunks` table gains a `parent_chunk_id` column; the ingestion pipeline gains a recursive splitting step before embedding.
+- New chunk content may be smaller on average (~512 tokens for children vs variable for current structure-aware chunks), which changes the embedding distribution and retrieval characteristics — the eval set will show whether this improves recall.
+- Retrieval latency increases: hybrid search adds a tsquery + RRF step; reranking adds an external API call. For a personal learning tool this is acceptable, but it should be measured.
+- The Cohere Rerank API dependency is temporary-friendly (free trial, no credit card) but adds a key rotation and availability dependency that the local BGE alternative would eliminate.
+- The eval set (4 queries) is too small to confidently measure improvement from these changes. Expanding it is deferred to a follow-up phase ("important but gatable" items) but should be prioritized early to avoid silent regressions.
+- Query decomposition (multi-hop sub-question generation) is explicitly deferred until after these three gaps are implemented and evaluated, per the RAG reference guide's priority order.

--- a/docs/adr/0017-important-but-gatable-retrieval-phase.md
+++ b/docs/adr/0017-important-but-gatable-retrieval-phase.md
@@ -1,0 +1,45 @@
+# 0017 — Important but Gatable: Retrieval Evaluation Infrastructure and Chunk-Size Tuning
+
+The three gaps identified in the RAG reference guide's review — chunk-size tuning, dedicated extraction for tables/equations/code blocks, and eval-set expansion — were deferred from Phase 1 (parent-child + hybrid search + reranking, ADR-0016) as "Important but Gatable." This ADR records the design decisions for that phase.
+
+## Decision
+
+### 1. Content-signature ground truth (not position ranges or page numbers)
+
+Ground truth passages are labeled by **content signature** — a distinctive substring or SHA-256 hash of the passage text. At eval time, a retrieved chunk is counted as a hit if it contains that substring. This is invariant to chunk boundaries, so the same 50 labeled queries work across all chunk-size configurations without re-labeling.
+
+Rejected alternatives:
+- **Page-number ranges** — only paper chunkers track pages; books and docs don't have consistent page metadata.
+- **Byte offsets in source file** — the extraction layer (pypdf, HTML strip, etc.) discards original byte positions; retrofitting them into all three chunkers is meaningful work that delays tuning.
+- **Chunk-id ranges** — `chunk.position` is a sequence index within a document, not a source-offset proxy; re-chunking changes every position.
+
+### 2. Tuning harness: single test DB, 3 parallel schemas, stratified 50-query eval
+
+Chunk-size tuning compares 256/10%, 512/15%, and 1024/20% in a single test database with three parallel schema/table variants (`chunks_256_10`, `chunks_512_15`, `chunks_1024_20`). Each variant is seeded from the same 6 representative documents (2 books, 2 papers, 2 doc sets). The eval set has 50 queries stratified across four types:
+
+| Type | Count | Purpose |
+|------|-------|---------|
+| Concept lookup (dense-friendly) | 12–15 | Single-fact retrieval |
+| Exact-match / keyword (sparse-friendly) | 10–12 | API names, error codes, CLI flags |
+| Context-dependent (parent-child matters) | 10–12 | Enclosing section required |
+| Multi-hop / reasoning (decomposition prep) | 8–10 | Relates two concepts across corpus |
+
+Metrics: recall@10 and MRR for dense alone, sparse alone, and fused (RRF). The winning config is re-ingested to production; the test DB is torn down.
+
+### 3. Dedicated extraction for tables/equations/code blocks (MVP scope)
+
+**Papers and books (PDF/EPUB):** Tables and equations are detected heuristically (lines dominated by numbers, operators, or symbolic content) and emitted as separate child chunks with cleaned text. No structured schema (row/cell/LaTeX). Post-MVP: dedicated extraction with caption metadata and structured table rows.
+
+**Documentation (Markdown, HTML):** Code blocks are kept intact — the splitter never splits mid-code-block. Detection uses Markdown fences (`` ``` ``) and HTML `<pre><code>` tags. PDF docs have no code-block detection; they get flat-text splitting only.
+
+## Consequences
+
+- Building the 50-query eval set requires reading real documents and writing queries — a manual, one-time cost of approximately 2–3 hours.
+- Content-signature matching is coarser than position-based overlap (a chunk "containing" the passage may also contain substantial nearby text), but this is acceptable for tuning rank-ordering across configurations.
+- The 3-schema test DB requires ~3× storage for the evaluation corpus but avoids maintaining per-configuration code branches or config-driven chunking logic.
+- Dedicated extraction for tables/equations is heuristic and will miss or misclassify some content — but structured extraction is deferred, not abandoned.
+- Code-block protection applies to two of three documentation source formats; PDF docs remain unprotected, which is an accepted gap for MVP.
+
+## Status
+
+Accepted

--- a/docs/ai-system-tree.md
+++ b/docs/ai-system-tree.md
@@ -75,7 +75,7 @@ learning-hub/
 ├── scripts/
 │   └── generate_eval_vectors.py      # Eval vector generation utility
 ├── docs/
-│   ├── adr/                          # 0001–0015 (skip 0008; 0015 supersedes 0007 scorer)
+│   ├── adr/                          # 0001–0017 (skip 0008; 0015 supersedes 0007 scorer)
 │   ├── ai-system-tree.md
 │   ├── tech-stack.md
 │   ├── coding-standards.md
@@ -86,7 +86,9 @@ learning-hub/
 │   ├── security.yml                  # Dependency scanning (pip-audit, etc.)
 │   └── dependabot-auto-merge.yml     # Auto-merge for low-risk Dependabot bumps
 ├── .out-of-scope/
-│   └── docker-compose.md             # Notes on docker-compose scoping decision
+│   ├── custom-deepeval-metric-async.md   # Deepeval a_measure pattern rationale
+│   ├── docker-compose.md                 # Notes on docker-compose scoping decision
+│   └── pytest-module-level-test-data.md  # Module-level test data I/O rationale
 ├── pyproject.toml                    # Root: uv workspace, ruff config, import-linter contracts
 ├── conftest.py                       # Root test fixtures (271 lines, shared by all packages)
 ├── alembic.ini                       # Alembic configuration for DB migrations


### PR DESCRIPTION
- Add ADR-0016 (parent-child chunking, hybrid search, cross-encoder reranking) and ADR-0017 (eval infrastructure, chunk-size tuning)

- Update CONTEXT.md with new domain terms (Parent Chunk, Child Chunk, Hybrid Search, Reranking, etc.)

- Add .out-of-scope design notes for deepeval async metric and module-level test data

- Sync AGENTS.md ADR list and docs/ai-system-tree.md ADR range + .out-of-scope listing