### PR TITLE
refactor(retrieval-qa): extract duplicated _sha256 into shared _utils…

### DIFF
--- a/retrieval_qa/src/retrieval_qa/_utils.py
+++ b/retrieval_qa/src/retrieval_qa/_utils.py
@@ -1,5 +1,7 @@
 """Internal shared utilities for the retrieval_qa package."""
 
+from hashlib import sha256
+
 
 def count_tokens(text: str) -> int:
     """Approximate token count for chunk sizing.
@@ -9,3 +11,7 @@ def count_tokens(text: str) -> int:
     changing the chunker interface.
     """
     return max(1, len(text.split()))
+
+
+def _sha256(text: str) -> str:
+    return sha256(text.encode()).hexdigest()

--- a/retrieval_qa/tests/retrieval_qa/retrieval/conftest.py
+++ b/retrieval_qa/tests/retrieval_qa/retrieval/conftest.py
@@ -13,7 +13,6 @@ is still present when the eval tests execute.
 
 import json
 from collections.abc import Generator
-from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +25,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from core.config.settings import Settings
 from core.database.schema import Base, Chunk, Document, Embedding
 from core.types.document import DocumentStatus, DocumentType
+from retrieval_qa._utils import _sha256
 
 _EVAL_SET_PATH = Path(__file__).parent / "eval_set.yaml"
 _EVAL_VECTORS_PATH = _EVAL_SET_PATH.with_name("eval_vectors.json")
@@ -42,10 +42,6 @@ def _create_enums(engine: Engine) -> None:
             enum_type = ENUM(*values, name=name)
             enum_type.create(bind=conn, checkfirst=True)
         conn.commit()
-
-
-def _sha256(text: str) -> str:
-    return sha256(text.encode()).hexdigest()
 
 
 def _validate_eval_integrity(

--- a/scripts/generate_eval_vectors.py
+++ b/scripts/generate_eval_vectors.py
@@ -15,7 +15,6 @@ Edit content in the YAML, run this script, and both files are in sync —
 no manual hash updates needed.
 """
 
-import hashlib
 import json
 from collections import OrderedDict
 from pathlib import Path
@@ -25,6 +24,7 @@ import yaml
 
 from core.clients import EmbeddingsClient
 from core.config.settings import Settings
+from retrieval_qa._utils import _sha256
 
 EVAL_SET_PATH = (
     Path(__file__).resolve().parent.parent
@@ -32,10 +32,6 @@ EVAL_SET_PATH = (
 )
 EVAL_VECTORS_PATH = EVAL_SET_PATH.with_name("eval_vectors.json")
 BATCH_SIZE = 20
-
-
-def _sha256(text: str) -> str:
-    return hashlib.sha256(text.encode()).hexdigest()
 
 
 def _rewrite_content_hashes(data: dict[str, Any]) -> None:


### PR DESCRIPTION
… module

Define _sha256 once in retrieval_qa/_utils.py and import it from both conftest.py and generate_eval_vectors.py, removing the identical local definitions.

Closes #94