### PR TITLE
feat(ingestion): add threading.Semaphore(2) to limit concurrent backg…

### DIFF
--- a/ingestion/src/ingestion/tasks.py
+++ b/ingestion/src/ingestion/tasks.py
@@ -5,6 +5,8 @@ This module is the only place that couples the pipeline to the task runner;
 ``ingestion/pipeline.py`` remains a plain function.
 """
 
+import threading
+
 from fastapi import BackgroundTasks
 
 from core.clients import Embedder
@@ -14,6 +16,8 @@ from core.exceptions import IngestionError
 from core.types.document import DocumentStatus
 from ingestion.models import PendingIngestion
 from ingestion.pipeline import run_ingestion
+
+_INGESTION_SEMAPHORE = threading.Semaphore(2)
 
 
 def _execute_ingestion_task(
@@ -25,41 +29,45 @@ def _execute_ingestion_task(
 
     Opens its own database session so that a pipeline failure can be captured
     and persisted as ``status='failed'`` after rolling back the partial work.
+
+    A ``threading.Semaphore(2)`` bounds peak memory by capping the number of
+    ingestion pipelines that can run concurrently.
     """
-    session = get_session()
-    try:
-        title = ""
-        document = session.get(Document, pending.document_id)
-        if document is not None:
-            title = document.title
-
-        resolved = pending.model_copy(update={"title": title})
-        run_ingestion(
-            pending=resolved,
-            session=session,
-            embeddings_client=embedder,
-            model_name=model_name,
-        )
-        session.commit()
-    except Exception as exc:
-        session.rollback()
-        error_message = str(exc)
-        if isinstance(exc, IngestionError) and exc.__cause__ is not None:
-            error_message = f"{exc}: {exc.__cause__}"
-
-        # Update the document row in a fresh mini-transaction so the failure
-        # reason is retained after the main transaction rolls back.
+    with _INGESTION_SEMAPHORE:
+        session = get_session()
         try:
-            failure_session = get_session()
-            failure_document = failure_session.get(Document, pending.document_id)
-            if failure_document is not None:
-                failure_document.status = DocumentStatus.FAILED
-                failure_document.error_message = error_message
-                failure_session.commit()
+            title = ""
+            document = session.get(Document, pending.document_id)
+            if document is not None:
+                title = document.title
+
+            resolved = pending.model_copy(update={"title": title})
+            run_ingestion(
+                pending=resolved,
+                session=session,
+                embeddings_client=embedder,
+                model_name=model_name,
+            )
+            session.commit()
+        except Exception as exc:
+            session.rollback()
+            error_message = str(exc)
+            if isinstance(exc, IngestionError) and exc.__cause__ is not None:
+                error_message = f"{exc}: {exc.__cause__}"
+
+            # Update the document row in a fresh mini-transaction so the failure
+            # reason is retained after the main transaction rolls back.
+            try:
+                failure_session = get_session()
+                failure_document = failure_session.get(Document, pending.document_id)
+                if failure_document is not None:
+                    failure_document.status = DocumentStatus.FAILED
+                    failure_document.error_message = error_message
+                    failure_session.commit()
+            finally:
+                failure_session.close()
         finally:
-            failure_session.close()
-    finally:
-        session.close()
+            session.close()
 
 
 def schedule_ingestion(

--- a/ingestion/tests/ingestion/test_tasks.py
+++ b/ingestion/tests/ingestion/test_tasks.py
@@ -1,12 +1,21 @@
 """Tests for the FastAPI background-tasks glue layer."""
 
-from unittest.mock import MagicMock
+import threading
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 from core.clients import InMemoryEmbedder
 from core.types.document import DocumentType
 from ingestion.models import PendingIngestion
 from ingestion.tasks import schedule_ingestion
+
+_SHARED_PENDING = PendingIngestion(
+    document_id=uuid4(),
+    title="Test",
+    document_type=DocumentType.PAPER,
+    source_filename="test.pdf",
+    file_bytes=b"data",
+)
 
 
 def test_schedule_ingestion_adds_background_task() -> None:
@@ -47,3 +56,69 @@ def test_schedule_ingestion_is_public_api() -> None:
     from ingestion.tasks import __all__
 
     assert "schedule_ingestion" in __all__
+
+
+# ── Concurrency-limiter tests ─────────────────────────────────────────────
+
+
+def _make_mock_session() -> MagicMock:
+    """Build a MagicMock session that behaves like one with a found document."""
+    sess = MagicMock()
+    doc = MagicMock()
+    doc.title = "Test"
+    sess.get.return_value = doc
+    return sess
+
+
+def test_ingestion_semaphore_initial_value() -> None:
+    """The ingestion semaphore is initialised with count 2."""
+    from ingestion.tasks import _INGESTION_SEMAPHORE
+
+    assert isinstance(_INGESTION_SEMAPHORE, threading.Semaphore)
+    assert _INGESTION_SEMAPHORE._value == 2
+
+
+def test_semaphore_released_on_success() -> None:
+    """_execute_ingestion_task releases the semaphore after a successful run."""
+    from ingestion.tasks import _INGESTION_SEMAPHORE, _execute_ingestion_task
+
+    with (
+        patch("ingestion.tasks.get_session", return_value=_make_mock_session()),
+        patch("ingestion.tasks.run_ingestion") as mock_run,
+    ):
+        initial = _INGESTION_SEMAPHORE._value
+        _execute_ingestion_task(_SHARED_PENDING, InMemoryEmbedder(), "model")
+        assert _INGESTION_SEMAPHORE._value == initial
+        mock_run.assert_called_once()
+
+
+def test_semaphore_released_on_failure() -> None:
+    """_execute_ingestion_task releases the semaphore when the pipeline raises."""
+    from ingestion.tasks import _INGESTION_SEMAPHORE, _execute_ingestion_task
+
+    with (
+        patch("ingestion.tasks.get_session", return_value=_make_mock_session()),
+        patch("ingestion.tasks.run_ingestion", side_effect=ValueError("boom")),
+        patch("ingestion.tasks.get_session") as mock_get_session,  # for failure handling
+    ):
+        mock_get_session.return_value = _make_mock_session()
+        initial = _INGESTION_SEMAPHORE._value
+        _execute_ingestion_task(_SHARED_PENDING, InMemoryEmbedder(), "model")
+        assert _INGESTION_SEMAPHORE._value == initial
+
+
+def test_semaphore_blocks_third_concurrent_call() -> None:
+    """When both permits are held, a third acquire(blocking=False) returns False."""
+    from ingestion.tasks import _INGESTION_SEMAPHORE
+
+    acquired: list[bool] = []
+    for _ in range(2):
+        acquired.append(_INGESTION_SEMAPHORE.acquire(blocking=False))
+    assert acquired == [True, True]
+
+    blocked = _INGESTION_SEMAPHORE.acquire(blocking=False)
+    assert blocked is False
+
+    # Restore permits
+    _INGESTION_SEMAPHORE.release()
+    _INGESTION_SEMAPHORE.release()


### PR DESCRIPTION
…round ingestion

Implements a concurrency limiter via a module-level threading.Semaphore(2) in _execute_ingestion_task to bound peak memory when multiple /ingest requests arrive in parallel.

- Adds _INGESTION_SEMAPHORE = threading.Semaphore(2) to tasks.py
- Wraps the pipeline body in the semaphore context manager
- New tests verify initial value (2), release on success, release on failure, and blocking behavior when both permits are held

Closes #119