### PR TITLE
feat(retrieval-qa): add cross-encoder reranking with Cohere Rerank an…

### DIFF
--- a/api/src/api/controllers/qa_controller.py
+++ b/api/src/api/controllers/qa_controller.py
@@ -15,12 +15,15 @@ Upstream failures (embeddings or inference) propagate
 ``UpstreamBadResponse`` / ``UpstreamUnavailable`` for the route layer to map
 to 502 / 503 (ADR-0014 § Error contract). DB-level failures propagate
 verbatim; the route's catch-all maps them to 500.
+
+Reranker rate-limit errors are handled in the retrieval layer — logged and
+fall back to RRF top-k, so they never reach this controller as an exception.
 """
 
 from sqlalchemy.orm import Session
 
 from api.prompt import build_messages
-from core.clients import CompletionProvider, Embedder
+from core.clients import CompletionProvider, Embedder, Reranker
 from core.types.responses import HarnessAResponse
 from core.types.retrieval_config import RetrievalConfig
 from retrieval_qa.retrieval.query import retrieve_relevant_chunks
@@ -33,6 +36,7 @@ def run_query(
     embeddings_client: Embedder,
     llm_client: CompletionProvider,
     config: RetrievalConfig,
+    reranker: Reranker | None = None,
 ) -> HarnessAResponse:
     """Run the full Harness A query flow and return a ``HarnessAResponse``.
 
@@ -43,7 +47,11 @@ def run_query(
             session's transaction.
         embeddings_client: Provider used to embed the query (1536-dim).
         llm_client: Provider used to generate the answer.
-        config: Retrieval configuration (model name, ef_search, top_k).
+        config: Retrieval configuration (model name, ef_search, top_k,
+            hybrid_search toggle, reranker toggle).
+        reranker: Reranker instance for cross-encoder reranking. When None
+            or when ``config.reranker`` is False, the RRF top-k is used
+            directly.
 
     Returns:
         A ``HarnessAResponse`` with ``answer`` always populated,
@@ -64,6 +72,7 @@ def run_query(
         session=session,
         config=config,
         query_text=query,
+        reranker=reranker,
     )
 
     messages = build_messages(query, chunks)

--- a/api/src/api/dependencies.py
+++ b/api/src/api/dependencies.py
@@ -1,15 +1,18 @@
 """FastAPI dependency providers.
 
 Factories here let route handlers depend on protocols (``Embedder``,
-``CompletionProvider``) rather than concrete clients, following the dependency
-inversion principle (ADR-0011, SOLID review).
+``CompletionProvider``, ``Reranker``) rather than concrete clients, following
+the dependency inversion principle (ADR-0011, SOLID review).
 """
 
 from core.clients import (
+    CohereReranker,
     CompletionProvider,
     Embedder,
     EmbeddingsClient,
     LLMClient,
+    NoopReranker,
+    Reranker,
 )
 from core.config.settings import settings
 
@@ -30,4 +33,18 @@ def get_completion_provider() -> CompletionProvider:
     )
 
 
-__all__ = ["get_completion_provider", "get_embedder"]
+def get_reranker() -> Reranker:
+    """Return the configured synchronous reranker.
+
+    Returns ``NoopReranker`` when ``cohere_api_key`` is not configured,
+    allowing the system to run without a Cohere API key during development.
+    """
+    if settings.cohere_api_key:
+        return CohereReranker(
+            api_key=settings.cohere_api_key,
+            model=settings.reranker_model,
+        )
+    return NoopReranker()
+
+
+__all__ = ["get_completion_provider", "get_embedder", "get_reranker"]

--- a/api/src/api/routes/retrieval_qa.py
+++ b/api/src/api/routes/retrieval_qa.py
@@ -5,8 +5,8 @@ from typing import Annotated
 from fastapi import APIRouter, Depends
 
 from api.controllers.qa_controller import run_query
-from api.dependencies import get_completion_provider, get_embedder
-from core.clients import CompletionProvider, Embedder
+from api.dependencies import get_completion_provider, get_embedder, get_reranker
+from core.clients import CompletionProvider, Embedder, Reranker
 from core.config.settings import settings
 from core.database.connection import db_session
 from core.types.responses import HarnessARequest, HarnessAResponse
@@ -20,6 +20,7 @@ def query(
     body: HarnessARequest,
     embeddings_client: Annotated[Embedder, Depends(get_embedder)],
     llm_client: Annotated[CompletionProvider, Depends(get_completion_provider)],
+    reranker: Annotated[Reranker, Depends(get_reranker)],
 ) -> HarnessAResponse:
     """Answer a query against the ingested corpus.
 
@@ -40,4 +41,5 @@ def query(
                 ef_search=settings.hnsw_ef_search,
                 top_k=settings.query_top_k,
             ),
+            reranker=reranker,
         )

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -14,9 +14,9 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from api.dependencies import get_completion_provider, get_embedder
+from api.dependencies import get_completion_provider, get_embedder, get_reranker
 from api.server import create_app
-from core.clients import InMemoryEmbedder, MockCompletionProvider
+from core.clients import InMemoryEmbedder, MockCompletionProvider, NoopReranker
 
 IngestADocument = Callable[[str], str]
 
@@ -86,6 +86,7 @@ def client(override_route_db_session: object, monkeypatch: pytest.MonkeyPatch) -
     app = create_app()
     app.dependency_overrides[get_embedder] = _default_fake_embedder
     app.dependency_overrides[get_completion_provider] = _default_fake_llm_refusal_provider
+    app.dependency_overrides[get_reranker] = lambda: NoopReranker()
     return TestClient(app)
 
 
@@ -118,6 +119,7 @@ def mock_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     app = create_app()
     app.dependency_overrides[get_embedder] = _default_fake_embedder
     app.dependency_overrides[get_completion_provider] = _default_fake_llm_refusal_provider
+    app.dependency_overrides[get_reranker] = lambda: NoopReranker()
     return TestClient(app)
 
 

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "psycopg2-binary>=2.9",
     "openai>=2.46.0",
     "uuid-utils>=0.10",
+    "cohere>=5.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/core/src/core/clients/__init__.py
+++ b/core/src/core/clients/__init__.py
@@ -10,12 +10,20 @@ from core.clients.llm_client import (
     LLMClient,
     MockCompletionProvider,
 )
+from core.clients.reranker_client import (
+    CohereReranker,
+    NoopReranker,
+    Reranker,
+)
 
 __all__ = [
+    "CohereReranker",
     "CompletionProvider",
     "Embedder",
     "EmbeddingsClient",
     "InMemoryEmbedder",
     "LLMClient",
     "MockCompletionProvider",
+    "NoopReranker",
+    "Reranker",
 ]

--- a/core/src/core/clients/reranker_client.py
+++ b/core/src/core/clients/reranker_client.py
@@ -1,0 +1,160 @@
+"""Client for the Cohere Rerank API.
+
+Provides a swappable ``Reranker`` protocol, a ``CohereReranker`` that calls
+the Cohere Rerank API, and a ``NoopReranker`` that returns passages unchanged.
+"""
+
+from typing import Protocol, runtime_checkable
+
+import cohere
+
+from core.config.settings import settings
+from core.exceptions import RerankerRateLimitError, UpstreamBadResponse, UpstreamUnavailable
+from core.types.responses import CitedPassage
+
+
+@runtime_checkable
+class Reranker(Protocol):
+    """Protocol for synchronous passage reranking providers.
+
+    Consumers depend on this protocol rather than a concrete client so that
+    hosted API clients, noop test doubles, and future provider implementations
+    are interchangeable.
+    """
+
+    def rerank(
+        self,
+        query: str,
+        passages: list[CitedPassage],
+        top_k: int,
+    ) -> list[CitedPassage]:
+        """Rerank passages by relevance to the query and return the top-k.
+
+        Args:
+            query: The user's original query string.
+            passages: Candidate passages to rerank.
+            top_k: Maximum number of passages to return.
+
+        Returns:
+            The top_k passages in descending relevance order.
+        """
+        ...
+
+
+class CohereReranker:
+    """Reranker backed by the Cohere Rerank API.
+
+    Calls the Cohere Rerank endpoint with the query and passage texts, then
+    returns the top_k passages in reranked order.
+
+    Rate-limit errors surface as ``RerankerRateLimitError`` so the caller
+    can fall back to RRF top-k without crashing (ADR-0016).
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str | None = None,
+    ) -> None:
+        """Initialize the reranker.
+
+        Args:
+            api_key: Cohere API key. Defaults to ``settings.cohere_api_key``.
+            model: Rerank model ID. Defaults to ``settings.reranker_model``.
+        """
+        self._model = model or settings.reranker_model
+        self._api_key = api_key or settings.cohere_api_key
+        self._client: cohere.ClientV2 | None = None
+
+    def _get_client(self) -> cohere.ClientV2:
+        if self._client is None:
+            if self._api_key is None:
+                raise UpstreamUnavailable("Cohere API key not configured (COHERE_API_KEY)")
+            self._client = cohere.ClientV2(api_key=self._api_key)
+        return self._client
+
+    def rerank(
+        self,
+        query: str,
+        passages: list[CitedPassage],
+        top_k: int,
+    ) -> list[CitedPassage]:
+        """Rerank passages via the Cohere Rerank API and return the top-k.
+
+        Args:
+            query: The user's original query string.
+            passages: Candidate passages to rerank.
+            top_k: Maximum number of passages to return.
+
+        Returns:
+            The top_k passages in descending Cohere relevance order.
+
+        Raises:
+            RerankerRateLimitError: Cohere returned a 429 (rate limit).
+                Caller should fall back to RRF top-k.
+            UpstreamBadResponse: Cohere returned an unexpected response shape
+                or a 4xx/5xx other than 429.
+            UpstreamUnavailable: Cohere could not be reached or timed out.
+        """
+        if not passages:
+            return []
+
+        texts = [p.text for p in passages]
+
+        try:
+            response = self._get_client().rerank(
+                model=self._model,
+                query=query,
+                documents=texts,
+                top_n=min(top_k, len(passages)),
+            )
+        except cohere.errors.TooManyRequestsError as exc:
+            raise RerankerRateLimitError(f"Cohere Rerank rate-limited (429): {exc}") from exc
+        except cohere.core.api_error.ApiError as exc:
+            raise UpstreamBadResponse(f"Cohere Rerank API returned bad status: {exc}") from exc
+        except Exception as exc:
+            raise UpstreamUnavailable(f"Cohere Rerank API unreachable: {exc}") from exc
+
+        try:
+            results = response.results
+        except AttributeError as exc:
+            raise UpstreamBadResponse(
+                f"Cohere Rerank API returned unexpected response shape: {exc}"
+            ) from exc
+
+        reranked: list[CitedPassage] = []
+        for result in results:
+            idx = result.index
+            if 0 <= idx < len(passages):
+                reranked.append(passages[idx])
+
+        return reranked[:top_k]
+
+
+class NoopReranker:
+    """Identity reranker that returns passages unchanged.
+
+    Used when reranking is disabled or for deterministic tests.
+    Implements ``Reranker``.
+    """
+
+    def rerank(
+        self,
+        query: str,
+        passages: list[CitedPassage],
+        top_k: int,
+    ) -> list[CitedPassage]:
+        """Return the first top_k passages unchanged.
+
+        Args:
+            query: Ignored.
+            passages: Candidate passages.
+            top_k: Maximum number of passages to return.
+
+        Returns:
+            The first top_k passages.
+        """
+        return passages[:top_k]
+
+
+__all__ = ["CohereReranker", "NoopReranker", "Reranker"]

--- a/core/src/core/config/settings.py
+++ b/core/src/core/config/settings.py
@@ -40,6 +40,8 @@ class Settings(BaseSettings):
     inference_model: str = "gpt-4o-mini"
     max_upload_bytes: int = 100 * 1024 * 1024  # 100 MB placeholder
     allowed_file_extensions: set[str] = {"pdf", "epub", "md", "html"}
+    cohere_api_key: str | None = None
+    reranker_model: str = "rerank-v3.5"
 
 
 # Global singleton used by the application. Tests override via monkeypatch or

--- a/core/src/core/exceptions.py
+++ b/core/src/core/exceptions.py
@@ -19,3 +19,7 @@ class UpstreamBadResponse(RetrievalError):
 
 class UpstreamUnavailable(RetrievalError):
     """Upstream API could not be reached or timed out (maps to 503)."""
+
+
+class RerankerRateLimitError(RetrievalError):
+    """Reranker API rate-limited (trigger graceful fallback to RRF top-k)."""

--- a/core/src/core/types/retrieval_config.py
+++ b/core/src/core/types/retrieval_config.py
@@ -22,6 +22,9 @@ class RetrievalConfig(BaseModel):
             and sparse (tsvector ts_rank) results via Reciprocal Rank Fusion
             and perform parent-swap before returning (ADR-0016).
             When False, fall back to dense-only retrieval.
+        reranker: When True (default), the top-20 RRF-fused parent passages
+            are reranked through a ``Reranker`` and narrowed to ``top_k``.
+            When False, the RRF top-k is used directly (ADR-0016).
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -30,6 +33,7 @@ class RetrievalConfig(BaseModel):
     ef_search: int
     top_k: int
     hybrid_search: bool = True
+    reranker: bool = True
 
 
 __all__ = ["RetrievalConfig"]

--- a/retrieval_qa/src/retrieval_qa/retrieval/query.py
+++ b/retrieval_qa/src/retrieval_qa/retrieval/query.py
@@ -30,8 +30,18 @@ When ``RetrievalConfig.hybrid_search`` is True (default, ADR-0016):
 
 When ``hybrid_search`` is False, retrieval falls back to dense-only
 (existing behavior).
+
+When ``RetrievalConfig.reranker`` is True (default, ADR-0016):
+
+- After RRF fusion and parent swap, the top-20 parent passages are reranked
+  via the configured ``Reranker``. Only the top-k (default 5) reach the prompt.
+- When the reranker is ``NoopReranker`` (or ``reranker`` is False), the
+  RRF top-k is used directly.
+- When the reranker raises ``RerankerRateLimitError`` (Cohere 429), the system
+  logs the error and falls back to RRF top-k (no crash, no 5xx).
 """
 
+import logging
 from collections import OrderedDict
 from uuid import UUID
 
@@ -39,11 +49,18 @@ from sqlalchemy import text
 from sqlalchemy.exc import InterfaceError, OperationalError
 from sqlalchemy.orm import Session
 
-from core.exceptions import UpstreamUnavailable
+from core.clients.reranker_client import Reranker
+from core.exceptions import RerankerRateLimitError, UpstreamUnavailable
 from core.types.responses import CitedPassage
 from core.types.retrieval_config import RetrievalConfig
 
+logger = logging.getLogger(__name__)
+
 _RRF_K = 60
+
+# When reranking is active, fetch more candidates from each retrieval path
+# to give the reranker a bigger pool to re-rank from (ADR-0016).
+_RERANK_CANDIDATE_COUNT = 20
 
 _DENSE_SQL = text(
     """
@@ -96,14 +113,16 @@ def _dense_retrieve(
     session: Session,
     query_vector: list[float],
     config: RetrievalConfig,
+    limit: int | None = None,
 ) -> OrderedDict[UUID, float]:
     """Run dense (pgvector cosine) search and return chunk_id -> RRF score."""
+    top_k = limit if limit is not None else config.top_k
     result = session.execute(
         _DENSE_SQL,
         {
             "model_name": config.model_name,
             "query_vector": str(query_vector),
-            "top_k": config.top_k,
+            "top_k": top_k,
         },
     )
     scored: OrderedDict[UUID, float] = OrderedDict()
@@ -117,13 +136,15 @@ def _sparse_retrieve(
     session: Session,
     query_text: str,
     config: RetrievalConfig,
+    limit: int | None = None,
 ) -> OrderedDict[UUID, float]:
     """Run sparse (tsvector ts_rank) search and return chunk_id -> RRF score."""
+    top_k = limit if limit is not None else config.top_k
     result = session.execute(
         _SPARSE_SQL,
         {
             "query_text": query_text,
-            "top_k": config.top_k,
+            "top_k": top_k,
         },
     )
     scored: OrderedDict[UUID, float] = OrderedDict()
@@ -227,6 +248,7 @@ def retrieve_relevant_chunks(
     session: Session,
     config: RetrievalConfig,
     query_text: str | None = None,
+    reranker: Reranker | None = None,
 ) -> list[CitedPassage]:
     """Retrieve the top-k closest chunks for ``query_vector`` by cosine distance.
 
@@ -238,16 +260,24 @@ def retrieve_relevant_chunks(
     Rank Fusion, then performs parent-swap to replace matched child chunks
     with their enclosing parent chunks (ADR-0016).
 
+    When ``config.reranker`` is True and a ``reranker`` is supplied, the
+    top-20 RRF-fused parent passages are reranked and narrowed to ``top_k``.
+    On rate-limit errors, the system logs a warning and falls back to RRF
+    top-k (no crash).
+
     Args:
         query_vector: A 1536-dim query embedding.
         session: SQLAlchemy session bound to the documents database. The
             ``SET LOCAL`` is scoped to the current transaction, so callers
             should not commit before consuming the results.
         config: Retrieval configuration (model name, ef_search, top_k,
-            hybrid_search toggle).
+            hybrid_search toggle, reranker toggle).
         query_text: The original user query string, required for the sparse
             search path when ``config.hybrid_search`` is True. Ignored when
             hybrid_search is False.
+        reranker: Reranker instance for cross-encoder reranking. When None
+            or when ``config.reranker`` is False, the RRF top-k is used
+            directly.
 
     Returns:
         Chunks in descending relevance order. An empty list signals the
@@ -264,27 +294,44 @@ def retrieve_relevant_chunks(
             text("SET LOCAL hnsw.ef_search = :ef_search"), {"ef_search": config.ef_search}
         )
 
-        if config.hybrid_search and query_text:
-            dense_scored = _dense_retrieve(session, query_vector, config)
-            sparse_scored = _sparse_retrieve(session, query_text, config)
-            fused = _rrf_fuse(dense_scored, sparse_scored, config.top_k)
-            return _parent_swap(session, fused)
+        should_rerank = config.reranker and reranker is not None
+        retrieval_limit = _RERANK_CANDIDATE_COUNT if should_rerank else config.top_k
 
-        # Dense-only path (hybrid_search=False or no query_text provided)
-        rows = session.execute(
-            _DENSE_SQL,
-            {
-                "model_name": config.model_name,
-                "query_vector": str(query_vector),
-                "top_k": config.top_k,
-            },
-        )
-        chunks: list[CitedPassage] = []
-        for row in rows.fetchall():
-            chunk_id = row._mapping["chunk_id"]
-            text_content = row._mapping["text"]
-            chunks.append(CitedPassage(chunk_id=chunk_id, text=text_content))
-        return chunks
+        if config.hybrid_search and query_text:
+            dense_scored = _dense_retrieve(session, query_vector, config, limit=retrieval_limit)
+            sparse_scored = _sparse_retrieve(session, query_text, config, limit=retrieval_limit)
+            fused = _rrf_fuse(dense_scored, sparse_scored, retrieval_limit)
+            passages = _parent_swap(session, fused)
+        else:
+            # Dense-only path (hybrid_search=False or no query_text provided)
+            rows = session.execute(
+                _DENSE_SQL,
+                {
+                    "model_name": config.model_name,
+                    "query_vector": str(query_vector),
+                    "top_k": retrieval_limit,
+                },
+            )
+            passages = [
+                CitedPassage(
+                    chunk_id=row._mapping["chunk_id"],
+                    text=row._mapping["text"],
+                )
+                for row in rows.fetchall()
+            ]
+
+        if should_rerank and passages and reranker is not None:
+            try:
+                passages = reranker.rerank(
+                    query=query_text or "",
+                    passages=passages,
+                    top_k=config.top_k,
+                )
+            except RerankerRateLimitError as exc:
+                logger.warning("Reranker rate-limited, falling back to RRF top-k: %s", exc)
+                passages = passages[: config.top_k]
+
+        return passages
 
     except (OperationalError, InterfaceError) as exc:
         raise UpstreamUnavailable(f"Database unreachable: {exc}") from exc

--- a/retrieval_qa/tests/retrieval_qa/retrieval/test_query.py
+++ b/retrieval_qa/tests/retrieval_qa/retrieval/test_query.py
@@ -5,7 +5,9 @@ from unittest.mock import MagicMock
 import pytest
 from sqlalchemy.orm import Session
 
+from core.clients.reranker_client import NoopReranker
 from core.database.schema import Chunk, Document, Embedding
+from core.exceptions import RerankerRateLimitError
 from core.types.document import DocumentStatus, DocumentType
 from core.types.responses import CitedPassage
 from core.types.retrieval_config import RetrievalConfig
@@ -645,3 +647,176 @@ def test_sparse_only_parent_swap_returns_parent_content(
     assert len(results) == 1
     assert results[0].chunk_id == parent.chunk_id
     assert results[0].text == parent_text
+
+
+# ── Reranker tests ───────────────────────────────────────────────────────────
+
+
+def test_reranker_reorders_passages(test_session: Session) -> None:
+    """When a reranker returns passages in a different order, the final
+    CitedPassage list reflects the reranked order.
+    """
+    vector = [0.5] * 1536
+    texts = ["chunk alpha", "chunk beta", "chunk gamma"]
+    vectors = [[0.5 + i * 0.01] * 1536 for i in range(len(texts))]
+    _seed_paper(
+        test_session,
+        title="Rerank Order",
+        chunks=[(t, v, f"c{i}") for i, (t, v) in enumerate(zip(texts, vectors, strict=True))],
+    )
+    test_session.commit()
+
+    reverse_reranker = _ReverseReranker()
+    results = retrieve_relevant_chunks(
+        query_vector=vector,
+        session=test_session,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=2),
+        query_text="chunk",
+        reranker=reverse_reranker,
+    )
+
+    assert len(results) == 2
+    assert results[0].text == "chunk gamma"
+    assert results[1].text == "chunk beta"
+
+
+def test_reranker_respects_top_k_when_narrowing(test_session: Session) -> None:
+    """The reranker narrows the candidate pool to the configured top_k."""
+    vector = [0.5] * 1536
+    texts = [f"passage {i}" for i in range(5)]
+    vectors = [[0.5 + i * 0.01] * 1536 for i in range(len(texts))]
+    _seed_paper(
+        test_session,
+        title="Narrow",
+        chunks=[(t, v, f"c{i}") for i, (t, v) in enumerate(zip(texts, vectors, strict=True))],
+    )
+    test_session.commit()
+
+    results = retrieve_relevant_chunks(
+        query_vector=vector,
+        session=test_session,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=3),
+        query_text="passage",
+        reranker=NoopReranker(),
+    )
+
+    assert len(results) == 3
+
+
+def test_reranker_disabled_falls_back_to_rrf_top_k_directly(
+    test_session: Session,
+) -> None:
+    """When reranker=False in config, the RRF top_k is used directly without
+    fetching extra candidates for reranking.
+    """
+    vector = [0.5] * 1536
+    texts = [f"chunk {i} with keyword zeta{i}" for i in range(6)]
+    vectors = [[0.5 + i * 0.01] * 1536 for i in range(len(texts))]
+    _seed_paper(
+        test_session,
+        title="Rerank Off",
+        chunks=[(t, v, f"c{i}") for i, (t, v) in enumerate(zip(texts, vectors, strict=True))],
+    )
+    test_session.commit()
+
+    # reranker=False, so retrieval_limit stays at top_k=3 (not 20)
+    results = retrieve_relevant_chunks(
+        query_vector=vector,
+        session=test_session,
+        config=RetrievalConfig(
+            model_name="text-embedding-3-small",
+            ef_search=40,
+            top_k=3,
+            reranker=False,
+        ),
+        query_text="zeta",
+        reranker=NoopReranker(),
+    )
+
+    # With reranker=False, we don't enlarge the retrieval limit, so at most
+    # top_k=3 results come back from RRF. Even with a reranker instance
+    # passed, it is not called.
+    assert len(results) <= 3
+
+
+def test_rate_limit_fallback_to_rrf_top_k(test_session: Session) -> None:
+    """When the reranker raises RerankerRateLimitError, the system falls back
+    to the RRF top-k without crashing.
+    """
+    vector = [0.5] * 1536
+    texts = [f"fallback chunk {i}" for i in range(5)]
+    vectors = [[0.5 + i * 0.01] * 1536 for i in range(len(texts))]
+    _seed_paper(
+        test_session,
+        title="Rate Limit Fallback",
+        chunks=[(t, v, f"c{i}") for i, (t, v) in enumerate(zip(texts, vectors, strict=True))],
+    )
+    test_session.commit()
+
+    results = retrieve_relevant_chunks(
+        query_vector=vector,
+        session=test_session,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=3),
+        query_text="fallback",
+        reranker=_RateLimitReranker(),
+    )
+
+    assert len(results) == 3
+    for result in results:
+        assert "fallback" in result.text
+
+
+def test_reranker_with_empty_passages_returns_empty(
+    test_session: Session,
+) -> None:
+    """When no passages are retrieved, the reranker receives an empty list
+    and returns an empty list.
+    """
+    vector = [0.5] * 1536
+    _seed_paper(
+        test_session,
+        title="Present",
+        chunks=[("some content", vector, "c1")],
+    )
+    test_session.commit()
+
+    results = retrieve_relevant_chunks(
+        query_vector=vector,
+        session=test_session,
+        config=RetrievalConfig(
+            model_name="some-other-model",  # dense: no embeddings
+            ef_search=40,
+            top_k=5,
+        ),
+        query_text="xyznonexistentkeyword12345",  # sparse: no match
+        reranker=NoopReranker(),
+    )
+
+    assert results == []
+
+
+# ── Test double rerankers ────────────────────────────────────────────────────
+
+
+class _ReverseReranker:
+    """Reranker that returns passages in reverse order for deterministic tests."""
+
+    def rerank(
+        self,
+        query: str,
+        passages: list[CitedPassage],
+        top_k: int,
+    ) -> list[CitedPassage]:
+        return list(reversed(passages))[:top_k]
+
+
+class _RateLimitReranker:
+    """Reranker that always raises RerankerRateLimitError."""
+
+    def rerank(
+        self,
+        query: str,
+        passages: list[CitedPassage],
+        top_k: int,
+    ) -> list[CitedPassage]:
+        raise RerankerRateLimitError("Simulated rate limit.")

--- a/uv.lock
+++ b/uv.lock
@@ -350,6 +350,25 @@ wheels = [
 ]
 
 [[package]]
+name = "cohere"
+version = "7.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastavro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "requests" },
+    { name = "tokenizers" },
+    { name = "types-requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/16/62ba386903ea854a2fce2cc2f959b9e0c8fa1d3e5699a3a523a6c691ffc9/cohere-7.0.8.tar.gz", hash = "sha256:5d9986b9b13cfe5590021474540648ff3c9e9ce4bfddc3d7f8e31acf1898c4d7", size = 213501, upload-time = "2026-07-23T19:31:41.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/52/255cefc27e058853b8750fcb22c549fd52684214d4fc1e4169ab23320644/cohere-7.0.8-py3-none-any.whl", hash = "sha256:a4fe9b9e148cb277ee152009d3566434b055db9d41fc7433abda78add22632ab", size = 357010, upload-time = "2026-07-23T19:31:39.432Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -364,6 +383,7 @@ version = "0.1.0"
 source = { editable = "core" }
 dependencies = [
     { name = "alembic" },
+    { name = "cohere" },
     { name = "openai" },
     { name = "pgvector" },
     { name = "psycopg2-binary" },
@@ -376,6 +396,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
+    { name = "cohere", specifier = ">=5.0" },
     { name = "openai", specifier = ">=2.46.0" },
     { name = "pgvector", specifier = ">=0.3" },
     { name = "psycopg2-binary", specifier = ">=2.9" },
@@ -471,6 +492,54 @@ wheels = [
 ]
 
 [[package]]
+name = "fastavro"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/5b/ccb338db71f347e3bc031d268bf6dc41e5ead63b6997b8e72af92f05e18e/fastavro-1.12.2.tar.gz", hash = "sha256:3c79502d56cf6b76210032e1c53494ddfbc73c140bccf2ef4092b3f0825323ab", size = 1030127, upload-time = "2026-04-24T14:36:01.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/bc/fe5731d6724d978694fbd3196bc1c0d7cab3fd0766e9551c40c39f798b52/fastavro-1.12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0e331896e8efffc72fa03e63b87ebfc37960113127da8e0f5152d91664ffed68", size = 964331, upload-time = "2026-04-24T14:36:31.297Z" },
+    { url = "https://files.pythonhosted.org/packages/98/36/50abf1145e4f1c4f418cd4b5f2ac806643d0b14e360b60e953826edf1b34/fastavro-1.12.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7f01ebaada59d74fdf6d28e5031a961a413b3752e9edb0c03866fa18480cf4c8", size = 3340170, upload-time = "2026-04-24T14:36:33.364Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8c/76ef4641e6c1c1aa3e6bb3c9efb5533ffda5dd975c8b5ae54e794322d9e3/fastavro-1.12.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25ef6855935f67582740ffa6bb978e40ec51be876117a3555c36fa2488dcdf25", size = 3425061, upload-time = "2026-04-24T14:36:35.497Z" },
+    { url = "https://files.pythonhosted.org/packages/31/10/379ff23425b2b470d5209cbc6736a6e5cbc34392ff17bb7355b8fd4aa0ca/fastavro-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:84a4f76a0aece0aa72b5ed8162ba2ff8c78908b8361b5a5d92ddd161977ccb74", size = 3243618, upload-time = "2026-04-24T14:36:37.969Z" },
+    { url = "https://files.pythonhosted.org/packages/88/29/4c8f9e7cd78f932f0d82823899e67a6d7f7e8f2524992db03956f9d9f5ef/fastavro-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:81e8da77d201916f6771fc357fda8267c2a256d7aa11923d43bc5f2fc155878b", size = 3378427, upload-time = "2026-04-24T14:36:40.278Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a1/eafeb302aaaea6055d4a9c11272b4aeaf713e43fe8eaf782f43a1fee2b44/fastavro-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:1924349c74666c89417bd5cc2749f598e2f15f1d56ee81428b2317ab02c88aae", size = 441077, upload-time = "2026-04-24T14:36:41.791Z" },
+    { url = "https://files.pythonhosted.org/packages/56/9d/67e831041ba8efc16265c65bd71ba92e1095bba19b91be99e102f19d9be6/fastavro-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:4c346cf449baf3b113e997c34151ad205e7135bc429469b005b180ade7e65e28", size = 378205, upload-time = "2026-04-24T14:36:43.679Z" },
+    { url = "https://files.pythonhosted.org/packages/83/39/f489a441d41cc9c0a8449fb1325d7a9c9eb57a5634e6ab19dfb0a1105324/fastavro-1.12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:57bb6b908cb2e05baab63b04c3a31be3b4545a10bfab9748b8763016b5256704", size = 958566, upload-time = "2026-04-24T14:36:45.49Z" },
+    { url = "https://files.pythonhosted.org/packages/31/69/776cc025aee2d02acacb734cf690d2fbc295eaadde1b5d47caf8c77a6a2b/fastavro-1.12.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a007f95cc682f56e6d83f1d17c29c00bf719d6fe8e003282b535af3a1ba09c0", size = 3276390, upload-time = "2026-04-24T14:36:47.875Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bc/b7e15fa788f42cbe65827af2ec06c9ad91bb9f72c213110dbef61b53a5b0/fastavro-1.12.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e90460b0cd21f62be3cb26087e706e2cebb7b3fcef9e05b4473b61bb0415b5e", size = 3372779, upload-time = "2026-04-24T14:36:50.122Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c2/98993ca810231fc1397212f48c3d46626983722a24bbaaa5c27ee0963751/fastavro-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7ccd15966b8218d41b06ec3e7c2556be89a8a693026c771e6564d2e40bbaf8ea", size = 3187591, upload-time = "2026-04-24T14:36:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/c180f340eba6478f1b20deccdd17e2b4a4d5074dafd812e3c4254fd035f7/fastavro-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:06b6971d3dae10cb34353b857d16ad21ebd6f0ea394e86c96abdcad109005d6e", size = 3320589, upload-time = "2026-04-24T14:36:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/e9/aca0456216b5b8992e7b0a8542711b66799c05bfe24c8e32ef6f56e7eb93/fastavro-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:98dfcdfaf1498ae2f0e2fafe900a82e8320cc81d8ae5a95b8b8879eaa3298c39", size = 440883, upload-time = "2026-04-24T14:36:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7e/984896e716af504927be71b80a1e9661aa96c6f9e1e777d52823aacb99f2/fastavro-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:3888ef7a51adc77cdf07251bc762566a1be36211e1cff689f13980f3776a2f36", size = 377536, upload-time = "2026-04-24T14:36:58.274Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/42/09a1e1f8d9998d73848a6ff0aad6713ae6abf0dbf99918776f8ef33344a7/fastavro-1.12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:283dcd3129b632021894425974bedd0eb6db3bbf5994e448ccad10db4d803d31", size = 1049506, upload-time = "2026-04-24T14:36:59.797Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ef/80cc16f43919d532f25a707f34b275cccc09dca87a05b000fbbfc8e8f255/fastavro-1.12.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d125e210d5a0a1f701f12c0ecad9a03f1b04b5eddbce6ca36a1fc217da977ef", size = 3495899, upload-time = "2026-04-24T14:37:02.306Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/54/a0817d1d0236e9e0233f5c996f450cc795b056b8e06edb531f24b9df82ed/fastavro-1.12.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2d4d66afad78e8f47feaa307728a6b71fe3effc63ba2b9eeb109ee687c9bd397", size = 3399232, upload-time = "2026-04-24T14:37:04.837Z" },
+    { url = "https://files.pythonhosted.org/packages/38/0a/650f256c15f5875b6081544b9ba7ed8254329213e7e49e3db0aec68b5bee/fastavro-1.12.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2328ec07925c04c89719e3971c9068a165c7fd474ea87675b1204de0440e71ff", size = 3320222, upload-time = "2026-04-24T14:37:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/54/8351d388f94fbb0870e8cffaae41d3cc607acc8d6a8a6a217e2794829593/fastavro-1.12.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:55dea7e74b834d4b70467fc19c5b9ccb5509fe39abc4d26891187c1b22176423", size = 3337096, upload-time = "2026-04-24T14:37:09.452Z" },
+    { url = "https://files.pythonhosted.org/packages/da/eb/b36ba9a88826e8c272df02e2f8b5da717e88b6eb508fddca3ca450043731/fastavro-1.12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8d37c87826ae7195cfbd20fcd448801f2f563bb38f2691ec6574e39cb9eca6c8", size = 963119, upload-time = "2026-04-24T14:37:11.557Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/02/3d7f540fb26ba4ea1f4ebd2783c586614da9ac00906a3092e92fd3f104a2/fastavro-1.12.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c463a3701f293e30d3d62e71e1989f112028d07f87432baf4507eeb57ec3831", size = 3266238, upload-time = "2026-04-24T14:37:13.84Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/0b/b77be56c5109da0fc7dcfd7e6b6752fe0a61d0a5c58c6a65e38b4501946a/fastavro-1.12.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f604ba83498e209fff4c7ecc5063a39421dc538dace694bc592f9f338254f3dc", size = 3324020, upload-time = "2026-04-24T14:37:16.096Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/6e/951d41f244107e91bf2f59245b71783c03eaab4bdbc960d58316c19652bb/fastavro-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bfac2dada8ddc002e8b7d8289d6fad4f070bc1fec20371cec684a7d10d932e96", size = 3170160, upload-time = "2026-04-24T14:37:18.168Z" },
+    { url = "https://files.pythonhosted.org/packages/94/6f/2adb571fda448d4afd2466e1cef2963fefdc6b37847da05249983e415f17/fastavro-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bc44ba6289fb1f5ee318335958dde6ad6d742dcb4bb8930de843e9024c64b68c", size = 3281842, upload-time = "2026-04-24T14:37:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/17/07/4bad2e96c4c6bae40253be2573cc09c1e5b9ccf821e1ff74e0d33b64bf90/fastavro-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:a475418f71c5aed69899813ecccf392429c08c3a63df3030129db71760b0db8f", size = 450903, upload-time = "2026-04-24T14:37:23.059Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b7/180f67ba9a46ba23a1ff6432f48d3087d4f2048579ecc262b00426cb1c63/fastavro-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:daec9f9655a1d4636613c47d6d3343f6e039150d66cdce62543e20ca36612a8a", size = 391076, upload-time = "2026-04-24T14:37:24.756Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8f/18f60329b627d2118a4a2b19e8741fbd807d60bf0470554e1bbfb7f1bca3/fastavro-1.12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:57594b72cf663bbd0f3ad8a319a999fc3d7c71065a6799b2c1d1a6a137894c5b", size = 1055430, upload-time = "2026-05-09T21:53:14.364Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ac/a1fa1fc29df0efc89d4946a743b09bdc9500591b5b92083eaf8e93664916/fastavro-1.12.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74412132bbfb153cbf704517f2c89f7d3e170feb681b13bceace690f66f8d5fa", size = 3503075, upload-time = "2026-04-24T14:37:26.826Z" },
+    { url = "https://files.pythonhosted.org/packages/82/bf/4f669e10b6bc38a731ee3400aed1a1e2d0a3e3cf411e72f6b320d3af0eaf/fastavro-1.12.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e367a84c9133018e0a3bc822abe78d7f1f9a6092991a0ec409468cf4ef260282", size = 3410900, upload-time = "2026-04-24T14:37:29.233Z" },
+    { url = "https://files.pythonhosted.org/packages/10/39/ecb19fdae4158a7730b5963fbf1b6d38d74678392d73083be518642af0c1/fastavro-1.12.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:044fafca0853e9ae14009de7763ac9e8e8f8b96f8a4e90bd58b695443266a370", size = 3335637, upload-time = "2026-04-24T14:37:31.472Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f1/f21bd5319113e89ceceed2df840df21e9c5150d181db74b6ba80400f9f48/fastavro-1.12.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:afede7324822800e4f90e96b9514188a237a60f35e8e7a10b2129c10c78f6e4d", size = 3356664, upload-time = "2026-04-24T14:37:34.231Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.32.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/80/8232b582c4b318b817cf1274ba74976b07b34d35ef439b3eb948f98645a1/filelock-3.32.0.tar.gz", hash = "sha256:7be2ad23a14607ccc71808e68fe30848aeace7058ace17852f68e2a68e310402", size = 213757, upload-time = "2026-07-21T13:17:42.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/79/b4c714bef36bc4ec2beeae1e0c124f0223888cd8c6feb1cdc56038116920/filelock-3.32.0-py3-none-any.whl", hash = "sha256:d396bea984af47333ef05e50eae7eff88c84256de6112aea0ec48a233c064fe3", size = 97732, upload-time = "2026-07-21T13:17:41.55Z" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -557,6 +626,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
 ]
 
 [[package]]
@@ -729,6 +807,30 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/39/67be8d71f900d9a55761b6022821d6679fb56c64f1b6063d5af2c2606727/hf_xet-1.5.2.tar.gz", hash = "sha256:73044bd31bae33c984af832d19c752a0dffb67518fee9ddbd91d616e1101cf47", size = 903674, upload-time = "2026-07-16T17:29:56.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/be/525eabac5d1736b679c39e342ecd4292534012546a2d18f0043c8e3b6021/hf_xet-1.5.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:4a5ecb9cda8512ba2aa8ee5d37c87a1422992165892d653098c7b90247481c3b", size = 4064284, upload-time = "2026-07-16T17:29:29.907Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3f/699749dd78442480eda4e4fca494284b0e3542e4063cc37654d5fdc929e6/hf_xet-1.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8764488197c1d7b1378c8438c18d2eea902e150dbca0b0f0d2d32603fb9b5576", size = 3828537, upload-time = "2026-07-16T17:29:31.549Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d7/2658ac0a5b9f4664ca27ce31bd015044fe9dea50ed455fb5197aba819c11/hf_xet-1.5.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8d7446f72abbf7e01ca5ff131786bc2e74a56393462c17a6bf1e303fbab81db4", size = 4417133, upload-time = "2026-07-16T17:29:33.391Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/58/8343f3cb63c8fa058d576136df3871550f7d5214a8f048a7ea2eab6ac906/hf_xet-1.5.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:580e59e29bf37aece1f2b68537de1e3fb04f43a23d910dcf6f128280b5bfbba4", size = 4212613, upload-time = "2026-07-16T17:29:34.989Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/33/a968f4e4535037b36941ec00714625fb60e026302407e7e26ca9f3e65f4e/hf_xet-1.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bee28c619622d36968056532fd49cf2b35ca75099b1d616c31a618a893491380", size = 4412710, upload-time = "2026-07-16T17:29:36.646Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d9/9e33981173dbaf194ba0015202b02d467b624d44d4eba89e1bf06c0d2995/hf_xet-1.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e396ab0faf6298199ad7a95305c3ca8498cb825978a6485be6d00587ee4ec577", size = 4628455, upload-time = "2026-07-16T17:29:38.352Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/4b/cc682832de4264a03880a2d1b5ec3e1fab3bf307f508817250baafdb9996/hf_xet-1.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:fd3add255549e8ef58fa35b2e42dc016961c050600444e7d77d030ba6b57120e", size = 3979044, upload-time = "2026-07-16T17:29:40.329Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/09/b2cdf2a0fb39a08af3222b96092a36bd3b40c54123eef07de4422e870971/hf_xet-1.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d6f9c58549407b84b9a5383afd68db0acc42345326a3159990b36a5ca8a20e4e", size = 3808037, upload-time = "2026-07-16T17:29:42.357Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ba/2b70603c7552db82baeb2623e2336898304a17328845151be4fe1f48d420/hf_xet-1.5.2-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f922b8f5fb84f1dd3d7ab7a1316354a1bca9b1c73ecfc19c76e51a2a49d29799", size = 4033760, upload-time = "2026-07-16T17:29:43.884Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ac/b097a86a1e4a6098f3a79382643ab09d5733d87ccc864877ad1e12b49b70/hf_xet-1.5.2-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:045f84440c55cdeb659cf1a1dd48c77bcd0d2e93632e2fea8f2c3bdee79f38ed", size = 3841438, upload-time = "2026-07-16T17:29:45.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/35/db860aa3a0780660324a506ad4b3d322ddc6ecbba4b9340aed0942cbf21c/hf_xet-1.5.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db78c39c83d6279daddc98e2238f373ab8980685556d42472b4ec51abcf03e8c", size = 4428006, upload-time = "2026-07-16T17:29:46.996Z" },
+    { url = "https://files.pythonhosted.org/packages/af/6b/832dd980af4b0c3ae0660e309285f2ffcdff2faa38129390dbb47aa4a3f9/hf_xet-1.5.2-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7db73c810500c54c6760be8c39d4b2e476974de85424c50063efc22fdda13025", size = 4221099, upload-time = "2026-07-16T17:29:48.525Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/05/ae50f0d34e3254e6c3e208beb2519f6b8673016fc4b3643badaf6450d186/hf_xet-1.5.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6395cfe3c9cbead4f16b31808b0e67eac428b66c656f856e99636adaddea878f", size = 4420766, upload-time = "2026-07-16T17:29:50.092Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a9/c050bc2743a2bcd68928bfee157b08681667a164a24ec95fbfcfcd717e08/hf_xet-1.5.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cde8cd167126bb6109b2ceb19b844433a4988643e8f3e01dd9dd0e4a34535097", size = 4636716, upload-time = "2026-07-16T17:29:51.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/68b01c5c2edb56ac9a67b3d076ffddcb90867abaee923923eb34e7a14e76/hf_xet-1.5.2-cp38-abi3-win_amd64.whl", hash = "sha256:ecf63d1cb69a9a7319910f8f83fcf9b46e7a32dfcf4b8f8eeddb55f647306e65", size = 3988373, upload-time = "2026-07-16T17:29:53.395Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c6/988383e9dc17294d536fcbcd6fd16eed882e411ad16c954984a53e47b09c/hf_xet-1.5.2-cp38-abi3-win_arm64.whl", hash = "sha256:1da28519496eb7c8094c11e4d25509b4a468457a0302d58136099db2fd9a671d", size = 3816957, upload-time = "2026-07-16T17:29:54.991Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -783,6 +885,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/4a/129b2e21b90ac2985d3928d96792bccc39bc6dfe796c5eee2d8ec06d4105/httpx2-2.7.0.tar.gz", hash = "sha256:8b30709aed5c8465b0dd3b95c09ce301c8f79e7e7a2d00ab0af551e0d0375b07", size = 94487, upload-time = "2026-07-14T20:40:02.318Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/b8/c341bba6411bdfda786020343c47a75ef472f6085caf82391b142b1a3ad9/httpx2-2.7.0-py3-none-any.whl", hash = "sha256:ed2a2719c696789e09493bd8e2bec3d8bd925cc6e26b68389ec25ade132f7bf4", size = 90234, upload-time = "2026-07-14T20:39:59.531Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
 ]
 
 [[package]]
@@ -2122,6 +2244,33 @@ wheels = [
 ]
 
 [[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.68.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2173,6 +2322,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/64/bc/cb7e7d7c4077216626791f094873a917ccfe31035daaa6d85d7aaf75bbc2/types_reportlab-4.5.1.20260712.tar.gz", hash = "sha256:7c7a64b21abfb811dd323e47d6be409666820dadb587d6c2e771237b99446ac1", size = 72451, upload-time = "2026-07-12T05:13:24.037Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/2c/cc3702c5e34eca04e243fb31dbeeda444f087590c54a6b56e2ebb1d1401e/types_reportlab-4.5.1.20260712-py3-none-any.whl", hash = "sha256:11e6bc24576d2c9f935e419b299b609b6253a9caad475e7b775fe38ed426684a", size = 113013, upload-time = "2026-07-12T05:13:23.023Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260712"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/51/703318f7b7be8bee126ec13bf615050f932d0179b8784420f3a0199cc769/types_requests-2.33.0.20260712.tar.gz", hash = "sha256:2141b67ab534a5c5cd2dac5034f2a35f42e699c5bf185eee608c5246a069d7fb", size = 25084, upload-time = "2026-07-12T05:14:20.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/e7/010c87f559e216d83f9dc51e939633fd0d0ead3377340181ab0e223cd3b5/types_requests-2.33.0.20260712-py3-none-any.whl", hash = "sha256:de027e28c171d3da529689cbfa023b0b4eab188c8dfa22fd834eebd2cee6e7bb", size = 21392, upload-time = "2026-07-12T05:14:19.616Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
…d graceful rate-limit fallback (#102)

- Add Reranker protocol, CohereReranker, and NoopReranker in core/clients
- Add reranker toggle to RetrievalConfig (default True)
- Wire reranker into retrieval pipeline: fetch 20 from RRF, rerank to top_k (5)
- Handle Cohere 429 rate-limit errors with logged fallback to RRF top-k
- Configure COHERE_API_KEY and reranker_model in Settings
- Add get_reranker FastAPI dependency with NoopReranker fallback when key unset
- Add 5 reranker-specific tests (reorder, narrow, disabled, rate-limit, empty)