### PR TITLE
refactor(core): migrate call sites to lazy API and remove old globals

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -76,7 +76,7 @@ def set_dependency_override(client: TestClient, dependency: Any, override: Any) 
 
 
 @pytest.fixture
-def client(override_route_db_session: object, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+def client(override_route_db_session: object) -> TestClient:
     """A TestClient with DB sessions and provider dependencies mocked.
 
     Real API calls belong only in the eval job (coding-standards.md). Both

--- a/conftest.py
+++ b/conftest.py
@@ -9,7 +9,6 @@ import io
 import os
 import zipfile
 from collections.abc import Generator
-from contextlib import contextmanager
 from urllib.parse import urlparse
 
 import pytest
@@ -37,6 +36,7 @@ import retrieval_qa.retrieval.query  # noqa: F401
 # would shadow the installed package under importlib import mode and break
 # submodule imports like ``retrieval_qa.chunking.paper_chunker``.
 from core.config.settings import Settings
+from core.database.connection import set_engine
 from core.database.schema import Base
 
 # Test database name derived from the configured database URL.
@@ -243,7 +243,7 @@ def _create_enums(engine: Engine) -> None:
 
 
 @pytest.fixture
-def override_route_db_session(test_engine: Engine, monkeypatch: pytest.MonkeyPatch) -> None:
+def override_route_db_session(test_engine: Engine) -> None:
     """Make API route ``db_session`` contexts yield sessions on the test engine."""
     Base.metadata.drop_all(bind=test_engine)
     with test_engine.connect() as conn:
@@ -251,21 +251,4 @@ def override_route_db_session(test_engine: Engine, monkeypatch: pytest.MonkeyPat
         conn.commit()
     _create_enums(test_engine)
     Base.metadata.create_all(bind=test_engine)
-    SessionFactory = sessionmaker(bind=test_engine)
-
-    @contextmanager
-    def _test_db_session() -> Generator[Session, None, None]:
-        session = SessionFactory()
-        try:
-            yield session
-            session.commit()
-        except Exception:
-            session.rollback()
-            raise
-        finally:
-            session.close()
-
-    monkeypatch.setattr("api.routes.ingest.db_session", _test_db_session)
-    monkeypatch.setattr("api.routes.documents.db_session", _test_db_session)
-    monkeypatch.setattr("api.routes.retrieval_qa.db_session", _test_db_session)
-    monkeypatch.setattr("ingestion.tasks.SessionLocal", SessionFactory)
+    set_engine(test_engine)

--- a/core/src/core/database/__init__.py
+++ b/core/src/core/database/__init__.py
@@ -1,34 +1,15 @@
 """Database access layer shared by all modules."""
 
-from typing import Any
-
 from core.database.connection import db_session, get_engine, get_session, set_engine
 from core.database.schema import Base, Chunk, Document, Embedding
-
-# ``engine`` and ``SessionLocal`` are accessed via ``__getattr__`` below to
-# avoid creating the database engine at import time.
 
 __all__ = [
     "Base",
     "Chunk",
     "Document",
     "Embedding",
-    "SessionLocal",
     "db_session",
-    "engine",
     "get_engine",
     "get_session",
     "set_engine",
 ]
-
-
-def __getattr__(name: str) -> Any:
-    if name in {"engine", "SessionLocal"}:
-        from core.database.connection import __getattr__ as _conn_getattr
-
-        return _conn_getattr(name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__() -> list[str]:
-    return __all__

--- a/core/src/core/database/connection.py
+++ b/core/src/core/database/connection.py
@@ -3,14 +3,10 @@
 The engine is not created at import time.  Use ``get_engine()`` / ``get_session()``
 to obtain the singleton engine or a new session respectively.  Tests can inject
 a test engine via ``set_engine()``.
-
-``engine`` and ``SessionLocal`` remain importable as deprecated aliases that
-delegate to the lazy functions so existing consumers continue to work.
 """
 
 from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Any
 
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -71,31 +67,3 @@ def db_session() -> Generator[Session, None, None]:
         raise
     finally:
         session.close()
-
-
-# ── Deprecated aliases ──────────────────────────────────────────────
-# These exist so that existing imports continue to work.  Prefer
-# ``get_engine()`` / ``get_session()`` in new code.
-_MODULE_DIR = frozenset(
-    {
-        "db_session",
-        "get_engine",
-        "get_session",
-        "set_engine",
-        "engine",
-        "SessionLocal",
-    }
-)
-
-
-def __getattr__(name: str) -> Any:
-    if name == "engine":
-        return get_engine()
-    if name == "SessionLocal":
-        return get_session
-    msg = f"module {__name__!r} has no attribute {name!r}"
-    raise AttributeError(msg)
-
-
-def __dir__() -> list[str]:
-    return sorted(_MODULE_DIR)

--- a/core/tests/core/test_connection.py
+++ b/core/tests/core/test_connection.py
@@ -50,31 +50,6 @@ def test_get_session_returns_session() -> None:
     session.close()
 
 
-def test_deprecated_engine_importable() -> None:
-    """The deprecated ``engine`` alias is importable and returns an Engine."""
-    from core.database.connection import engine
-
-    assert isinstance(engine, Engine)
-
-
-def test_deprecated_session_local_importable() -> None:
-    """The deprecated ``SessionLocal`` alias is importable and callable."""
-    from core.database.connection import SessionLocal
-
-    assert callable(SessionLocal)
-    session = SessionLocal()
-    assert isinstance(session, Session)
-    session.close()
-
-
-def test_deprecated_aliases_from_package_init() -> None:
-    """``engine`` and ``SessionLocal`` are accessible via ``core.database``."""
-    from core.database import SessionLocal, engine
-
-    assert isinstance(engine, Engine)
-    assert callable(SessionLocal)
-
-
 def test_db_session_uses_get_session() -> None:
     """db_session() yields a valid session and commits/rollbacks correctly."""
     from core.database.connection import db_session

--- a/ingestion/src/ingestion/tasks.py
+++ b/ingestion/src/ingestion/tasks.py
@@ -8,7 +8,7 @@ This module is the only place that couples the pipeline to the task runner;
 from fastapi import BackgroundTasks
 
 from core.clients import Embedder
-from core.database.connection import SessionLocal
+from core.database.connection import get_session
 from core.database.schema import Document
 from core.exceptions import IngestionError
 from core.types.document import DocumentStatus
@@ -26,7 +26,7 @@ def _execute_ingestion_task(
     Opens its own database session so that a pipeline failure can be captured
     and persisted as ``status='failed'`` after rolling back the partial work.
     """
-    session = SessionLocal()
+    session = get_session()
     try:
         title = ""
         document = session.get(Document, pending.document_id)
@@ -50,7 +50,7 @@ def _execute_ingestion_task(
         # Update the document row in a fresh mini-transaction so the failure
         # reason is retained after the main transaction rolls back.
         try:
-            failure_session = SessionLocal()
+            failure_session = get_session()
             failure_document = failure_session.get(Document, pending.document_id)
             if failure_document is not None:
                 failure_document.status = DocumentStatus.FAILED


### PR DESCRIPTION
Replaces monkeypatching in root conftest with set_engine(), updates ingestion/tasks.py to use get_session(), drops the unused monkeypatch parameter from the client fixture, and removes the deprecated engine and SessionLocal aliases from core.database.

Closes #114