### PR TITLE
feat(api): add GET /health endpoint with DB probe

### DIFF
--- a/api/src/api/routes/health.py
+++ b/api/src/api/routes/health.py
@@ -20,8 +20,8 @@ def health_check() -> dict[str, str] | JSONResponse:
         with get_engine().connect() as conn:
             conn.execute(text("SELECT 1"))
         return {"status": "ok"}
-    except Exception as exc:
+    except Exception as _exc:
         return JSONResponse(
             status_code=503,
-            content={"status": "unhealthy", "detail": str(exc)},
+            content={"status": "unhealthy", "detail": "Service unavailable"},
         )

--- a/api/src/api/routes/health.py
+++ b/api/src/api/routes/health.py
@@ -1,0 +1,27 @@
+"""Health-check route: GET /health."""
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
+
+from core.database.connection import get_engine
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health", response_model=None)
+def health_check() -> dict[str, str] | JSONResponse:
+    """Probe the database and return connectivity status.
+
+    Returns ``{"status": "ok"}`` (200) on success, or
+    ``{"status": "unhealthy", "detail": "<error>"}`` (503) on failure.
+    """
+    try:
+        with get_engine().connect() as conn:
+            conn.execute(text("SELECT 1"))
+        return {"status": "ok"}
+    except Exception as exc:
+        return JSONResponse(
+            status_code=503,
+            content={"status": "unhealthy", "detail": str(exc)},
+        )

--- a/api/src/api/server.py
+++ b/api/src/api/server.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from api.routes.documents import router as documents_router
+from api.routes.health import router as health_router
 from api.routes.ingest import router as ingest_router
 from api.routes.retrieval_qa import router as query_router
 from core.exceptions import UpstreamBadResponse, UpstreamUnavailable
@@ -22,6 +23,7 @@ def _retrieval_error_handler(request: Request, exc: Exception, status_code: int)
 def create_app() -> FastAPI:
     """Create and configure the Learning Hub API."""
     app = FastAPI(title="Learning Hub", version="0.1.0")
+    app.include_router(health_router)
     app.include_router(ingest_router)
     app.include_router(documents_router)
     app.include_router(query_router)

--- a/api/tests/api/test_health.py
+++ b/api/tests/api/test_health.py
@@ -1,0 +1,61 @@
+"""Tests for the GET /health route.
+
+Two fixture variants are used:
+- ``mock_client``: ``db_session`` is mocked (yields a ``MagicMock``), and
+  ``get_engine`` is overridden per test. Runs anywhere, including CI without
+  a Postgres instance.
+- ``client``: a real test Postgres+pgvector session is wired through; the
+  happy-path integration test uses it. Skips locally when the test database
+  is unavailable.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import Engine, create_engine
+
+from core.database.connection import set_engine
+
+
+def test_health_returns_200_with_mock_engine(
+    mock_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GET /health returns 200 with ``{"status": "ok"}`` via a mocked engine."""
+    engine = create_engine("sqlite:///:memory:")
+    monkeypatch.setattr("api.routes.health.get_engine", lambda: engine)
+
+    response = mock_client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_health_returns_503_when_get_engine_raises(
+    mock_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GET /health returns 503 when ``get_engine()`` raises an exception."""
+
+    def _broken() -> None:
+        msg = "could not connect to server: Connection refused"
+        raise ConnectionRefusedError(msg)
+
+    monkeypatch.setattr("api.routes.health.get_engine", _broken)
+
+    response = mock_client.get("/health")
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "unhealthy"
+    assert "detail" in body
+    assert body["detail"]
+
+
+def test_health_returns_200_via_real_test_db(
+    client: TestClient, test_engine: Engine, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Integration test: GET /health returns 200 via the real test database."""
+    set_engine(test_engine)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
New GET /health endpoint that probes the database via get_engine(). Returns 200 with {"status": "ok"} on success, or 503 with {"status": "unhealthy", "detail": "..."} on failure.

Closes #113