### PR TITLE
fix(core): add thread-safety to lazy engine init and dispose old engi…

### DIFF
--- a/api/src/api/routes/health.py
+++ b/api/src/api/routes/health.py
@@ -1,10 +1,14 @@
 """Health-check route: GET /health."""
 
+import logging
+
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from sqlalchemy import text
 
 from core.database.connection import get_engine
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["health"])
 
@@ -20,7 +24,8 @@ def health_check() -> dict[str, str] | JSONResponse:
         with get_engine().connect() as conn:
             conn.execute(text("SELECT 1"))
         return {"status": "ok"}
-    except Exception as _exc:
+    except Exception:
+        logger.exception("Health check failed")
         return JSONResponse(
             status_code=503,
             content={"status": "unhealthy", "detail": "Service unavailable"},

--- a/api/tests/api/test_health.py
+++ b/api/tests/api/test_health.py
@@ -13,8 +13,6 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import Engine, create_engine
 
-from core.database.connection import set_engine
-
 
 def test_health_returns_200_with_mock_engine(
     mock_client: TestClient, monkeypatch: pytest.MonkeyPatch
@@ -53,7 +51,6 @@ def test_health_returns_200_via_real_test_db(
     client: TestClient, test_engine: Engine, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Integration test: GET /health returns 200 via the real test database."""
-    set_engine(test_engine)
 
     response = client.get("/health")
 

--- a/core/src/core/database/connection.py
+++ b/core/src/core/database/connection.py
@@ -5,6 +5,7 @@ to obtain the singleton engine or a new session respectively.  Tests can inject
 a test engine via ``set_engine()``.
 """
 
+import threading
 from collections.abc import Generator
 from contextlib import contextmanager
 
@@ -15,6 +16,7 @@ from core.config.settings import settings
 
 _engine: Engine | None = None
 _sessionmaker: sessionmaker[Session] | None = None
+_lock = threading.RLock()
 
 
 def get_engine() -> Engine:
@@ -24,7 +26,9 @@ def get_engine() -> Engine:
     """
     global _engine
     if _engine is None:
-        _engine = create_engine(settings.database_url, future=True)
+        with _lock:
+            if _engine is None:
+                _engine = create_engine(settings.database_url, future=True)
     return _engine
 
 
@@ -36,8 +40,12 @@ def set_engine(test_engine: Engine) -> None:
     subsequent ``get_session()`` calls bind to the new engine.
     """
     global _engine, _sessionmaker
-    _engine = test_engine
-    _sessionmaker = None
+    with _lock:
+        old_engine = _engine
+        _engine = test_engine
+        _sessionmaker = None
+    if old_engine is not None:
+        old_engine.dispose()
 
 
 def get_session() -> Session:
@@ -48,7 +56,9 @@ def get_session() -> Session:
     """
     global _sessionmaker
     if _sessionmaker is None:
-        _sessionmaker = sessionmaker(autocommit=False, autoflush=False, bind=get_engine())
+        with _lock:
+            if _sessionmaker is None:
+                _sessionmaker = sessionmaker(autocommit=False, autoflush=False, bind=get_engine())
     return _sessionmaker()
 
 


### PR DESCRIPTION
…ne on set_engine

Thread-safety:
- Guard lazy initialization of _engine and _sessionmaker with a reentrant lock (RLock) so concurrent FastAPI requests don't race on create_engine or sessionmaker.
- Double-checked locking pattern avoids the lock cost on the fast path.

Dispose:
- set_engine() now disposes the previous engine's connection pool instead of leaking it, and does so outside the lock so the new engine is immediately visible.

Health endpoint:
- Log the caught exception server-side so operators can diagnose failures without exposing internals in the response body.

Test hygiene:
- Remove redundant set_engine() call in test_health.py (already handled by the client fixture via override_route_db_session).