### PR TITLE
feat(ingestion): add parent-child schema and chunking pipeline

### DIFF
--- a/core/src/core/database/migrations/versions/edda412e1f07_add_parent_chunk_id_and_content_search.py
+++ b/core/src/core/database/migrations/versions/edda412e1f07_add_parent_chunk_id_and_content_search.py
@@ -1,0 +1,66 @@
+"""Add parent_chunk_id and content_search (tsvector) to chunks.
+
+Revision ID: edda412e1f07
+Revises: 2fff441e94ab
+Create Date: 2026-07-23 09:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import TSVECTOR
+
+# revision identifiers, used by Alembic.
+revision: str = "edda412e1f07"
+down_revision: str | None = "2fff441e94ab"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chunks",
+        sa.Column(
+            "parent_chunk_id",
+            sa.Uuid(),
+            nullable=True,
+        ),
+    )
+    op.create_foreign_key(
+        "fk_chunks_parent_chunk_id",
+        "chunks",
+        "chunks",
+        ["parent_chunk_id"],
+        ["chunk_id"],
+        ondelete="SET NULL",
+    )
+
+    op.add_column(
+        "chunks",
+        sa.Column(
+            "content_search",
+            TSVECTOR(),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_chunks_content_search_gin",
+        "chunks",
+        ["content_search"],
+        postgresql_using="gin",
+    )
+
+    op.drop_constraint(
+        "uq_chunk_document_position",
+        "chunks",
+        type_="unique",
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_chunks_content_search_gin")
+    op.drop_column("chunks", "content_search")
+    op.execute("ALTER TABLE chunks DROP CONSTRAINT IF EXISTS fk_chunks_parent_chunk_id")
+    op.drop_column("chunks", "parent_chunk_id")

--- a/core/src/core/database/schema.py
+++ b/core/src/core/database/schema.py
@@ -1,11 +1,12 @@
 """SQLAlchemy declarative base and table models.
 
-The schema matches ADR-0014:
+The schema matches ADR-0014 + ADR-0016 (parent-child):
 - UUIDv7 primary keys generated app-side.
 - Postgres enums for ``document_type`` and ``status`` with lowercase labels that
   match the Python ``StrEnum`` values.
 - CHECK constraints on ``error_message``, ``position``, and ``token_count``.
-- ``UNIQUE (document_id, position)`` on chunks.
+- ``parent_chunk_id`` self-referential FK with ``ON DELETE SET NULL``.
+- ``content_search`` tsvector column with GIN index (created in migration).
 - Composite PK ``(chunk_id, model_name)`` on embeddings.
 - No ``updated_at`` on chunks or embeddings.
 - HNSW index created in the Alembic migration, not here.
@@ -22,10 +23,9 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Text,
-    UniqueConstraint,
     text,
 )
-from sqlalchemy.dialects.postgresql import ENUM
+from sqlalchemy.dialects.postgresql import ENUM, TSVECTOR
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 from sqlalchemy.sql.elements import TextClause
@@ -101,7 +101,13 @@ class Document(Base):
 
 
 class Chunk(Base):
-    """An atomic retrievable unit produced by a document-type chunker."""
+    """An atomic retrievable unit produced by a document-type chunker.
+
+    A row may be a *parent* (structure-aware chunk, ``parent_chunk_id`` is NULL)
+    or a *child* (fixed-size split of a parent, ``parent_chunk_id`` points to the
+    parent). Only children are embedded and indexed for retrieval; parents exist
+    solely for parent-swap at query time (ADR-0016).
+    """
 
     __tablename__ = "chunks"
 
@@ -116,6 +122,14 @@ class Chunk(Base):
     content: Mapped[str]
     token_count: Mapped[int]
     type_metadata: Mapped[dict[str, object]] = mapped_column(JSON, default=dict)
+    parent_chunk_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("chunks.chunk_id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    content_search: Mapped[str | None] = mapped_column(
+        TSVECTOR,
+        nullable=True,
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=_utc_now,
@@ -125,7 +139,6 @@ class Chunk(Base):
     __table_args__ = (
         CheckConstraint("position >= 0", name="ck_chunk_position_non_negative"),
         CheckConstraint("token_count > 0", name="ck_chunk_token_count_positive"),
-        UniqueConstraint("document_id", "position", name="uq_chunk_document_position"),
     )
 
     document: Mapped["Document"] = relationship(back_populates="chunks")

--- a/core/tests/core/test_migration.py
+++ b/core/tests/core/test_migration.py
@@ -59,6 +59,20 @@ def _unique_constraints(engine: Engine, table: str) -> set[str]:
     return {uc["name"] for uc in inspector.get_unique_constraints(table) if uc["name"] is not None}
 
 
+def _gin_index_info(engine: Engine, table: str, index_name: str) -> dict[str, object]:
+    with engine.connect() as conn:
+        row = conn.execute(
+            text(
+                "SELECT indexname, indexdef FROM pg_indexes "
+                "WHERE tablename = :table_name AND indexname = :index_name"
+            ),
+            {"table_name": table, "index_name": index_name},
+        ).fetchone()
+    if row is None:
+        return {}
+    return {"name": row[0], "definition": row[1]}
+
+
 def _hnsw_index_info(engine: Engine, table: str) -> dict[str, object]:
     with engine.connect() as conn:
         row = conn.execute(
@@ -110,6 +124,8 @@ def test_migration_creates_expected_schema(migrated_engine: Engine) -> None:
         "content",
         "token_count",
         "type_metadata",
+        "parent_chunk_id",
+        "content_search",
         "created_at",
     }
     assert "updated_at" not in chunk_columns
@@ -133,8 +149,25 @@ def test_migration_creates_expected_schema(migrated_engine: Engine) -> None:
     assert "ck_chunk_position_non_negative" in _check_constraints(migrated_engine, "chunks")
     assert "ck_chunk_token_count_positive" in _check_constraints(migrated_engine, "chunks")
 
-    # Unique (document_id, position) present.
-    assert "uq_chunk_document_position" in _unique_constraints(migrated_engine, "chunks")
+    # parent_chunk_id FK is self-referential with ON DELETE SET NULL.
+    chunk_fks = inspector.get_foreign_keys("chunks")
+    parent_chunk_fk = [fk for fk in chunk_fks if fk["constrained_columns"] == ["parent_chunk_id"]]
+    assert len(parent_chunk_fk) == 1
+    assert parent_chunk_fk[0]["referred_table"] == "chunks"
+    assert parent_chunk_fk[0]["referred_columns"] == ["chunk_id"]
+    assert parent_chunk_fk[0].get("options", {}).get("ondelete", "").upper() == "SET NULL"
+
+    # content_search column is tsvector.
+    chunk_cols = inspector.get_columns("chunks")
+    content_search_col = [c for c in chunk_cols if c["name"] == "content_search"]
+    assert len(content_search_col) == 1
+    assert str(content_search_col[0]["type"]).lower() == "tsvector"
+
+    # GIN index on content_search.
+    content_search_index = _gin_index_info(
+        migrated_engine, "chunks", "ix_chunks_content_search_gin"
+    )
+    assert content_search_index, "GIN index on content_search not found"
 
     # HNSW index on embeddings.embedding with vector_cosine_ops.
     hnsw = _hnsw_index_info(migrated_engine, "embeddings")

--- a/ingestion/src/ingestion/__init__.py
+++ b/ingestion/src/ingestion/__init__.py
@@ -1,3 +1,3 @@
 """Ingestion package."""
 
-__all__ = ["pipeline", "tasks"]
+__all__ = ["pipeline", "splitting", "tasks"]

--- a/ingestion/src/ingestion/pipeline.py
+++ b/ingestion/src/ingestion/pipeline.py
@@ -12,6 +12,7 @@ from core.exceptions import IngestionError
 from core.types.chunk import Chunk
 from core.types.document import DocumentStatus, DocumentType
 from ingestion.models import PendingIngestion
+from ingestion.splitting import recursive_fixed_size_split
 from retrieval_qa.chunking import chunker_registry, get_chunker_class
 
 
@@ -102,6 +103,15 @@ def run_ingestion(
     embeddings attached. On failure, this function raises ``IngestionError``
     and the caller should roll back.
 
+    The pipeline follows ADR-0016 parent-child chunking:
+    1. Structure-aware chunking produces parent chunks.
+    2. Each parent is stored as a row (not embedded).
+    3. Each parent is split into fixed-size child chunks (512 tokens, 15%
+       overlap) via ``recursive_fixed_size_split``.
+    4. Child chunks inherit ``type_metadata`` from the parent with an
+       additional ``"child_of"`` lineage key.
+    5. Only child chunks are embedded and indexed for retrieval.
+
     Args:
         pending: Document-identity fields for the ingestion.
         session: SQLAlchemy session bound to the documents database.
@@ -119,27 +129,47 @@ def run_ingestion(
         document.status = DocumentStatus.CHUNKING
         session.flush()
 
-        db_chunks: list[ChunkRow] = []
-        for position, (content, type_metadata, token_count) in enumerate(chunk_inputs):
+        # ── Phase 1: Store parent rows (structure-aware chunks, not embedded) ──
+        parent_rows: list[ChunkRow] = []
+        for parent_position, (content, type_metadata, token_count) in enumerate(chunk_inputs):
             _validate_type_metadata(pending.document_type, type_metadata)
-            chunk = ChunkRow(
+            parent = ChunkRow(
                 document_id=pending.document_id,
-                position=position,
+                position=parent_position,
                 content=content,
                 token_count=token_count,
                 type_metadata=type_metadata,
+                parent_chunk_id=None,
             )
-            session.add(chunk)
-            db_chunks.append(chunk)
+            session.add(parent)
+            parent_rows.append(parent)
+
+        session.flush()
+
+        # ── Phase 2: Split parents into children ──
+        child_rows: list[ChunkRow] = []
+        for parent in parent_rows:
+            child_splits = recursive_fixed_size_split(parent.content, parent.token_count)
+            for child_split in child_splits:
+                child_metadata = dict(parent.type_metadata)
+                child_metadata["child_of"] = str(parent.chunk_id)
+                child = ChunkRow(
+                    document_id=pending.document_id,
+                    position=child_split.position,
+                    content=child_split.content,
+                    token_count=child_split.token_count,
+                    type_metadata=child_metadata,
+                    parent_chunk_id=parent.chunk_id,
+                )
+                session.add(child)
+                child_rows.append(child)
 
         document.status = DocumentStatus.EMBEDDING
         session.flush()
 
-        embedded = _embed_chunks(session, embeddings_client, db_chunks, model_name)
+        # ── Phase 3: Embed only child chunks ──
+        embedded = _embed_chunks(session, embeddings_client, child_rows, model_name)
         for chunk, vector in embedded:
-            # The composite PK (chunk_id, model_name) means we can add each
-            # embedding directly; re-embedding the same chunk under the same
-            # model would raise, but chunks are immutable in the happy path.
             session.add(
                 Embedding(
                     chunk_id=chunk.chunk_id,

--- a/ingestion/src/ingestion/splitting.py
+++ b/ingestion/src/ingestion/splitting.py
@@ -1,0 +1,95 @@
+"""Recursive fixed-size text splitter for parent-child chunking.
+
+Per ADR-0016, structure-aware chunks (parents) are split into fixed-size
+child chunks of 512 tokens with 15% contextual overlap. Only child chunks
+are embedded and indexed for retrieval.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ChildSplit:
+    """A single child chunk produced by the recursive splitter.
+
+    Attributes:
+        content: The text content of the child chunk.
+        token_count: Approximate token count (whitespace-based).
+        position: Zero-based position of this child within its parent.
+    """
+
+    content: str
+    token_count: int
+    position: int
+
+
+_DEFAULT_CHUNK_SIZE = 512
+_DEFAULT_OVERLAP_RATIO = 0.15
+
+
+def _count_tokens(text: str) -> int:
+    """Approximate token count matching the convention in retrieval_qa._utils."""
+    return max(1, len(text.split()))
+
+
+def recursive_fixed_size_split(
+    text: str,
+    text_token_count: int | None = None,
+    *,
+    chunk_size: int = _DEFAULT_CHUNK_SIZE,
+    overlap_ratio: float = _DEFAULT_OVERLAP_RATIO,
+) -> list[ChildSplit]:
+    """Split ``text`` into fixed-size child chunks with contextual overlap.
+
+    If the text is at or below ``chunk_size`` tokens, a single child is
+    returned (identity split). Otherwise, the text is split into sliding
+    windows of ``chunk_size`` tokens with ``overlap_ratio`` fractional
+    overlap between adjacent windows.
+
+    Args:
+        text: The parent chunk content to split.
+        text_token_count: Precomputed token count. If ``None``, computed
+            via whitespace split.
+        chunk_size: Maximum tokens per child chunk.
+        overlap_ratio: Fractional overlap between adjacent children
+            (e.g. 0.15 = 15%).
+
+    Returns:
+        A list of ``ChildSplit`` instances ordered by position.
+
+    Raises:
+        ValueError: If ``text`` is empty.
+    """
+    if not text:
+        raise ValueError("text cannot be empty")
+
+    token_count = text_token_count if text_token_count is not None else _count_tokens(text)
+
+    if token_count <= chunk_size:
+        return [ChildSplit(content=text, token_count=token_count, position=0)]
+
+    tokens = text.split()
+    overlap_tokens = round(chunk_size * overlap_ratio)
+    step = max(1, chunk_size - overlap_tokens)
+
+    children: list[ChildSplit] = []
+    start = 0
+    position = 0
+
+    while start < len(tokens):
+        end = min(start + chunk_size, len(tokens))
+        child_tokens = tokens[start:end]
+        child_content = " ".join(child_tokens)
+        child_token_count = len(child_tokens)
+        children.append(
+            ChildSplit(content=child_content, token_count=child_token_count, position=position)
+        )
+        position += 1
+        if end >= len(tokens):
+            break
+        start += step
+
+    return children
+
+
+__all__ = ["ChildSplit", "recursive_fixed_size_split"]

--- a/ingestion/tests/ingestion/test_pipeline.py
+++ b/ingestion/tests/ingestion/test_pipeline.py
@@ -64,12 +64,21 @@ def test_pipeline_happy_path_reaches_ready(
         .all()
     )
     assert len(chunks) >= 1
-    positions = [chunk.position for chunk in chunks]
-    assert positions == sorted(positions)
-    assert positions == list(range(len(chunks)))
+
+    # Parents are NOT embedded; only children are.
+    parents = [c for c in chunks if c.parent_chunk_id is None]
+    children = [c for c in chunks if c.parent_chunk_id is not None]
+    assert len(parents) >= 1
+    assert len(children) >= 1
+    # Parents enumerate at document level; children enumerate within their parent.
+    for p in parents:
+        assert p.position < len(parents)
+    for child in children:
+        assert child.parent_chunk_id is not None
+        assert "child_of" in child.type_metadata
 
     embeddings = test_session.query(Embedding).all()
-    assert len(embeddings) == len(chunks)
+    assert len(embeddings) == len(children)
     for embedding in embeddings:
         assert len(embedding.embedding) == 1536
 
@@ -151,12 +160,18 @@ def test_pipeline_book_happy_path_reaches_ready(
         .all()
     )
     assert len(chunks) >= 1
+    # Parents have original metadata; children inherit with "child_of" key.
     for chunk in chunks:
         assert "chapter" in chunk.type_metadata
         assert isinstance(chunk.type_metadata["chapter"], int)
 
+    children = [c for c in chunks if c.parent_chunk_id is not None]
+    assert len(children) >= 1
+    for child in children:
+        assert "child_of" in child.type_metadata
+
     embeddings = test_session.query(Embedding).all()
-    assert len(embeddings) == len(chunks)
+    assert len(embeddings) == len(children)
 
 
 def test_pipeline_documentation_happy_path_reaches_ready(
@@ -202,6 +217,11 @@ def test_pipeline_documentation_happy_path_reaches_ready(
     for chunk in chunks:
         assert "page" in chunk.type_metadata
         assert isinstance(chunk.type_metadata["page"], str)
+
+    children = [c for c in chunks if c.parent_chunk_id is not None]
+    assert len(children) >= 1
+    for child in children:
+        assert "child_of" in child.type_metadata
 
 
 def test_reingestion_creates_new_document_id(
@@ -441,3 +461,263 @@ class TestPipelineValidation:
         for chunk in chunks:
             assert "chapter" in chunk.type_metadata
             assert isinstance(chunk.type_metadata["chapter"], int)
+
+
+# ── Parent-child ingestion tests ─────────────────────────────────────
+
+
+class TestParentChildIngestion:
+    """Tests for parent-child chunking in the ingestion pipeline."""
+
+    def test_parents_not_embedded_children_are(
+        self,
+        test_session: Session,
+        fake_embeddings_client: MagicMock,
+        sample_paper_pdf: bytes,
+    ) -> None:
+        """Parent rows are stored without embeddings; children are embedded."""
+        document = Document(
+            title="PC Paper",
+            document_type=DocumentType.PAPER,
+            source_filename="pc.pdf",
+        )
+        test_session.add(document)
+        test_session.flush()
+
+        run_ingestion(
+            pending=PendingIngestion(
+                document_id=document.document_id,
+                title="PC Paper",
+                document_type=DocumentType.PAPER,
+                source_filename="pc.pdf",
+                file_bytes=sample_paper_pdf,
+            ),
+            session=test_session,
+            embeddings_client=fake_embeddings_client,
+            model_name="text-embedding-3-small",
+        )
+
+        test_session.commit()
+        chunks = (
+            test_session.query(Chunk)
+            .filter(Chunk.document_id == document.document_id)
+            .order_by(Chunk.position)
+            .all()
+        )
+        parents = [c for c in chunks if c.parent_chunk_id is None]
+        children = [c for c in chunks if c.parent_chunk_id is not None]
+        assert len(parents) >= 1
+        assert len(children) >= 1
+
+        # Parents should not have embeddings
+        if parents:
+            parent_ids = [p.chunk_id for p in parents]
+            parent_emb_count = (
+                test_session.query(Embedding).filter(Embedding.chunk_id.in_(parent_ids)).count()
+            )
+            assert parent_emb_count == 0
+
+        # All children should have embeddings
+        if children:
+            child_ids = [c.chunk_id for c in children]
+            child_emb_count = (
+                test_session.query(Embedding).filter(Embedding.chunk_id.in_(child_ids)).count()
+            )
+            assert child_emb_count == len(children)
+
+    def test_large_parent_creates_multiple_children(
+        self,
+        test_session: Session,
+        fake_embeddings_client: MagicMock,
+    ) -> None:
+        """A parent >512 tokens produces multiple child chunks."""
+        big_content = "large_parent_child_test_word " * 600
+        document = Document(
+            title="Big Parent",
+            document_type=DocumentType.PAPER,
+            source_filename="big.pdf",
+        )
+        test_session.add(document)
+        test_session.flush()
+
+        with patch("ingestion.pipeline._chunk_document") as mock_chunk:
+            mock_chunk.return_value = [
+                (big_content, {"section": "Test", "subsection": None, "page": 1}, 600),
+            ]
+            run_ingestion(
+                pending=PendingIngestion(
+                    document_id=document.document_id,
+                    title="Big Parent",
+                    document_type=DocumentType.PAPER,
+                    source_filename="big.pdf",
+                    file_bytes=b"fake",
+                ),
+                session=test_session,
+                embeddings_client=fake_embeddings_client,
+                model_name="text-embedding-3-small",
+            )
+
+        test_session.commit()
+        chunks = (
+            test_session.query(Chunk)
+            .filter(Chunk.document_id == document.document_id)
+            .order_by(Chunk.position)
+            .all()
+        )
+        parents = [c for c in chunks if c.parent_chunk_id is None]
+        children = [c for c in chunks if c.parent_chunk_id is not None]
+
+        assert len(parents) == 1
+        assert len(children) >= 2
+        for child in children:
+            assert child.parent_chunk_id == parents[0].chunk_id
+            assert child.type_metadata.get("child_of") == str(parents[0].chunk_id)
+
+    def test_small_parent_produces_one_child(
+        self,
+        test_session: Session,
+        fake_embeddings_client: MagicMock,
+    ) -> None:
+        """A parent ≤512 tokens produces exactly one child (identity split)."""
+        small_content = "small chunk content"
+        document = Document(
+            title="Small Parent",
+            document_type=DocumentType.PAPER,
+            source_filename="small.pdf",
+        )
+        test_session.add(document)
+        test_session.flush()
+
+        with patch("ingestion.pipeline._chunk_document") as mock_chunk:
+            mock_chunk.return_value = [
+                (small_content, {"section": "Intro", "subsection": None, "page": 1}, 3),
+            ]
+            run_ingestion(
+                pending=PendingIngestion(
+                    document_id=document.document_id,
+                    title="Small Parent",
+                    document_type=DocumentType.PAPER,
+                    source_filename="small.pdf",
+                    file_bytes=b"fake",
+                ),
+                session=test_session,
+                embeddings_client=fake_embeddings_client,
+                model_name="text-embedding-3-small",
+            )
+
+        test_session.commit()
+        chunks = (
+            test_session.query(Chunk)
+            .filter(Chunk.document_id == document.document_id)
+            .order_by(Chunk.position)
+            .all()
+        )
+        parents = [c for c in chunks if c.parent_chunk_id is None]
+        children = [c for c in chunks if c.parent_chunk_id is not None]
+
+        assert len(parents) == 1
+        assert len(children) == 1
+        assert children[0].content == small_content
+
+    def test_child_inherits_type_metadata_with_child_of(
+        self,
+        test_session: Session,
+        fake_embeddings_client: MagicMock,
+    ) -> None:
+        """Children inherit type_metadata from parent and add 'child_of' key."""
+        content = "inherit_metadata_test_word " * 400
+        document = Document(
+            title="Inherit Test",
+            document_type=DocumentType.BOOK,
+            source_filename="inherit.pdf",
+        )
+        test_session.add(document)
+        test_session.flush()
+
+        with patch("ingestion.pipeline._chunk_document") as mock_chunk:
+            mock_chunk.return_value = [
+                (content, {"chapter": 5, "heading": "Deep Dive"}, 400),
+            ]
+            run_ingestion(
+                pending=PendingIngestion(
+                    document_id=document.document_id,
+                    title="Inherit Test",
+                    document_type=DocumentType.BOOK,
+                    source_filename="inherit.pdf",
+                    file_bytes=b"fake",
+                ),
+                session=test_session,
+                embeddings_client=fake_embeddings_client,
+                model_name="text-embedding-3-small",
+            )
+
+        test_session.commit()
+        chunks = (
+            test_session.query(Chunk)
+            .filter(Chunk.document_id == document.document_id)
+            .order_by(Chunk.position)
+            .all()
+        )
+        children = [c for c in chunks if c.parent_chunk_id is not None]
+        assert len(children) >= 1
+        for child in children:
+            assert child.type_metadata.get("chapter") == 5
+            assert child.type_metadata.get("heading") == "Deep Dive"
+            assert "child_of" in child.type_metadata
+            child_of_val = child.type_metadata["child_of"]
+            assert isinstance(child_of_val, str)
+            assert len(child_of_val) > 0
+
+    def test_positions_enumerate_within_parent(
+        self,
+        test_session: Session,
+        fake_embeddings_client: MagicMock,
+    ) -> None:
+        """Children enumerate position within their parent; parents enumerate at document level."""
+        content_a = "position_test_word_a " * 400
+        content_b = "position_test_word_b " * 400
+        document = Document(
+            title="Position Test",
+            document_type=DocumentType.PAPER,
+            source_filename="pos.pdf",
+        )
+        test_session.add(document)
+        test_session.flush()
+
+        with patch("ingestion.pipeline._chunk_document") as mock_chunk:
+            mock_chunk.return_value = [
+                (content_a, {"section": "A", "subsection": None, "page": 1}, 400),
+                (content_b, {"section": "B", "subsection": None, "page": 2}, 400),
+            ]
+            run_ingestion(
+                pending=PendingIngestion(
+                    document_id=document.document_id,
+                    title="Position Test",
+                    document_type=DocumentType.PAPER,
+                    source_filename="pos.pdf",
+                    file_bytes=b"fake",
+                ),
+                session=test_session,
+                embeddings_client=fake_embeddings_client,
+                model_name="text-embedding-3-small",
+            )
+
+        test_session.commit()
+        chunks = (
+            test_session.query(Chunk)
+            .filter(Chunk.document_id == document.document_id)
+            .order_by(Chunk.position)
+            .all()
+        )
+        parents = [c for c in chunks if c.parent_chunk_id is None]
+        # Parents enumerate at document level
+        for i, p in enumerate(parents):
+            assert p.position == i, f"Parent at index {i} has position {p.position}"
+
+        # Children enumerate within their parent
+        for parent in parents:
+            parent_children = [c for c in chunks if c.parent_chunk_id == parent.chunk_id]
+            for i, child in enumerate(parent_children):
+                assert child.position == i, (
+                    f"Child at index {i} of parent {parent.chunk_id} has position {child.position}"
+                )

--- a/ingestion/tests/ingestion/test_splitting.py
+++ b/ingestion/tests/ingestion/test_splitting.py
@@ -1,0 +1,107 @@
+"""Tests for the recursive fixed-size text splitter."""
+
+from ingestion.splitting import recursive_fixed_size_split
+
+
+def test_identity_split_when_under_limit() -> None:
+    """A parent ≤512 tokens produces exactly one child (identity split)."""
+    content = "small chunk"
+    parent_token_count = 2
+    result = recursive_fixed_size_split(content, parent_token_count)
+    assert len(result) == 1
+    assert result[0].content == content
+    assert result[0].token_count == 2
+    assert result[0].position == 0
+
+
+def test_identity_split_at_exact_limit() -> None:
+    """A parent at exactly 512 tokens produces exactly one child."""
+    tokens = ["token"] * 512
+    content = " ".join(tokens)
+    result = recursive_fixed_size_split(content, 512)
+    assert len(result) == 1
+    assert result[0].position == 0
+
+
+def test_splits_into_multiple_children() -> None:
+    """A parent >512 tokens produces multiple child chunks."""
+    tokens = ["token"] * 1200
+    content = " ".join(tokens)
+    result = recursive_fixed_size_split(content, 1200)
+    assert len(result) >= 2
+
+
+def test_each_child_within_token_limit() -> None:
+    """Each child chunk is ≤512 tokens."""
+    tokens = ["token"] * 2000
+    content = " ".join(tokens)
+    result = recursive_fixed_size_split(content, 2000)
+    for child in result:
+        assert child.token_count <= 512, f"Child has {child.token_count} tokens, exceeds 512"
+
+
+def test_overlapping_boundary_content() -> None:
+    """Adjacent children share overlapping content."""
+    tokens = [f"word{i}" for i in range(1500)]
+    content = " ".join(tokens)
+    result = recursive_fixed_size_split(content, 1500)
+
+    # Adjacent children should share some tokens
+    for i in range(len(result) - 1):
+        current_tokens = set(result[i].content.split())
+        next_tokens = set(result[i + 1].content.split())
+        overlap = current_tokens & next_tokens
+        assert len(overlap) > 0, f"Children {i} and {i + 1} have no overlapping content"
+
+
+def test_position_enumerates_within_parent() -> None:
+    """Child position enumerates from 0 within the parent."""
+    tokens = ["token"] * 2000
+    content = " ".join(tokens)
+    result = recursive_fixed_size_split(content, 2000)
+    for i, child in enumerate(result):
+        assert child.position == i, f"Expected position {i}, got {child.position}"
+
+
+def test_children_ordered_correctly() -> None:
+    """Children are ordered by position, first child starts with parent content."""
+    words = [f"unique_word_{i}" for i in range(600)]
+    content = " ".join(words)
+    result = recursive_fixed_size_split(content, 600)
+    assert len(result) >= 2
+    assert result[0].content.startswith("unique_word_0")
+    assert result[-1].content.endswith("unique_word_599")
+
+
+def test_small_chunk_size() -> None:
+    """Works correctly with very small chunk sizes."""
+    tokens = ["a"] * 50
+    content = " ".join(tokens)
+    result = recursive_fixed_size_split(content, 50, chunk_size=10, overlap_ratio=0.0)
+    assert len(result) == 5
+    for child in result:
+        assert child.token_count <= 10
+
+
+def test_zero_overlap() -> None:
+    """With 0% overlap, children partition the content without sharing."""
+    tokens = [f"w{i}" for i in range(600)]
+    content = " ".join(tokens)
+    result = recursive_fixed_size_split(content, 600, overlap_ratio=0.0)
+    assert len(result) >= 2
+
+
+def test_empty_content_raises() -> None:
+    """Empty content raises ValueError."""
+    import pytest
+
+    with pytest.raises(ValueError, match="cannot be empty"):
+        recursive_fixed_size_split("", 0)
+
+
+def test_single_token() -> None:
+    """A single token produces exactly one child."""
+    result = recursive_fixed_size_split("hello", 1)
+    assert len(result) == 1
+    assert result[0].content == "hello"
+    assert result[0].token_count == 1


### PR DESCRIPTION
Implements issue #100 (1/3 — Parent-child schema + ingestion).

- Chunk ORM model gains parent_chunk_id (self-referential FK, ON DELETE SET NULL) and content_search (tsvector + GIN index)
- Migration edda412e1f07 adds both columns, drops the old document-position unique constraint, and creates the GIN index
- New recursive_fixed_size_split in ingestion/splitting.py splits parent content into 512-token child chunks with 15% contextual overlap
- Ingestion pipeline stores parent rows (not embedded), splits parents into children, embeds only children, and inherits type_metadata with a "child_of" lineage key
- Child position enumerates within parent (per spec); parents enumerate at document level