### PR TITLE
feat(api): add api service to docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,9 @@ RUN groupadd -r app && useradd -r -g app app
 COPY --from=builder --chown=app:app /app/.venv ./.venv
 COPY --from=builder --chown=app:app /app/alembic.ini ./
 COPY --from=builder --chown=app:app /app/core/src/core/database/migrations ./core/src/core/database/migrations
+COPY --chown=app:app docker-entrypoint.sh /docker-entrypoint.sh
 ENV PATH="/app/.venv/bin:$PATH"
 
 USER app
 
-CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,18 @@ services:
       timeout: 5s
       retries: 5
 
+  api:
+    build: .
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: postgresql+psycopg2://learning_hub:learning_hub@postgres:5432/learning_hub
+    depends_on:
+      postgres:
+        condition: service_healthy
+
 volumes:
   postgres_data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Apply pending database migrations before serving traffic.
+alembic upgrade head
+
+# Start the API server.
+exec uvicorn api.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
Add api service that builds from the project Dockerfile and runs alembic upgrade head before starting uvicorn, replacing the manual three-step startup with a single docker compose up -d command.

The new docker-entrypoint.sh runs migrations then execs uvicorn. DATABASE_URL is overridden to point at the compose postgres service. The api service depends on postgres being healthy.

Closes #107