### PR TITLE
feat(core): lazy Postgres engine init with get_engine/get_session/set…

### DIFF
--- a/core/src/core/database/__init__.py
+++ b/core/src/core/database/__init__.py
@@ -1,7 +1,12 @@
 """Database access layer shared by all modules."""
 
-from core.database.connection import SessionLocal, db_session, engine
+from typing import Any
+
+from core.database.connection import db_session, get_engine, get_session, set_engine
 from core.database.schema import Base, Chunk, Document, Embedding
+
+# ``engine`` and ``SessionLocal`` are accessed via ``__getattr__`` below to
+# avoid creating the database engine at import time.
 
 __all__ = [
     "Base",
@@ -11,4 +16,19 @@ __all__ = [
     "SessionLocal",
     "db_session",
     "engine",
+    "get_engine",
+    "get_session",
+    "set_engine",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name in {"engine", "SessionLocal"}:
+        from core.database.connection import __getattr__ as _conn_getattr
+
+        return _conn_getattr(name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return __all__

--- a/core/src/core/database/connection.py
+++ b/core/src/core/database/connection.py
@@ -1,15 +1,59 @@
-"""SQLAlchemy engine and session factory."""
+"""SQLAlchemy engine and session factory with lazy initialisation.
+
+The engine is not created at import time.  Use ``get_engine()`` / ``get_session()``
+to obtain the singleton engine or a new session respectively.  Tests can inject
+a test engine via ``set_engine()``.
+
+``engine`` and ``SessionLocal`` remain importable as deprecated aliases that
+delegate to the lazy functions so existing consumers continue to work.
+"""
 
 from collections.abc import Generator
 from contextlib import contextmanager
+from typing import Any
 
-from sqlalchemy import create_engine
+from sqlalchemy import Engine, create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from core.config.settings import settings
 
-engine = create_engine(settings.database_url, future=True)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+_engine: Engine | None = None
+_sessionmaker: sessionmaker[Session] | None = None
+
+
+def get_engine() -> Engine:
+    """Return the application's SQLAlchemy engine, creating it lazily if needed.
+
+    Subsequent calls return the same singleton until ``set_engine()`` replaces it.
+    """
+    global _engine
+    if _engine is None:
+        _engine = create_engine(settings.database_url, future=True)
+    return _engine
+
+
+def set_engine(test_engine: Engine) -> None:
+    """Replace the engine singleton with *test_engine*.
+
+    This is intended for testing — call once per test suite to inject a
+    SQLite or test-Postgres engine.  The session-maker is reset so that
+    subsequent ``get_session()`` calls bind to the new engine.
+    """
+    global _engine, _sessionmaker
+    _engine = test_engine
+    _sessionmaker = None
+
+
+def get_session() -> Session:
+    """Return a new ``Session`` bound to the current engine.
+
+    The underlying ``sessionmaker`` is lazily created on first call and
+    re-created after ``set_engine()`` replaces the engine.
+    """
+    global _sessionmaker
+    if _sessionmaker is None:
+        _sessionmaker = sessionmaker(autocommit=False, autoflush=False, bind=get_engine())
+    return _sessionmaker()
 
 
 @contextmanager
@@ -18,7 +62,7 @@ def db_session() -> Generator[Session, None, None]:
 
     Commits on clean exit and rolls back on any exception.
     """
-    session = SessionLocal()
+    session = get_session()
     try:
         yield session
         session.commit()
@@ -27,3 +71,31 @@ def db_session() -> Generator[Session, None, None]:
         raise
     finally:
         session.close()
+
+
+# ── Deprecated aliases ──────────────────────────────────────────────
+# These exist so that existing imports continue to work.  Prefer
+# ``get_engine()`` / ``get_session()`` in new code.
+_MODULE_DIR = frozenset(
+    {
+        "db_session",
+        "get_engine",
+        "get_session",
+        "set_engine",
+        "engine",
+        "SessionLocal",
+    }
+)
+
+
+def __getattr__(name: str) -> Any:
+    if name == "engine":
+        return get_engine()
+    if name == "SessionLocal":
+        return get_session
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
+
+
+def __dir__() -> list[str]:
+    return sorted(_MODULE_DIR)

--- a/core/tests/core/test_connection.py
+++ b/core/tests/core/test_connection.py
@@ -1,0 +1,83 @@
+"""Tests for lazy engine initialisation in core.database.connection."""
+
+import importlib
+
+import pytest
+from sqlalchemy import Engine, create_engine
+from sqlalchemy.orm import Session
+
+from core.database.connection import get_engine, get_session, set_engine
+
+
+def test_engine_not_created_at_import_time() -> None:
+    """Verify importing the module does not trigger engine creation."""
+    import core.database.connection as conn
+
+    importlib.reload(conn)
+    assert conn._engine is None
+
+
+def test_get_engine_creates_engine_on_first_call() -> None:
+    """get_engine() creates the engine from settings the first time it is called."""
+    engine = get_engine()
+    assert isinstance(engine, Engine)
+    assert str(engine.url) != ""
+
+
+def test_get_engine_returns_same_singleton() -> None:
+    """Subsequent get_engine() calls return the same engine instance."""
+    first = get_engine()
+    second = get_engine()
+    assert first is second
+
+
+def test_set_engine_replaces_singleton(monkeypatch: pytest.MonkeyPatch) -> None:
+    """set_engine() replaces the engine singleton for testing."""
+    import core.database.connection as conn
+
+    monkeypatch.setattr(conn, "_engine", None)
+    monkeypatch.setattr(conn, "_sessionmaker", None)
+
+    test_engine = create_engine("sqlite:///:memory:", future=True)
+    set_engine(test_engine)
+    assert get_engine() is test_engine
+
+
+def test_get_session_returns_session() -> None:
+    """get_session() returns a new SQLAlchemy Session."""
+    session = get_session()
+    assert isinstance(session, Session)
+    session.close()
+
+
+def test_deprecated_engine_importable() -> None:
+    """The deprecated ``engine`` alias is importable and returns an Engine."""
+    from core.database.connection import engine
+
+    assert isinstance(engine, Engine)
+
+
+def test_deprecated_session_local_importable() -> None:
+    """The deprecated ``SessionLocal`` alias is importable and callable."""
+    from core.database.connection import SessionLocal
+
+    assert callable(SessionLocal)
+    session = SessionLocal()
+    assert isinstance(session, Session)
+    session.close()
+
+
+def test_deprecated_aliases_from_package_init() -> None:
+    """``engine`` and ``SessionLocal`` are accessible via ``core.database``."""
+    from core.database import SessionLocal, engine
+
+    assert isinstance(engine, Engine)
+    assert callable(SessionLocal)
+
+
+def test_db_session_uses_get_session() -> None:
+    """db_session() yields a valid session and commits/rollbacks correctly."""
+    from core.database.connection import db_session
+
+    with db_session() as session:
+        assert isinstance(session, Session)


### PR DESCRIPTION
…_engine

- Replace module-level engine creation with lazy init via get_engine()
- Add set_engine() for test engine injection
- Add get_session() with lazily-created sessionmaker
- Update db_session() to delegate through get_session()
- Keep engine and SessionLocal as deprecated aliases via __getattr__
- Re-export new symbols from core/database/__init__.py
- Add 9 unit tests covering lazy init, deprecated aliases, and set_engine

Closes #112