### PR TITLE
refactor(ingestion): pass file paths instead of bytes through ingesti…

### DIFF
--- a/api/src/api/routes/ingest.py
+++ b/api/src/api/routes/ingest.py
@@ -1,5 +1,9 @@
 """Ingestion route: POST /ingest."""
 
+import atexit
+import contextlib
+import os
+import tempfile
 from pathlib import Path
 from typing import Annotated
 from uuid import UUID
@@ -35,19 +39,41 @@ def _extension(filename: str | None) -> str | None:
     return suffix if suffix else None
 
 
-async def _read_upload_with_limit(upload: UploadFile, max_bytes: int) -> bytes:
-    """Read upload contents, raising 413 if the limit is exceeded."""
-    chunks: list[bytes] = []
+# Track temp files handed off to background tasks so the atexit handler can
+# clean them up if the process exits before the background task runs.
+_pending_temp_files: set[Path] = set()
+
+
+@atexit.register
+def _cleanup_pending_temp_files() -> None:
+    for path in _pending_temp_files:
+        with contextlib.suppress(OSError):
+            path.unlink(missing_ok=True)
+
+
+async def _save_upload_to_temp(upload: UploadFile, max_bytes: int) -> Path:
+    """Write upload to a temp file, raising 413 if the limit is exceeded.
+
+    Returns the ``Path`` to the temp file, which the caller is responsible for
+    cleaning up after the background ingestion task completes.
+    """
+    suffix = Path(upload.filename or "upload").suffix or ".tmp"
+    fd, path = tempfile.mkstemp(suffix=suffix)
     total = 0
-    while True:
-        chunk = await upload.read(8192)
-        if not chunk:
-            break
-        total += len(chunk)
-        if total > max_bytes:
-            raise HTTPException(status_code=413, detail="File exceeds maximum upload size")
-        chunks.append(chunk)
-    return b"".join(chunks)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            while True:
+                chunk = await upload.read(8192)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > max_bytes:
+                    raise HTTPException(status_code=413, detail="File exceeds maximum upload size")
+                f.write(chunk)
+    except Exception:
+        os.unlink(path)
+        raise
+    return Path(path)
 
 
 @router.post("/ingest", status_code=202, response_model=DocumentStatusResponse)
@@ -73,7 +99,7 @@ async def ingest_document(
             detail=f"Unsupported file type: {extension or 'unknown'}",
         )
 
-    file_bytes = await _read_upload_with_limit(file, settings.max_upload_bytes)
+    file_path = await _save_upload_to_temp(file, settings.max_upload_bytes)
     source_filename = file.filename or "upload"
 
     try:
@@ -88,6 +114,7 @@ async def ingest_document(
             document_id: UUID = document.document_id
             response_body = DocumentStatusResponse.model_validate(document)
     except Exception as exc:
+        os.unlink(file_path)
         raise HTTPException(status_code=500, detail=f"Failed to create document: {exc}") from exc
 
     schedule_ingestion(
@@ -97,11 +124,13 @@ async def ingest_document(
             title=title,
             document_type=document_type,
             source_filename=source_filename,
-            file_bytes=file_bytes,
+            file_path=file_path,
         ),
         embedder=embedder,
         model_name=settings.embedding_model,
     )
+
+    _pending_temp_files.add(file_path)
 
     location = request.url_for("get_document", document_id=str(document_id))
     response.headers["Location"] = str(location)

--- a/conftest.py
+++ b/conftest.py
@@ -8,7 +8,8 @@ If the database is unavailable, the fixtures skip the test.
 import io
 import os
 import zipfile
-from collections.abc import Generator
+from collections.abc import Callable, Generator
+from pathlib import Path
 from urllib.parse import urlparse
 
 import pytest
@@ -102,6 +103,27 @@ def test_session(test_engine: Engine) -> Generator[Session, None, None]:
         yield session
     finally:
         session.close()
+
+
+@pytest.fixture
+def temp_file(tmp_path: Path) -> Callable[..., Path]:
+    """Write fixture bytes to a temp file and return the Path.
+
+    Usage::
+
+        pdf_path = temp_file(sample_paper_pdf, "sample.pdf")
+        md_path = temp_file(sample_documentation_md, "docs.md")
+
+    The file is created under ``tmp_path`` and cleaned up automatically by
+    pytest's tmp_path lifecycle.
+    """
+
+    def _write(content: bytes, filename: str = "temp") -> Path:
+        path = tmp_path / filename
+        path.write_bytes(content)
+        return path
+
+    return _write
 
 
 @pytest.fixture

--- a/ingestion/src/ingestion/models.py
+++ b/ingestion/src/ingestion/models.py
@@ -1,5 +1,6 @@
 """Pydantic models for the ingestion package."""
 
+from pathlib import Path
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -20,4 +21,4 @@ class PendingIngestion(BaseModel):
     title: str
     document_type: DocumentType
     source_filename: str
-    file_bytes: bytes
+    file_path: Path

--- a/ingestion/src/ingestion/pipeline.py
+++ b/ingestion/src/ingestion/pipeline.py
@@ -1,6 +1,7 @@
 """Background ingestion pipeline for uploaded documents."""
 
 from collections.abc import Sequence
+from pathlib import Path
 
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
@@ -54,7 +55,7 @@ def _chunk_inputs(
 
 def _chunk_document(
     document_type: DocumentType,
-    file_bytes: bytes,
+    file_path: Path,
 ) -> list[tuple[str, dict[str, object], int]]:
     """Return (content, type_metadata, token_count) tuples for a document.
 
@@ -63,7 +64,7 @@ def _chunk_document(
     function does not need to change.
     """
     chunker_class = get_chunker_class(document_type)
-    return _chunk_inputs(chunker_class().chunk(file_bytes))
+    return _chunk_inputs(chunker_class().chunk(file_path))
 
 
 def _embed_chunks(
@@ -124,7 +125,7 @@ def run_ingestion(
 
     try:
         # validating phase: ensure the file is parseable for the document type.
-        chunk_inputs = _chunk_document(pending.document_type, pending.file_bytes)
+        chunk_inputs = _chunk_document(pending.document_type, pending.file_path)
 
         document.status = DocumentStatus.CHUNKING
         session.flush()

--- a/ingestion/src/ingestion/tasks.py
+++ b/ingestion/src/ingestion/tasks.py
@@ -32,6 +32,8 @@ def _execute_ingestion_task(
 
     A ``threading.Semaphore(2)`` bounds peak memory by capping the number of
     ingestion pipelines that can run concurrently.
+
+    Cleans up the temp file at ``pending.file_path`` when done.
     """
     with _INGESTION_SEMAPHORE:
         session = get_session()
@@ -68,6 +70,7 @@ def _execute_ingestion_task(
                 failure_session.close()
         finally:
             session.close()
+            pending.file_path.unlink(missing_ok=True)
 
 
 def schedule_ingestion(

--- a/ingestion/tests/ingestion/test_pipeline.py
+++ b/ingestion/tests/ingestion/test_pipeline.py
@@ -1,5 +1,7 @@
 """Integration tests for the ingestion pipeline."""
 
+from collections.abc import Callable
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -28,8 +30,10 @@ def test_pipeline_happy_path_reaches_ready(
     test_session: Session,
     fake_embeddings_client: MagicMock,
     sample_paper_pdf: bytes,
+    temp_file: Callable[..., Path],
 ) -> None:
     """A paper ingestion advances validating -> chunking -> embedding -> ready."""
+    pdf_path = temp_file(sample_paper_pdf, "sample.pdf")
     document = Document(
         title="Sample Paper",
         document_type=DocumentType.PAPER,
@@ -44,7 +48,7 @@ def test_pipeline_happy_path_reaches_ready(
             title="Sample Paper",
             document_type=DocumentType.PAPER,
             source_filename="sample.pdf",
-            file_bytes=sample_paper_pdf,
+            file_path=pdf_path,
         ),
         session=test_session,
         embeddings_client=fake_embeddings_client,
@@ -86,8 +90,10 @@ def test_pipeline_happy_path_reaches_ready(
 def test_pipeline_failure_marks_failed_with_error(
     test_session: Session,
     sample_paper_pdf: bytes,
+    temp_file: Callable[..., Path],
 ) -> None:
     """A mocked embeddings client that raises surfaces as a failure."""
+    pdf_path = temp_file(sample_paper_pdf, "sample.pdf")
     document = Document(
         title="Failing Paper",
         document_type=DocumentType.PAPER,
@@ -106,7 +112,7 @@ def test_pipeline_failure_marks_failed_with_error(
                 title="Failing Paper",
                 document_type=DocumentType.PAPER,
                 source_filename="fail.pdf",
-                file_bytes=sample_paper_pdf,
+                file_path=pdf_path,
             ),
             session=test_session,
             embeddings_client=failing_client,
@@ -124,8 +130,10 @@ def test_pipeline_book_happy_path_reaches_ready(
     test_session: Session,
     fake_embeddings_client: MagicMock,
     sample_book_pdf: bytes,
+    temp_file: Callable[..., Path],
 ) -> None:
     """A book ingestion advances validating -> chunking -> embedding -> ready."""
+    pdf_path = temp_file(sample_book_pdf, "sample.pdf")
     document = Document(
         title="Sample Book",
         document_type=DocumentType.BOOK,
@@ -140,7 +148,7 @@ def test_pipeline_book_happy_path_reaches_ready(
             title="Sample Book",
             document_type=DocumentType.BOOK,
             source_filename="sample.pdf",
-            file_bytes=sample_book_pdf,
+            file_path=pdf_path,
         ),
         session=test_session,
         embeddings_client=fake_embeddings_client,
@@ -178,8 +186,10 @@ def test_pipeline_documentation_happy_path_reaches_ready(
     test_session: Session,
     fake_embeddings_client: MagicMock,
     sample_documentation_md: bytes,
+    temp_file: Callable[..., Path],
 ) -> None:
     """A documentation ingestion advances validating -> chunking -> embedding -> ready."""
+    md_path = temp_file(sample_documentation_md, "docs.md")
     document = Document(
         title="Sample Docs",
         document_type=DocumentType.DOCUMENTATION,
@@ -194,7 +204,7 @@ def test_pipeline_documentation_happy_path_reaches_ready(
             title="Sample Docs",
             document_type=DocumentType.DOCUMENTATION,
             source_filename="docs.md",
-            file_bytes=sample_documentation_md,
+            file_path=md_path,
         ),
         session=test_session,
         embeddings_client=fake_embeddings_client,
@@ -228,8 +238,10 @@ def test_reingestion_creates_new_document_id(
     test_session: Session,
     fake_embeddings_client: MagicMock,
     sample_paper_pdf: bytes,
+    temp_file: Callable[..., Path],
 ) -> None:
     """Re-uploading creates a new row; old chunks and embeddings coexist."""
+    pdf_path = temp_file(sample_paper_pdf, "sample.pdf")
     first = Document(
         title="Paper",
         document_type=DocumentType.PAPER,
@@ -243,7 +255,7 @@ def test_reingestion_creates_new_document_id(
             title="Paper",
             document_type=DocumentType.PAPER,
             source_filename="sample.pdf",
-            file_bytes=sample_paper_pdf,
+            file_path=pdf_path,
         ),
         session=test_session,
         embeddings_client=fake_embeddings_client,
@@ -255,6 +267,7 @@ def test_reingestion_creates_new_document_id(
         test_session.query(Chunk).filter(Chunk.document_id == first.document_id).count()
     )
 
+    second_pdf_path = temp_file(sample_paper_pdf, "sample2.pdf")
     second = Document(
         title="Paper",
         document_type=DocumentType.PAPER,
@@ -268,7 +281,7 @@ def test_reingestion_creates_new_document_id(
             title="Paper",
             document_type=DocumentType.PAPER,
             source_filename="sample.pdf",
-            file_bytes=sample_paper_pdf,
+            file_path=second_pdf_path,
         ),
         session=test_session,
         embeddings_client=fake_embeddings_client,
@@ -376,7 +389,7 @@ class TestPipelineValidation:
                         title="Bad Book",
                         document_type=DocumentType.BOOK,
                         source_filename="bad.pdf",
-                        file_bytes=b"irrelevant",
+                        file_path=Path("/tmp/fake"),
                     ),
                     session=test_session,
                     embeddings_client=fake_embeddings_client,
@@ -412,7 +425,7 @@ class TestPipelineValidation:
                         title="Bad Paper",
                         document_type=DocumentType.PAPER,
                         source_filename="bad.pdf",
-                        file_bytes=b"irrelevant",
+                        file_path=Path("/tmp/fake"),
                     ),
                     session=test_session,
                     embeddings_client=fake_embeddings_client,
@@ -427,8 +440,10 @@ class TestPipelineValidation:
         test_session: Session,
         fake_embeddings_client: MagicMock,
         sample_book_pdf: bytes,
+        temp_file: Callable[..., Path],
     ) -> None:
         """Existing book happy path is not broken by validation step."""
+        pdf_path = temp_file(sample_book_pdf, "sample.pdf")
         document = Document(
             title="Sample Book",
             document_type=DocumentType.BOOK,
@@ -443,7 +458,7 @@ class TestPipelineValidation:
                 title="Sample Book",
                 document_type=DocumentType.BOOK,
                 source_filename="sample.pdf",
-                file_bytes=sample_book_pdf,
+                file_path=pdf_path,
             ),
             session=test_session,
             embeddings_client=fake_embeddings_client,
@@ -474,8 +489,10 @@ class TestParentChildIngestion:
         test_session: Session,
         fake_embeddings_client: MagicMock,
         sample_paper_pdf: bytes,
+        temp_file: Callable[..., Path],
     ) -> None:
         """Parent rows are stored without embeddings; children are embedded."""
+        pdf_path = temp_file(sample_paper_pdf, "sample.pdf")
         document = Document(
             title="PC Paper",
             document_type=DocumentType.PAPER,
@@ -490,7 +507,7 @@ class TestParentChildIngestion:
                 title="PC Paper",
                 document_type=DocumentType.PAPER,
                 source_filename="pc.pdf",
-                file_bytes=sample_paper_pdf,
+                file_path=pdf_path,
             ),
             session=test_session,
             embeddings_client=fake_embeddings_client,
@@ -550,7 +567,7 @@ class TestParentChildIngestion:
                     title="Big Parent",
                     document_type=DocumentType.PAPER,
                     source_filename="big.pdf",
-                    file_bytes=b"fake",
+                    file_path=Path("/tmp/fake"),
                 ),
                 session=test_session,
                 embeddings_client=fake_embeddings_client,
@@ -598,7 +615,7 @@ class TestParentChildIngestion:
                     title="Small Parent",
                     document_type=DocumentType.PAPER,
                     source_filename="small.pdf",
-                    file_bytes=b"fake",
+                    file_path=Path("/tmp/fake"),
                 ),
                 session=test_session,
                 embeddings_client=fake_embeddings_client,
@@ -644,7 +661,7 @@ class TestParentChildIngestion:
                     title="Inherit Test",
                     document_type=DocumentType.BOOK,
                     source_filename="inherit.pdf",
-                    file_bytes=b"fake",
+                    file_path=Path("/tmp/fake"),
                 ),
                 session=test_session,
                 embeddings_client=fake_embeddings_client,
@@ -695,7 +712,7 @@ class TestParentChildIngestion:
                     title="Position Test",
                     document_type=DocumentType.PAPER,
                     source_filename="pos.pdf",
-                    file_bytes=b"fake",
+                    file_path=Path("/tmp/fake"),
                 ),
                 session=test_session,
                 embeddings_client=fake_embeddings_client,

--- a/ingestion/tests/ingestion/test_tasks.py
+++ b/ingestion/tests/ingestion/test_tasks.py
@@ -1,6 +1,7 @@
 """Tests for the FastAPI background-tasks glue layer."""
 
 import threading
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -14,7 +15,7 @@ _SHARED_PENDING = PendingIngestion(
     title="Test",
     document_type=DocumentType.PAPER,
     source_filename="test.pdf",
-    file_bytes=b"data",
+    file_path=Path("/tmp/fake"),
 )
 
 
@@ -30,7 +31,7 @@ def test_schedule_ingestion_adds_background_task() -> None:
         title="Test Document",
         document_type=DocumentType.PAPER,
         source_filename="test.pdf",
-        file_bytes=b"fake-pdf-bytes",
+        file_path=Path("/tmp/fake"),
     )
 
     schedule_ingestion(

--- a/retrieval_qa/src/retrieval_qa/chunking/base.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/base.py
@@ -2,6 +2,7 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from pathlib import Path
 from typing import ClassVar
 
 from pydantic import BaseModel
@@ -17,11 +18,11 @@ class DocumentChunker(ABC):
     metadata_model: ClassVar[type[BaseModel]]
 
     @abstractmethod
-    def chunk(self, file_bytes: bytes) -> Sequence[Chunk]:
-        """Chunk ``file_bytes`` into a sequence of ``Chunk`` objects.
+    def chunk(self, file_path: Path) -> Sequence[Chunk]:
+        """Chunk a file into a sequence of ``Chunk`` objects.
 
         Args:
-            file_bytes: Raw uploaded file contents.
+            file_path: Path to the uploaded file on disk.
 
         Returns:
             Chunks ordered by their appearance in the document.

--- a/retrieval_qa/src/retrieval_qa/chunking/book_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/book_chunker.py
@@ -11,7 +11,7 @@ import zipfile
 from collections.abc import Sequence
 from enum import StrEnum
 from html.parser import HTMLParser
-from io import BytesIO
+from pathlib import Path
 
 from pydantic import ConfigDict
 from pypdf import PdfReader
@@ -198,10 +198,10 @@ def _split_into_chapters(text: str) -> list[tuple[int, str | None, str]]:
     return sections
 
 
-def _extract_text_from_pdf(pdf_bytes: bytes) -> str:
-    """Extract text from a PDF byte stream."""
+def _extract_text_from_pdf(pdf_path: Path) -> str:
+    """Extract text from a PDF file on disk."""
     try:
-        reader = PdfReader(BytesIO(pdf_bytes))
+        reader = PdfReader(pdf_path)
     except Exception as exc:
         raise IngestionError(f"Failed to parse PDF: {exc}") from exc
 
@@ -283,7 +283,7 @@ def _extract_epub_text(
     return "\n\n".join(parts)
 
 
-def _extract_chapters_from_epub(epub_bytes: bytes) -> list[tuple[int, str | None, str]]:
+def _extract_chapters_from_epub(epub_path: Path) -> list[tuple[int, str | None, str]]:
     """Extract chapters from an EPUB using native HTML heading structure.
 
     Uses the EPUB spine order and HTML heading tags (``<h1>``--``<h6>``) to
@@ -292,7 +292,7 @@ def _extract_chapters_from_epub(epub_bytes: bytes) -> list[tuple[int, str | None
     chapter.  Falls back to regex heuristics when no heading tags are present.
     """
     try:
-        with zipfile.ZipFile(BytesIO(epub_bytes)) as archive:
+        with zipfile.ZipFile(epub_path) as archive:
             container_xml = archive.read("META-INF/container.xml").decode("utf-8")
             opf_path = _opf_root_path(container_xml)
             opf_dir = os.path.dirname(opf_path)
@@ -338,14 +338,19 @@ def _extract_chapters_from_epub(epub_bytes: bytes) -> list[tuple[int, str | None
         raise IngestionError(f"Failed to parse EPUB: {exc}") from exc
 
 
-def _detect_format(file_bytes: bytes) -> BookFormat:
-    """Detect whether ``file_bytes`` is a PDF or EPUB."""
-    if file_bytes.startswith(b"%PDF"):
+def _detect_format(file_path: Path) -> BookFormat:
+    """Detect whether a file at ``file_path`` is a PDF or EPUB."""
+    fd = os.open(file_path, os.O_RDONLY)
+    try:
+        head = os.read(fd, 4)
+    finally:
+        os.close(fd)
+    if head.startswith(b"%PDF"):
         return BookFormat.PDF
 
-    if file_bytes.startswith(b"PK"):
+    if head.startswith(b"PK"):
         try:
-            with zipfile.ZipFile(BytesIO(file_bytes)) as archive:
+            with zipfile.ZipFile(file_path) as archive:
                 if "mimetype" in archive.namelist():
                     mimetype = archive.read("mimetype").strip().lower()
                     if mimetype == b"application/epub+zip":
@@ -356,11 +361,11 @@ def _detect_format(file_bytes: bytes) -> BookFormat:
     raise IngestionError("Unsupported book format: expected PDF or EPUB")
 
 
-def chunk_book(file_bytes: bytes) -> list[BookChunk]:
+def chunk_book(file_path: Path) -> list[BookChunk]:
     """Extract text from a book PDF or EPUB and split it into chunks.
 
     Args:
-        file_bytes: Raw PDF or EPUB file contents.
+        file_path: Path to the PDF or EPUB file on disk.
 
     Returns:
         A list of chunks ordered by their appearance in the document.
@@ -369,14 +374,14 @@ def chunk_book(file_bytes: bytes) -> list[BookChunk]:
         IngestionError: The file could not be parsed or is not a supported
             book format.
     """
-    document_format = _detect_format(file_bytes)
+    document_format = _detect_format(file_path)
     if document_format is BookFormat.PDF:
-        raw_text = _extract_text_from_pdf(file_bytes)
+        raw_text = _extract_text_from_pdf(file_path)
         if not raw_text.strip():
             raise IngestionError("Book contains no extractable text")
         chapters = _split_into_chapters(raw_text)
     else:
-        chapters = _extract_chapters_from_epub(file_bytes)
+        chapters = _extract_chapters_from_epub(file_path)
 
     if not chapters:
         raise IngestionError("Book contains no extractable text")
@@ -414,9 +419,9 @@ class BookChunker(DocumentChunker):
 
     metadata_model = BookChunkMetadata
 
-    def chunk(self, file_bytes: bytes) -> Sequence[Chunk]:
+    def chunk(self, file_path: Path) -> Sequence[Chunk]:
         """Chunk a book PDF or EPUB into chapter-aware pieces."""
-        return chunk_book(file_bytes)
+        return chunk_book(file_path)
 
 
 register_chunker(DocumentType.BOOK, BookChunker)

--- a/retrieval_qa/src/retrieval_qa/chunking/documentation_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/documentation_chunker.py
@@ -8,10 +8,11 @@ PDF page breaks). Sections include sub-headings and API endpoint lines such as
 ``GET /api/v1/users``.
 """
 
+import os
 import re
 from collections.abc import Sequence
 from enum import StrEnum
-from io import BytesIO
+from pathlib import Path
 
 from pydantic import ConfigDict
 from pypdf import PdfReader
@@ -78,22 +79,27 @@ class _HTMLTextExtractor(_BaseHTMLTextExtractor):
             super().handle_endtag(tag)
 
 
-def _detect_format(file_bytes: bytes) -> DocumentationFormat:
-    """Detect whether ``file_bytes`` is PDF, HTML, or Markdown/text."""
-    if file_bytes.startswith(b"%PDF"):
+def _detect_format(file_path: Path) -> DocumentationFormat:
+    """Detect whether a file at ``file_path`` is PDF, HTML, or Markdown/text."""
+    fd = os.open(file_path, os.O_RDONLY)
+    try:
+        raw = os.read(fd, 2048)
+    finally:
+        os.close(fd)
+    if raw.startswith(b"%PDF"):
         return DocumentationFormat.PDF
 
-    head = file_bytes[:2048].lower()
+    head = raw.lower()
     if b"<!doctype html" in head or b"<html" in head:
         return DocumentationFormat.HTML
 
     return DocumentationFormat.MARKDOWN
 
 
-def _extract_text_from_html(html_bytes: bytes) -> str:
+def _extract_text_from_html(html_path: Path) -> str:
     """Strip HTML tags and convert headings to Markdown-style markers."""
     try:
-        text = html_bytes.decode("utf-8")
+        text = html_path.read_bytes().decode("utf-8")
     except UnicodeDecodeError as exc:
         raise IngestionError(f"Failed to decode HTML as UTF-8: {exc}") from exc
 
@@ -103,14 +109,14 @@ def _extract_text_from_html(html_bytes: bytes) -> str:
     return extractor.get_text()
 
 
-def _extract_text_from_pdf(pdf_bytes: bytes) -> str:
+def _extract_text_from_pdf(pdf_path: Path) -> str:
     """Extract text from a PDF, inserting a page marker before each page.
 
     The page markers let the Markdown-style splitter treat each PDF page as a
     top-level documentation page.
     """
     try:
-        reader = PdfReader(BytesIO(pdf_bytes))
+        reader = PdfReader(pdf_path)
     except Exception as exc:
         raise IngestionError(f"Failed to parse PDF: {exc}") from exc
 
@@ -175,27 +181,27 @@ def _split_documentation(text: str) -> list[tuple[str, str | None, str]]:
     return sections
 
 
-def _extract_text(file_bytes: bytes, document_format: DocumentationFormat) -> str:
+def _extract_text(file_path: Path, document_format: DocumentationFormat) -> str:
     """Extract plain text from a documentation file in the given format."""
     match document_format:
         case DocumentationFormat.PDF:
-            return _extract_text_from_pdf(file_bytes)
+            return _extract_text_from_pdf(file_path)
         case DocumentationFormat.HTML:
-            return _extract_text_from_html(file_bytes)
+            return _extract_text_from_html(file_path)
         case DocumentationFormat.MARKDOWN:
             try:
-                return file_bytes.decode("utf-8")
+                return file_path.read_bytes().decode("utf-8")
             except UnicodeDecodeError as exc:
                 raise IngestionError(f"Failed to decode Markdown as UTF-8: {exc}") from exc
         case _ as unreachable:
             raise IngestionError(f"Unsupported documentation format: {unreachable}")
 
 
-def chunk_documentation(file_bytes: bytes) -> list[DocumentationChunk]:
+def chunk_documentation(file_path: Path) -> list[DocumentationChunk]:
     """Extract text from a documentation file and split it into chunks.
 
     Args:
-        file_bytes: Raw Markdown, HTML, or PDF file contents.
+        file_path: Path to the Markdown, HTML, or PDF file on disk.
 
     Returns:
         A list of chunks ordered by their appearance in the document.
@@ -204,8 +210,8 @@ def chunk_documentation(file_bytes: bytes) -> list[DocumentationChunk]:
         IngestionError: The file could not be parsed or contains no extractable
             text.
     """
-    document_format = _detect_format(file_bytes)
-    raw_text = _extract_text(file_bytes, document_format)
+    document_format = _detect_format(file_path)
+    raw_text = _extract_text(file_path, document_format)
 
     if not raw_text.strip():
         raise IngestionError("Documentation contains no extractable text")
@@ -246,9 +252,9 @@ class DocumentationChunker(DocumentChunker):
 
     metadata_model = DocumentationChunkMetadata
 
-    def chunk(self, file_bytes: bytes) -> Sequence[Chunk]:
+    def chunk(self, file_path: Path) -> Sequence[Chunk]:
         """Chunk a Markdown/HTML/PDF documentation file into page-aware pieces."""
-        return chunk_documentation(file_bytes)
+        return chunk_documentation(file_path)
 
 
 register_chunker(DocumentType.DOCUMENTATION, DocumentationChunker)

--- a/retrieval_qa/src/retrieval_qa/chunking/paper_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/paper_chunker.py
@@ -6,7 +6,7 @@ emitting ``PaperChunkMetadata`` for each chunk.
 
 import re
 from collections.abc import Sequence
-from io import BytesIO
+from pathlib import Path
 
 from pydantic import ConfigDict
 from pypdf import PdfReader
@@ -74,11 +74,11 @@ def _split_into_sections(text: str) -> list[tuple[str, str | None, str]]:
     return sections
 
 
-def chunk_paper(pdf_bytes: bytes) -> list[PaperChunk]:
+def chunk_paper(pdf_path: Path) -> list[PaperChunk]:
     """Extract text from a paper PDF and split it into chunks.
 
     Args:
-        pdf_bytes: Raw PDF file contents.
+        pdf_path: Path to the PDF file on disk.
 
     Returns:
         A list of chunks ordered by their appearance in the document.
@@ -87,7 +87,7 @@ def chunk_paper(pdf_bytes: bytes) -> list[PaperChunk]:
         IngestionError: The PDF could not be read.
     """
     try:
-        reader = PdfReader(BytesIO(pdf_bytes))
+        reader = PdfReader(pdf_path)
     except Exception as exc:
         raise IngestionError(f"Failed to parse PDF: {exc}") from exc
 
@@ -142,9 +142,9 @@ class PaperChunker(DocumentChunker):
 
     metadata_model = PaperChunkMetadata
 
-    def chunk(self, file_bytes: bytes) -> Sequence[Chunk]:
+    def chunk(self, file_path: Path) -> Sequence[Chunk]:
         """Chunk a paper PDF into section-aware pieces."""
-        return chunk_paper(file_bytes)
+        return chunk_paper(file_path)
 
 
 register_chunker(DocumentType.PAPER, PaperChunker)

--- a/retrieval_qa/tests/retrieval_qa/test_book_chunker.py
+++ b/retrieval_qa/tests/retrieval_qa/test_book_chunker.py
@@ -1,7 +1,8 @@
 """Tests for the book chunker."""
 
-import io
 import zipfile
+from collections.abc import Callable
+from pathlib import Path
 
 import pytest
 
@@ -10,16 +11,12 @@ from core.types.chunk import BookChunkMetadata
 from retrieval_qa.chunking.book_chunker import chunk_book
 
 
-def _make_epub(chapters: list[tuple[str, str, str]]) -> bytes:
-    """Build an in-memory EPUB from chapter specs.
+def _make_epub(chapters: list[tuple[str, str, str]], epub_path: Path) -> Path:
+    """Build an EPUB file from chapter specs.
 
     Each tuple is ``(file_name, xhtml_body, spine_idref)``.
-
-    The *xhtml_body* is placed directly inside ``<body>...</body>``.
-    All chapters share the same OPF manifest/spine structure.
     """
-    buffer = io.BytesIO()
-    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+    with zipfile.ZipFile(epub_path, "w", zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("mimetype", "application/epub+zip", compress_type=zipfile.ZIP_STORED)
         zf.writestr(
             "META-INF/container.xml",
@@ -63,13 +60,16 @@ def _make_epub(chapters: list[tuple[str, str, str]]) -> bytes:
                 "<head><title>Test</title></head>"
                 f"<body>{body}</body></html>",
             )
-    buffer.seek(0)
-    return buffer.read()
+    return epub_path
 
 
-def test_book_chunker_emits_chapters(sample_book_pdf: bytes) -> None:
+def test_book_chunker_emits_chapters(
+    sample_book_pdf: bytes,
+    temp_file: Callable[..., Path],
+) -> None:
     """chunk_book extracts text and splits it into ordered chunks."""
-    chunks = chunk_book(sample_book_pdf)
+    pdf_path = temp_file(sample_book_pdf, "sample.pdf")
+    chunks = chunk_book(pdf_path)
 
     assert len(chunks) >= 1
     for chunk in chunks:
@@ -80,18 +80,23 @@ def test_book_chunker_emits_chapters(sample_book_pdf: bytes) -> None:
         assert chunk.metadata.heading is None or isinstance(chunk.metadata.heading, str)
 
 
-def test_book_chunker_detects_chapter_boundaries(sample_book_pdf: bytes) -> None:
+def test_book_chunker_detects_chapter_boundaries(
+    sample_book_pdf: bytes,
+    temp_file: Callable[..., Path],
+) -> None:
     """Detected chapter boundaries are reflected in chunk metadata."""
-    chunks = chunk_book(sample_book_pdf)
+    pdf_path = temp_file(sample_book_pdf, "sample.pdf")
+    chunks = chunk_book(pdf_path)
 
     chapters = [chunk.metadata.chapter for chunk in chunks]
     assert 1 in chapters
     assert 2 in chapters
 
 
-def test_book_chunker_epub(sample_book_epub: bytes) -> None:
+def test_book_chunker_epub(sample_book_epub: bytes, temp_file: Callable[..., Path]) -> None:
     """chunk_book can parse an EPUB with chapter structure."""
-    chunks = chunk_book(sample_book_epub)
+    epub_path = temp_file(sample_book_epub, "sample.epub")
+    chunks = chunk_book(epub_path)
 
     assert len(chunks) >= 1
     chapters = {chunk.metadata.chapter for chunk in chunks}
@@ -99,31 +104,35 @@ def test_book_chunker_epub(sample_book_epub: bytes) -> None:
     assert all(isinstance(chunk.metadata.chapter, int) for chunk in chunks)
 
 
-def test_book_chunker_rejects_invalid_bytes() -> None:
-    """A non-PDF/non-EPUB byte stream raises IngestionError."""
+def test_book_chunker_rejects_invalid_file(temp_file: Callable[..., Path]) -> None:
+    """A non-PDF/non-EPUB file raises IngestionError."""
+    file_path = temp_file(b"not a book", "invalid.bin")
     with pytest.raises(IngestionError):
-        chunk_book(b"not a book")
+        chunk_book(file_path)
 
 
-def test_book_chunk_metadata_validates_at_boundary(sample_book_pdf: bytes) -> None:
+def test_book_chunk_metadata_validates_at_boundary(
+    sample_book_pdf: bytes,
+    temp_file: Callable[..., Path],
+) -> None:
     """Chunks emitted by the book chunker validate against BookChunkMetadata."""
-    chunks = chunk_book(sample_book_pdf)
+    pdf_path = temp_file(sample_book_pdf, "sample.pdf")
+    chunks = chunk_book(pdf_path)
     for chunk in chunks:
-        # model_validate should succeed and extra='forbid' means unknown keys
-        # would have already raised during construction.
         assert BookChunkMetadata.model_validate(chunk.metadata.model_dump())
 
 
-def test_epub_chunks_by_heading_tags() -> None:
+def test_epub_chunks_by_heading_tags(tmp_path: Path) -> None:
     """EPUB with ``<h1>`` headings (no 'Chapter N' text) splits correctly."""
-    epub = _make_epub(
+    epub_path = _make_epub(
         [
             ("ch1.xhtml", "<h1>The Beginning</h1><p>First chapter content.</p>", "ch1"),
             ("ch2.xhtml", "<h1>The Middle</h1><p>Second chapter content.</p>", "ch2"),
             ("ch3.xhtml", "<h1>The End</h1><p>Third chapter content.</p>", "ch3"),
-        ]
+        ],
+        epub_path=tmp_path / "test.epub",
     )
-    chunks = chunk_book(epub)
+    chunks = chunk_book(epub_path)
 
     assert len(chunks) == 3
     assert [c.metadata.chapter for c in chunks] == [1, 2, 3]
@@ -135,14 +144,15 @@ def test_epub_chunks_by_heading_tags() -> None:
     assert all("Chapter" not in c.content for c in chunks)
 
 
-def test_epub_heading_content_included_in_chunk() -> None:
+def test_epub_heading_content_included_in_chunk(tmp_path: Path) -> None:
     """Heading text appears in both chunk content and metadata."""
-    epub = _make_epub(
+    epub_path = _make_epub(
         [
             ("ch1.xhtml", "<h1>Part One</h1><p>Some text.</p>", "ch1"),
-        ]
+        ],
+        epub_path=tmp_path / "test.epub",
     )
-    chunks = chunk_book(epub)
+    chunks = chunk_book(epub_path)
 
     assert len(chunks) == 1
     assert chunks[0].metadata.heading == "Part One"
@@ -150,9 +160,9 @@ def test_epub_heading_content_included_in_chunk() -> None:
     assert "Some text." in chunks[0].content
 
 
-def test_epub_subheadings_same_chapter() -> None:
+def test_epub_subheadings_same_chapter(tmp_path: Path) -> None:
     """``<h2>`` sub-headings produce additional chunks within the same chapter."""
-    epub = _make_epub(
+    epub_path = _make_epub(
         [
             (
                 "ch1.xhtml",
@@ -162,18 +172,19 @@ def test_epub_subheadings_same_chapter() -> None:
                 "<h2>Section B</h2><p>Content B.</p>",
                 "ch1",
             ),
-        ]
+        ],
+        epub_path=tmp_path / "test.epub",
     )
-    chunks = chunk_book(epub)
+    chunks = chunk_book(epub_path)
 
     assert len(chunks) == 3
     assert [c.metadata.chapter for c in chunks] == [1, 1, 1]
     assert [c.metadata.heading for c in chunks] == ["Chapter 1", "Section A", "Section B"]
 
 
-def test_epub_fallback_to_regex_when_no_headings() -> None:
+def test_epub_fallback_to_regex_when_no_headings(tmp_path: Path) -> None:
     """EPUB without heading tags falls back to regex heuristics."""
-    epub = _make_epub(
+    epub_path = _make_epub(
         [
             (
                 "ch1.xhtml",
@@ -185,9 +196,10 @@ def test_epub_fallback_to_regex_when_no_headings() -> None:
                 "<p>Chapter 2</p><p>The story continues.</p>",
                 "ch2",
             ),
-        ]
+        ],
+        epub_path=tmp_path / "test.epub",
     )
-    chunks = chunk_book(epub)
+    chunks = chunk_book(epub_path)
 
     # Regex should detect "Chapter 1" / "Chapter 2" as chapter boundaries
     chapters = {c.metadata.chapter for c in chunks}

--- a/retrieval_qa/tests/retrieval_qa/test_chunker_registry.py
+++ b/retrieval_qa/tests/retrieval_qa/test_chunker_registry.py
@@ -1,6 +1,7 @@
 """Tests for the document-type chunker registry."""
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from pathlib import Path
 
 import pytest
 from pydantic import BaseModel
@@ -61,10 +62,14 @@ def test_chunker_classes_declare_metadata_model() -> None:
     assert issubclass(DocumentationChunker.metadata_model, BaseModel)
 
 
-def test_chunker_returns_chunk_base_model_objects(sample_paper_pdf: bytes) -> None:
+def test_chunker_returns_chunk_base_model_objects(
+    sample_paper_pdf: bytes,
+    temp_file: Callable[..., Path],
+) -> None:
     """Chunker instances return objects that inherit from the Chunk base model."""
+    pdf_path = temp_file(sample_paper_pdf, "sample.pdf")
     chunker = get_chunker(DocumentType.PAPER)
-    result = chunker.chunk(sample_paper_pdf)
+    result = chunker.chunk(pdf_path)
     assert isinstance(result, Sequence)
     assert len(result) >= 1
     for chunk in result:
@@ -91,7 +96,7 @@ def test_register_chunker_allows_extension_without_editing_existing() -> None:
     class FakeChunker(DocumentChunker):
         metadata_model = FakeMetadata
 
-        def chunk(self, file_bytes: bytes) -> Sequence[Chunk]:
+        def chunk(self, file_path: Path) -> Sequence[Chunk]:
             return []
 
     # Temporarily swap the paper chunker to simulate adding a new document type.

--- a/retrieval_qa/tests/retrieval_qa/test_documentation_chunker.py
+++ b/retrieval_qa/tests/retrieval_qa/test_documentation_chunker.py
@@ -1,6 +1,7 @@
 """Tests for the documentation chunker."""
 
-import io
+from collections.abc import Callable
+from pathlib import Path
 
 import pytest
 
@@ -9,36 +10,35 @@ from core.types.chunk import DocumentationChunkMetadata
 from retrieval_qa.chunking.documentation_chunker import chunk_documentation
 
 
-def _make_pdf_from_text(text: str) -> bytes:
+def _make_pdf_from_text(text: str, pdf_path: Path) -> Path:
     """Build a minimal PDF containing the given text using reportlab."""
     from reportlab.lib.pagesizes import letter
     from reportlab.pdfgen import canvas
 
-    buffer = io.BytesIO()
-    canva = canvas.Canvas(buffer, pagesize=letter)
+    canva = canvas.Canvas(str(pdf_path), pagesize=letter)
     y = 720
     for line in text.splitlines():
         canva.drawString(72, y, line)
         y -= 20
     canva.showPage()
     canva.save()
-    buffer.seek(0)
-    return buffer.read()
+    return pdf_path
 
 
-def test_documentation_chunker_splits_markdown_by_headings() -> None:
+def test_documentation_chunker_splits_markdown_by_headings(temp_file: Callable[..., Path]) -> None:
     """Markdown headings create page/section boundaries."""
-    markdown = (
-        "# Installation\n\n"
-        "Install the package with pip.\n\n"
-        "## Quick start\n\n"
-        "Run the init command.\n\n"
-        "# API Reference\n\n"
-        "Endpoints are described below.\n\n"
-        "## Users\n\n"
-        "Manage users.\n"
+    md_path = temp_file(
+        b"# Installation\n\n"
+        b"Install the package with pip.\n\n"
+        b"## Quick start\n\n"
+        b"Run the init command.\n\n"
+        b"# API Reference\n\n"
+        b"Endpoints are described below.\n\n"
+        b"## Users\n\n"
+        b"Manage users.\n",
+        "docs.md",
     )
-    chunks = chunk_documentation(markdown.encode("utf-8"))
+    chunks = chunk_documentation(md_path)
 
     assert len(chunks) >= 2
     pages = {chunk.metadata.page for chunk in chunks}
@@ -46,33 +46,35 @@ def test_documentation_chunker_splits_markdown_by_headings() -> None:
     assert "API Reference" in pages
 
 
-def test_documentation_chunker_detects_api_entries() -> None:
+def test_documentation_chunker_detects_api_entries(temp_file: Callable[..., Path]) -> None:
     """API endpoint lines become section boundaries."""
-    markdown = (
-        "# API Reference\n\n"
-        "## Users\n\n"
-        "GET /api/v1/users\n\n"
-        "Returns a list of users.\n\n"
-        "POST /api/v1/users\n\n"
-        "Creates a new user.\n"
+    md_path = temp_file(
+        b"# API Reference\n\n"
+        b"## Users\n\n"
+        b"GET /api/v1/users\n\n"
+        b"Returns a list of users.\n\n"
+        b"POST /api/v1/users\n\n"
+        b"Creates a new user.\n",
+        "api.md",
     )
-    chunks = chunk_documentation(markdown.encode("utf-8"))
+    chunks = chunk_documentation(md_path)
 
     sections = [chunk.metadata.section for chunk in chunks]
     assert any(section == "GET /api/v1/users" for section in sections)
     assert any(section == "POST /api/v1/users" for section in sections)
 
 
-def test_documentation_chunker_parses_html_headings() -> None:
+def test_documentation_chunker_parses_html_headings(temp_file: Callable[..., Path]) -> None:
     """HTML ``<h1>`` / ``<h2>`` tags are converted to page/section boundaries."""
-    html = (
-        "<!DOCTYPE html><html><body>"
-        "<h1>Installation</h1><p>Install with pip.</p>"
-        "<h2>Quick start</h2><p>Run init.</p>"
-        "<h1>API Reference</h1><p>Endpoints below.</p>"
-        "</body></html>"
+    html_path = temp_file(
+        b"<!DOCTYPE html><html><body>"
+        b"<h1>Installation</h1><p>Install with pip.</p>"
+        b"<h2>Quick start</h2><p>Run init.</p>"
+        b"<h1>API Reference</h1><p>Endpoints below.</p>"
+        b"</body></html>",
+        "docs.html",
     )
-    chunks = chunk_documentation(html.encode("utf-8"))
+    chunks = chunk_documentation(html_path)
 
     assert len(chunks) >= 2
     pages = {chunk.metadata.page for chunk in chunks}
@@ -80,33 +82,36 @@ def test_documentation_chunker_parses_html_headings() -> None:
     assert "API Reference" in pages
 
 
-def test_documentation_chunker_parses_pdf_pages() -> None:
+def test_documentation_chunker_parses_pdf_pages(tmp_path: Path) -> None:
     """PDF pages are treated as documentation pages."""
-    pdf_bytes = _make_pdf_from_text(
-        "# Installation\nInstall the package.\n\n## Quick start\nRun init."
+    pdf_path = _make_pdf_from_text(
+        "# Installation\nInstall the package.\n\n## Quick start\nRun init.",
+        pdf_path=tmp_path / "docs.pdf",
     )
-    chunks = chunk_documentation(pdf_bytes)
+    chunks = chunk_documentation(pdf_path)
 
     assert len(chunks) >= 1
     assert all(chunk.metadata.page for chunk in chunks)
 
 
-def test_documentation_chunker_rejects_empty_bytes() -> None:
-    """Empty byte streams raise IngestionError."""
+def test_documentation_chunker_rejects_empty_file(temp_file: Callable[..., Path]) -> None:
+    """Empty files raise IngestionError."""
+    empty_path = temp_file(b"", "empty.md")
     with pytest.raises(IngestionError):
-        chunk_documentation(b"")
+        chunk_documentation(empty_path)
 
 
-def test_documentation_chunker_rejects_invalid_bytes() -> None:
-    """Byte streams that are not valid text raise IngestionError."""
+def test_documentation_chunker_rejects_invalid_utf8(temp_file: Callable[..., Path]) -> None:
+    """Files that are not valid UTF-8 raise IngestionError."""
+    bad_path = temp_file(b"\xff\xfe not valid utf-8", "bad.bin")
     with pytest.raises(IngestionError):
-        chunk_documentation(b"\xff\xfe not valid utf-8")
+        chunk_documentation(bad_path)
 
 
-def test_documentation_chunk_metadata_validates_at_boundary() -> None:
+def test_documentation_chunk_metadata_validates_at_boundary(temp_file: Callable[..., Path]) -> None:
     """Chunks emitted by the documentation chunker validate against the metadata model."""
-    markdown = "# Installation\n\nInstall with pip.\n"
-    chunks = chunk_documentation(markdown.encode("utf-8"))
+    md_path = temp_file(b"# Installation\n\nInstall with pip.\n", "docs.md")
+    chunks = chunk_documentation(md_path)
 
     for chunk in chunks:
         assert DocumentationChunkMetadata.model_validate(chunk.metadata.model_dump())

--- a/retrieval_qa/tests/retrieval_qa/test_paper_chunker.py
+++ b/retrieval_qa/tests/retrieval_qa/test_paper_chunker.py
@@ -1,13 +1,20 @@
 """Tests for the paper chunker."""
 
+from collections.abc import Callable
+from pathlib import Path
+
 import pytest
 
 from retrieval_qa.chunking.paper_chunker import chunk_paper
 
 
-def test_paper_chunker_emits_sections(sample_paper_pdf: bytes) -> None:
+def test_paper_chunker_emits_sections(
+    sample_paper_pdf: bytes,
+    temp_file: Callable[..., Path],
+) -> None:
     """chunk_paper extracts text and splits it into ordered chunks."""
-    chunks = chunk_paper(sample_paper_pdf)
+    pdf_path = temp_file(sample_paper_pdf, "sample.pdf")
+    chunks = chunk_paper(pdf_path)
 
     assert len(chunks) >= 1
     for chunk in chunks:
@@ -18,18 +25,23 @@ def test_paper_chunker_emits_sections(sample_paper_pdf: bytes) -> None:
         assert chunk.metadata.subsection is None or isinstance(chunk.metadata.subsection, str)
 
 
-def test_paper_chunker_includes_section_metadata(sample_paper_pdf: bytes) -> None:
+def test_paper_chunker_includes_section_metadata(
+    sample_paper_pdf: bytes,
+    temp_file: Callable[..., Path],
+) -> None:
     """Extracted chunks carry paper-specific section/subsection metadata."""
-    chunks = chunk_paper(sample_paper_pdf)
+    pdf_path = temp_file(sample_paper_pdf, "sample.pdf")
+    chunks = chunk_paper(pdf_path)
 
     sections = [chunk.metadata.section for chunk in chunks]
     # The first section header detected should appear in the extracted chunks.
     assert any("Introduction" in section or "Methods" in section for section in sections)
 
 
-def test_paper_chunker_rejects_invalid_pdf() -> None:
-    """A non-PDF byte stream raises IngestionError."""
+def test_paper_chunker_rejects_invalid_pdf(temp_file: Callable[..., Path]) -> None:
+    """A non-PDF file raises IngestionError."""
     from core.exceptions import IngestionError
 
+    pdf_path = temp_file(b"not a pdf", "invalid.pdf")
     with pytest.raises(IngestionError):
-        chunk_paper(b"not a pdf")
+        chunk_paper(pdf_path)


### PR DESCRIPTION
…on pipeline

Update the ingestion pipeline, chunkers, and API route to accept local file paths and have each chunker open/read the file itself, rather than passing raw bytes across module boundaries.

This avoids holding large blobs in memory at the API layer and keeps file I/O co-located with the chunking logic that needs it.

Closes #120