### PR TITLE
feat(retrieval-qa): add hybrid search with sparse tsvector, RRF fusio…

### DIFF
--- a/api/src/api/controllers/qa_controller.py
+++ b/api/src/api/controllers/qa_controller.py
@@ -63,6 +63,7 @@ def run_query(
         query_vector=query_vector,
         session=session,
         config=config,
+        query_text=query,
     )
 
     messages = build_messages(query, chunks)

--- a/core/src/core/types/retrieval_config.py
+++ b/core/src/core/types/retrieval_config.py
@@ -18,6 +18,10 @@ class RetrievalConfig(BaseModel):
             ``embeddings.model_name``).
         ef_search: HNSW query-time candidate-list size (``hnsw.ef_search``).
         top_k: Maximum number of chunks to return.
+        hybrid_search: When True (default), combine dense (pgvector cosine)
+            and sparse (tsvector ts_rank) results via Reciprocal Rank Fusion
+            and perform parent-swap before returning (ADR-0016).
+            When False, fall back to dense-only retrieval.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -25,6 +29,7 @@ class RetrievalConfig(BaseModel):
     model_name: str
     ef_search: int
     top_k: int
+    hybrid_search: bool = True
 
 
 __all__ = ["RetrievalConfig"]

--- a/retrieval_qa/src/retrieval_qa/retrieval/query.py
+++ b/retrieval_qa/src/retrieval_qa/retrieval/query.py
@@ -15,9 +15,25 @@ Implements the retrieval half of Harness A's RAG pipeline (ADR-0014):
   and ``chunk_id`` (for ``CitedPassage.chunk_id``) in the same query — no
   second round-trip, since the chunk content is already needed for the prompt.
 
-The cosine distance operator ``<=>`` matches the HNSW index's
-``vector_cosine_ops`` opclass declared in the Alembic migration (ADR-0014).
+When ``RetrievalConfig.hybrid_search`` is True (default, ADR-0016):
+
+- A parallel sparse search via ``to_tsvector`` / ``websearch_to_tsquery`` on
+  chunk content recovers exact-match queries (function names, API endpoints,
+  error codes) that pure dense retrieval misses.
+- Dense and sparse results are fused via Reciprocal Rank Fusion (RRF) with
+  k=60, producing a single ranked set with no duplicates.
+- After fusion, matched child chunks are swapped to their parent chunks
+  (parent-swap): the parent's content replaces the child's in the cited
+  passage, and duplicate parents are deduplicated.
+- When one path returns zero results, the other path's results alone still
+  produce output (graceful degradation).
+
+When ``hybrid_search`` is False, retrieval falls back to dense-only
+(existing behavior).
 """
+
+from collections import OrderedDict
+from uuid import UUID
 
 from sqlalchemy import text
 from sqlalchemy.exc import InterfaceError, OperationalError
@@ -27,10 +43,10 @@ from core.exceptions import UpstreamUnavailable
 from core.types.responses import CitedPassage
 from core.types.retrieval_config import RetrievalConfig
 
-_RETRIEVE_SQL = text(
-    """
-    SET LOCAL hnsw.ef_search = :ef_search;
+_RRF_K = 60
 
+_DENSE_SQL = text(
+    """
     SELECT
         chunks.chunk_id AS chunk_id,
         chunks.content  AS text
@@ -44,27 +60,197 @@ _RETRIEVE_SQL = text(
     """
 )
 
+_SPARSE_SQL = text(
+    """
+    SELECT
+        chunks.chunk_id AS chunk_id,
+        chunks.content  AS text,
+        ts_rank(
+            to_tsvector('english', chunks.content),
+            websearch_to_tsquery('english', :query_text)
+        ) AS rank
+    FROM chunks
+    JOIN documents ON documents.document_id = chunks.document_id
+    WHERE documents.status = 'ready'
+      AND to_tsvector('english', chunks.content)
+          @@ websearch_to_tsquery('english', :query_text)
+    ORDER BY rank DESC
+    LIMIT :top_k
+    """
+)
+
+_PARENT_SWAP_SQL = text(
+    """
+    SELECT
+        children.chunk_id       AS child_chunk_id,
+        COALESCE(parents.chunk_id, children.chunk_id) AS chunk_id,
+        COALESCE(parents.content, children.content)   AS text
+    FROM chunks children
+    LEFT JOIN chunks parents ON children.parent_chunk_id = parents.chunk_id
+    WHERE children.chunk_id IN :chunk_ids
+    """
+)
+
+
+def _dense_retrieve(
+    session: Session,
+    query_vector: list[float],
+    config: RetrievalConfig,
+) -> OrderedDict[UUID, float]:
+    """Run dense (pgvector cosine) search and return chunk_id -> RRF score."""
+    result = session.execute(
+        _DENSE_SQL,
+        {
+            "model_name": config.model_name,
+            "query_vector": str(query_vector),
+            "top_k": config.top_k,
+        },
+    )
+    scored: OrderedDict[UUID, float] = OrderedDict()
+    for rank, row in enumerate(result.fetchall(), 1):
+        chunk_id = row._mapping["chunk_id"]
+        scored[chunk_id] = 1.0 / (_RRF_K + rank)
+    return scored
+
+
+def _sparse_retrieve(
+    session: Session,
+    query_text: str,
+    config: RetrievalConfig,
+) -> OrderedDict[UUID, float]:
+    """Run sparse (tsvector ts_rank) search and return chunk_id -> RRF score."""
+    result = session.execute(
+        _SPARSE_SQL,
+        {
+            "query_text": query_text,
+            "top_k": config.top_k,
+        },
+    )
+    scored: OrderedDict[UUID, float] = OrderedDict()
+    for rank, row in enumerate(result.fetchall(), 1):
+        chunk_id = row._mapping["chunk_id"]
+        scored[chunk_id] = 1.0 / (_RRF_K + rank)
+    return scored
+
+
+def _rrf_fuse(
+    dense_scored: OrderedDict[UUID, float],
+    sparse_scored: OrderedDict[UUID, float],
+    top_k: int,
+) -> OrderedDict[UUID, float]:
+    """Fuse dense and sparse scores via Reciprocal Rank Fusion.
+
+    When one path returns zero results, the other path's results alone produce
+    the output (graceful degradation). Duplicate chunk_ids (present in both
+    paths) receive a combined score.
+
+    Args:
+        dense_scored: chunk_id -> RRF score from dense path.
+        sparse_scored: chunk_id -> RRF score from sparse path.
+        top_k: Maximum number of fused results to return.
+
+    Returns:
+        An OrderedDict of chunk_id -> combined RRF score, sorted descending
+        by score and limited to top_k.
+    """
+    combined: dict[UUID, float] = {}
+
+    for chunk_id, score in dense_scored.items():
+        combined[chunk_id] = combined.get(chunk_id, 0.0) + score
+    for chunk_id, score in sparse_scored.items():
+        combined[chunk_id] = combined.get(chunk_id, 0.0) + score
+
+    sorted_pairs = sorted(combined.items(), key=lambda item: item[1], reverse=True)
+    return OrderedDict(sorted_pairs[:top_k])
+
+
+def _parent_swap(
+    session: Session,
+    scored_chunks: OrderedDict[UUID, float],
+) -> list[CitedPassage]:
+    """Swap matched child chunks to their parents and deduplicate.
+
+    For each chunk in scored_chunks (ordered by descending RRF score),
+    resolve its parent. If the chunk has a parent, use the parent's content
+    and chunk_id. If multiple children belong to the same parent, only the
+    highest-scoring child is retained.
+
+    Chunks that are themselves parents (``parent_chunk_id IS NULL``) are
+    returned as-is.
+
+    Args:
+        session: SQLAlchemy session.
+        scored_chunks: chunk_id -> RRF score, ordered descending by score.
+
+    Returns:
+        A deduplicated list of CitedPassage instances preserving RRF rank order.
+    """
+    if not scored_chunks:
+        return []
+
+    chunk_ids = tuple(scored_chunks.keys())
+    result = session.execute(
+        _PARENT_SWAP_SQL,
+        {"chunk_ids": chunk_ids},
+    )
+
+    # Build child -> (parent_chunk_id, parent_text) map
+    child_to_parent: dict[UUID, tuple[UUID, str]] = {}
+    for row in result.fetchall():
+        child_id = row._mapping["child_chunk_id"]
+        parent_id = row._mapping["chunk_id"]
+        parent_text = row._mapping["text"]
+        child_to_parent[child_id] = (parent_id, parent_text)
+
+    # Walk the scored chunks in RRF rank order, deduplicating by parent
+    seen_parents: set[UUID] = set()
+    passages: list[CitedPassage] = []
+
+    for child_chunk_id in scored_chunks:
+        parent_info = child_to_parent.get(child_chunk_id)
+        if parent_info is None:
+            continue
+        parent_id, parent_text = parent_info
+
+        if parent_id in seen_parents:
+            continue
+        seen_parents.add(parent_id)
+
+        passages.append(CitedPassage(chunk_id=parent_id, text=parent_text))
+
+    return passages
+
 
 def retrieve_relevant_chunks(
     *,
     query_vector: list[float],
     session: Session,
     config: RetrievalConfig,
+    query_text: str | None = None,
 ) -> list[CitedPassage]:
     """Retrieve the top-k closest chunks for ``query_vector`` by cosine distance.
 
     Issues ``SET LOCAL hnsw.ef_search`` inside the caller's transaction and
     returns chunks only from documents whose status is ``ready``.
 
+    When ``config.hybrid_search`` is True (default), also runs a sparse
+    tsvector search against chunk content and fuses results via Reciprocal
+    Rank Fusion, then performs parent-swap to replace matched child chunks
+    with their enclosing parent chunks (ADR-0016).
+
     Args:
         query_vector: A 1536-dim query embedding.
         session: SQLAlchemy session bound to the documents database. The
             ``SET LOCAL`` is scoped to the current transaction, so callers
             should not commit before consuming the results.
-        config: Retrieval configuration (model name, ef_search, top_k).
+        config: Retrieval configuration (model name, ef_search, top_k,
+            hybrid_search toggle).
+        query_text: The original user query string, required for the sparse
+            search path when ``config.hybrid_search`` is True. Ignored when
+            hybrid_search is False.
 
     Returns:
-        Chunks in ascending cosine-distance order. An empty list signals the
+        Chunks in descending relevance order. An empty list signals the
         not-found case (empty corpus or no relevant chunks), which is a valid
         response per ADR-0009 — never raised as an exception.
 
@@ -74,24 +260,34 @@ def retrieve_relevant_chunks(
             dimension mismatch from a bad query vector) propagate verbatim.
     """
     try:
-        result = session.execute(
-            _RETRIEVE_SQL,
+        session.execute(
+            text("SET LOCAL hnsw.ef_search = :ef_search"), {"ef_search": config.ef_search}
+        )
+
+        if config.hybrid_search and query_text:
+            dense_scored = _dense_retrieve(session, query_vector, config)
+            sparse_scored = _sparse_retrieve(session, query_text, config)
+            fused = _rrf_fuse(dense_scored, sparse_scored, config.top_k)
+            return _parent_swap(session, fused)
+
+        # Dense-only path (hybrid_search=False or no query_text provided)
+        rows = session.execute(
+            _DENSE_SQL,
             {
-                "ef_search": config.ef_search,
                 "model_name": config.model_name,
                 "query_vector": str(query_vector),
                 "top_k": config.top_k,
             },
         )
+        chunks: list[CitedPassage] = []
+        for row in rows.fetchall():
+            chunk_id = row._mapping["chunk_id"]
+            text_content = row._mapping["text"]
+            chunks.append(CitedPassage(chunk_id=chunk_id, text=text_content))
+        return chunks
+
     except (OperationalError, InterfaceError) as exc:
         raise UpstreamUnavailable(f"Database unreachable: {exc}") from exc
-    rows = result.fetchall()
-    chunks: list[CitedPassage] = []
-    for row in rows:
-        chunk_id = row._mapping["chunk_id"]
-        text_content = row._mapping["text"]
-        chunks.append(CitedPassage(chunk_id=chunk_id, text=text_content))
-    return chunks
 
 
 __all__ = ["CitedPassage", "retrieve_relevant_chunks"]

--- a/retrieval_qa/tests/retrieval_qa/retrieval/test_query.py
+++ b/retrieval_qa/tests/retrieval_qa/retrieval/test_query.py
@@ -48,6 +48,60 @@ def _seed_paper(
     return document
 
 
+def _seed_parent_child_paper(
+    session: Session,
+    *,
+    title: str = "Parent-Child Paper",
+    parent_content: str,
+    child_contents: list[str],
+    vectors: list[list[float]],
+) -> tuple[Document, Chunk, list[Chunk]]:
+    """Seed a document with one parent and several embedded children.
+
+    Returns (document, parent_row, child_rows).
+    """
+    document = Document(
+        title=title,
+        document_type=DocumentType.PAPER,
+        source_filename=f"{title}.pdf",
+        status=DocumentStatus.READY,
+    )
+    session.add(document)
+    session.flush()
+
+    parent = Chunk(
+        document_id=document.document_id,
+        position=0,
+        content=parent_content,
+        token_count=max(1, len(parent_content.split())),
+        parent_chunk_id=None,
+    )
+    session.add(parent)
+    session.flush()
+
+    children: list[Chunk] = []
+    for position, (content, vector) in enumerate(zip(child_contents, vectors, strict=True)):
+        child = Chunk(
+            document_id=document.document_id,
+            position=position + 1,
+            content=content,
+            token_count=max(1, len(content.split())),
+            parent_chunk_id=parent.chunk_id,
+        )
+        session.add(child)
+        session.flush()
+        session.add(
+            Embedding(
+                chunk_id=child.chunk_id,
+                model_name="text-embedding-3-small",
+                embedding=vector,
+            )
+        )
+        children.append(child)
+
+    return document, parent, children
+
+
 def test_retrieve_returns_closest_chunks_by_cosine(test_session: Session) -> None:
     """The closest chunks by cosine distance are returned in ascending order."""
     near = [1.0] + [0.0] * 1535
@@ -263,3 +317,331 @@ def test_retrieve_wraps_db_connection_error_as_upstream_unavailable() -> None:
             session=fake_session,
             config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=1),
         )
+
+
+# ── Hybrid search tests ──────────────────────────────────────────────────────
+
+
+def test_hybrid_dense_only_when_no_query_text_falls_back_to_dense(
+    test_session: Session,
+) -> None:
+    """When query_text is None, hybrid search falls back to dense-only."""
+    vector = [0.5] * 1536
+    _seed_paper(
+        test_session,
+        title="Test",
+        chunks=[("dense match", vector, "dense")],
+    )
+    test_session.commit()
+
+    results = retrieve_relevant_chunks(
+        query_vector=vector,
+        session=test_session,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
+        query_text=None,
+    )
+
+    assert len(results) == 1
+    assert results[0].text == "dense match"
+
+
+def test_hybrid_search_false_falls_back_to_dense_only(
+    test_session: Session,
+) -> None:
+    """Setting hybrid_search=False uses dense-only retrieval."""
+    vector = [0.5] * 1536
+    _seed_paper(
+        test_session,
+        title="Test",
+        chunks=[("dense only", vector, "dense")],
+    )
+    test_session.commit()
+
+    results = retrieve_relevant_chunks(
+        query_vector=vector,
+        session=test_session,
+        config=RetrievalConfig(
+            model_name="text-embedding-3-small",
+            ef_search=40,
+            top_k=5,
+            hybrid_search=False,
+        ),
+        query_text="some query that would match via sparse if enabled",
+    )
+
+    assert len(results) == 1
+    assert results[0].text == "dense only"
+
+
+def test_sparse_only_matches_exact_keyword_not_in_embedding_space(
+    test_session: Session,
+) -> None:
+    """A query matching only via sparse tsvector still returns the chunk.
+
+    The dense path gets no meaningful match (all vectors are far from
+    the query), but the sparse path finds the exact keyword.
+    """
+    dense_near = [1.0] + [0.0] * 1535
+    dense_far = [-1.0] + [0.0] * 1535
+
+    _seed_paper(
+        test_session,
+        title="Mixed",
+        chunks=[
+            ("semantic content about machine learning topics", dense_near, "near"),
+            ("git checkout --orphan creates a new branch without history", dense_far, "far"),
+        ],
+    )
+    test_session.commit()
+
+    results = retrieve_relevant_chunks(
+        query_vector=dense_near,
+        session=test_session,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
+        query_text="checkout orphan",
+    )
+
+    assert len(results) >= 1
+    texts = [r.text for r in results]
+    assert any("checkout" in t for t in texts)
+
+
+def test_sparse_path_graceful_degradation_when_no_text_matches(
+    test_session: Session,
+) -> None:
+    """When the sparse path finds nothing, dense results still come through."""
+    vector = [0.5] * 1536
+    _seed_paper(
+        test_session,
+        title="Dense",
+        chunks=[("dense result text", vector, "d")],
+    )
+    test_session.commit()
+
+    results = retrieve_relevant_chunks(
+        query_vector=vector,
+        session=test_session,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
+        query_text="xyznonexistentkeyword12345",
+    )
+
+    assert len(results) == 1
+    assert results[0].text == "dense result text"
+
+
+def test_sparse_only_finds_result_when_dense_returns_empty(
+    test_session: Session,
+) -> None:
+    """When the dense path returns empty (no embeddings for model_name),
+    the sparse path alone still produces output.
+    """
+    vector = [0.5] * 1536
+    _seed_paper(
+        test_session,
+        title="Sparse Only",
+        chunks=[("unique sparse keyword zxcvbnm", vector, "sparse")],
+    )
+    test_session.commit()
+
+    results = retrieve_relevant_chunks(
+        query_vector=[-1.0] * 1536,  # far from all chunks
+        session=test_session,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
+        query_text="zxcvbnm",
+    )
+
+    # Sparse should find the keyword even though the dense vector is far
+    assert len(results) >= 1
+    assert any("zxcvbnm" in r.text for r in results)
+
+
+def test_parent_swap_replaces_child_content_with_parent_content(
+    test_session: Session,
+) -> None:
+    """After hybrid retrieval, matched child chunks are swapped to parents."""
+    parent_text = "This is the full parent section about vector databases."
+    child_text = "vector databases store high-dimensional embeddings"
+    vector = [0.5] * 1536
+
+    _, parent, _ = _seed_parent_child_paper(
+        test_session,
+        parent_content=parent_text,
+        child_contents=[child_text],
+        vectors=[vector],
+    )
+    test_session.commit()
+
+    results = retrieve_relevant_chunks(
+        query_vector=vector,
+        session=test_session,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
+        query_text="vector databases embeddings",
+    )
+
+    assert len(results) == 1
+    assert results[0].text == parent_text
+    assert results[0].chunk_id == parent.chunk_id
+
+
+def test_parent_swap_deduplicates_multiple_children_of_same_parent(
+    test_session: Session,
+) -> None:
+    """When two children of the same parent match, only one parent result is
+    returned (deduplication by parent).
+    """
+    parent_text = "Kubernetes orchestrates container deployments across clusters."
+    child1 = "Kubernetes pods are the smallest deployable units in a cluster"
+    child2 = "Kubernetes deployments manage the lifecycle of pods"
+    vector = [0.5] * 1536
+
+    _, parent, _ = _seed_parent_child_paper(
+        test_session,
+        parent_content=parent_text,
+        child_contents=[child1, child2],
+        vectors=[vector, vector],
+    )
+    test_session.commit()
+
+    results = retrieve_relevant_chunks(
+        query_vector=vector,
+        session=test_session,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
+        query_text="Kubernetes pods",
+    )
+
+    assert len(results) == 1
+    assert results[0].chunk_id == parent.chunk_id
+    assert results[0].text == parent_text
+
+
+def test_parent_swap_returns_standalone_chunks_without_parents_as_is(
+    test_session: Session,
+) -> None:
+    """Chunks that have no parent (parent_chunk_id IS NULL) are returned as-is,
+    without being swapped or dropped.
+    """
+    vector = [0.5] * 1536
+    content = "standalone chunk without a parent"
+    _seed_paper(
+        test_session,
+        title="Standalone",
+        chunks=[(content, vector, "solo")],
+    )
+    test_session.commit()
+
+    results = retrieve_relevant_chunks(
+        query_vector=vector,
+        session=test_session,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
+        query_text="standalone chunk",
+    )
+
+    assert len(results) == 1
+    assert results[0].text == content
+
+
+def test_hybrid_rrf_fusion_combines_dense_and_sparse_without_duplicates(
+    test_session: Session,
+) -> None:
+    """RRF fusion produces a single ranked set with no duplicate entries."""
+    vector = [0.5] * 1536
+
+    # Same content so both dense and sparse paths find the same chunk
+    content = "postgresql and pgvector are used for vector similarity search"
+    _seed_paper(
+        test_session,
+        title="Hybrid",
+        chunks=[(content, vector, "h")],
+    )
+    test_session.commit()
+
+    results = retrieve_relevant_chunks(
+        query_vector=vector,
+        session=test_session,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
+        query_text="pgvector",
+    )
+
+    assert len(results) == 1
+    assert results[0].text == content
+
+
+def test_hybrid_search_respects_top_k_limit(test_session: Session) -> None:
+    """Hybrid search with RRF fusion respects the top_k limit."""
+    vector = [0.5] * 1536
+
+    _seed_paper(
+        test_session,
+        title="Many",
+        chunks=[(f"chunk {i} with unique word zeta{i}", vector, f"c{i}") for i in range(5)],
+    )
+    test_session.commit()
+
+    results = retrieve_relevant_chunks(
+        query_vector=vector,
+        session=test_session,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=3),
+        query_text="zeta",
+    )
+
+    assert len(results) <= 3
+
+
+def test_hybrid_search_returns_empty_list_when_no_results_from_either_path(
+    test_session: Session,
+) -> None:
+    """When neither dense nor sparse paths find results, return empty list."""
+    vector = [0.5] * 1536
+    _seed_paper(
+        test_session,
+        title="Present",
+        chunks=[("some content", vector, "c1")],
+    )
+    test_session.commit()
+
+    results = retrieve_relevant_chunks(
+        query_vector=vector,
+        session=test_session,
+        config=RetrievalConfig(
+            model_name="some-other-model",  # dense: no embeddings under this model
+            ef_search=40,
+            top_k=5,
+        ),
+        query_text="xyznonexistentkeyword12345",  # sparse: no text match
+    )
+
+    assert results == []
+
+
+def test_sparse_only_parent_swap_returns_parent_content(
+    test_session: Session,
+) -> None:
+    """A query that matches only via sparse path returns the parent's content.
+
+    The dense vector is far from the child's embedding, but the exact
+    keyword in the sparse path recovers the match, and parent-swap
+    replaces the child with the parent.
+    """
+    parent_text = "PostgreSQL full-text search with tsvector and tsquery."
+    child_text = "pgvector and HNSW indexing for ANN search on embedding vectors."
+    far_vector = [-1.0] * 1536  # far from child's embedding
+    child_vector = [0.5] * 1536
+
+    _, parent, _ = _seed_parent_child_paper(
+        test_session,
+        parent_content=parent_text,
+        child_contents=[child_text],
+        vectors=[child_vector],
+    )
+    test_session.commit()
+
+    results = retrieve_relevant_chunks(
+        query_vector=far_vector,  # dense path won't find this close
+        session=test_session,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
+        query_text="pgvector",
+    )
+
+    assert len(results) == 1
+    assert results[0].chunk_id == parent.chunk_id
+    assert results[0].text == parent_text


### PR DESCRIPTION
…n, and parent-swap

- Add hybrid_search toggle (default True) to RetrievalConfig
- Implement parallel sparse search via to_tsvector + websearch_to_tsquery
- Fuse dense and sparse results via Reciprocal Rank Fusion (RRF, k=60)
- Perform parent-swap: replace matched child chunks with parent content
- Deduplicate children of the same parent, keeping highest RRF score
- Graceful degradation: when one path returns zero, the other still works
- When hybrid_search=False or query_text is None, fall back to dense-only
- Add 11 tests covering all acceptance criteria and edge cases

Closes #101