### PR TITLE
chore: add baseline security guardrails before live API testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,15 @@ MAX_UPLOAD_BYTES=104857600
 
 # Allowed file extensions (placeholder).
 ALLOWED_FILE_EXTENSIONS=["pdf", "epub", "md", "html"]
+
+# Cohere API key for reranking.
+COHERE_API_KEY=co_...
+
+# Server-side top-k for retrieval (not client-controlled, ADR-0014).
+QUERY_TOP_K=5
+
+# Active inference model for generation.
+INFERENCE_MODEL=gpt-4o-mini
+
+# Active reranker model.
+RERANKER_MODEL=rerank-v3.5

--- a/api/src/api/routes/ingest.py
+++ b/api/src/api/routes/ingest.py
@@ -18,6 +18,7 @@ from fastapi import (
     Response,
     UploadFile,
 )
+from pydantic import Field
 
 from api.dependencies import get_embedder
 from core.clients import Embedder
@@ -28,7 +29,26 @@ from core.types.document import DocumentStatusResponse, DocumentType
 from ingestion.models import PendingIngestion
 from ingestion.tasks import schedule_ingestion
 
+MAGIC_PDF = b"%PDF"
+MAGIC_ZIP = b"PK"
+
 router = APIRouter(tags=["ingestion"])
+
+
+async def _validate_content_type(file: UploadFile, extension: str) -> None:
+    head = await file.read(4)
+    await file.seek(0)
+
+    if extension == "pdf" and not head.startswith(MAGIC_PDF):
+        raise HTTPException(
+            status_code=415,
+            detail="File content does not match PDF format",
+        )
+    if extension == "epub" and not head.startswith(MAGIC_ZIP):
+        raise HTTPException(
+            status_code=415,
+            detail="File content does not match EPUB format",
+        )
 
 
 def _extension(filename: str | None) -> str | None:
@@ -82,15 +102,15 @@ async def ingest_document(
     response: Response,
     background_tasks: BackgroundTasks,
     file: UploadFile,
-    title: Annotated[str, Form(...)],
+    title: Annotated[str, Form(...), Field(max_length=500)],
     document_type: Annotated[DocumentType, Form(...)],
     embedder: Annotated[Embedder, Depends(get_embedder)],
 ) -> DocumentStatusResponse:
     """Accept a document for background ingestion.
 
     Returns 202 Accepted with a ``Location`` header pointing at the status
-    endpoint. Pre-flight checks return 413 for oversized files and 415 for
-    unsupported extensions; missing fields return 422 via FastAPI defaults.
+    endpoint.     Pre-flight checks return 415 for unsupported content/mime type and 413 for
+    oversized files; missing fields return 422 via FastAPI defaults.
     """
     extension = _extension(file.filename)
     if extension is None or extension not in settings.allowed_file_extensions:
@@ -98,6 +118,8 @@ async def ingest_document(
             status_code=415,
             detail=f"Unsupported file type: {extension or 'unknown'}",
         )
+
+    await _validate_content_type(file, extension)
 
     file_path = await _save_upload_to_temp(file, settings.max_upload_bytes)
     source_filename = file.filename or "upload"

--- a/core/src/core/clients/embeddings_client.py
+++ b/core/src/core/clients/embeddings_client.py
@@ -52,7 +52,7 @@ class EmbeddingsClient:
 
     def _get_client(self) -> OpenAI:
         if self._client is None:
-            self._client = OpenAI(api_key=self._api_key)
+            self._client = OpenAI(api_key=self._api_key, timeout=30.0, max_retries=2)
         return self._client
 
     def embed(self, texts: Sequence[str]) -> list[list[float]]:
@@ -85,7 +85,7 @@ class EmbeddingsClient:
     async def aembed(self, texts: Sequence[str]) -> list[list[float]]:
         """Embed a batch of texts asynchronously."""
         if self._async_client is None:
-            self._async_client = AsyncOpenAI(api_key=self._api_key)
+            self._async_client = AsyncOpenAI(api_key=self._api_key, timeout=30.0, max_retries=2)
         try:
             response = await self._async_client.embeddings.create(
                 input=list(texts),

--- a/core/src/core/clients/llm_client.py
+++ b/core/src/core/clients/llm_client.py
@@ -58,7 +58,7 @@ class LLMClient:
 
     def _get_client(self) -> OpenAI:
         if self._client is None:
-            self._client = OpenAI(api_key=self._api_key)
+            self._client = OpenAI(api_key=self._api_key, timeout=60.0, max_retries=2)
         return self._client
 
     def chat(self, messages: Sequence[ChatMessage]) -> str:

--- a/core/src/core/clients/reranker_client.py
+++ b/core/src/core/clients/reranker_client.py
@@ -70,7 +70,7 @@ class CohereReranker:
         if self._client is None:
             if self._api_key is None:
                 raise UpstreamUnavailable("Cohere API key not configured (COHERE_API_KEY)")
-            self._client = cohere.ClientV2(api_key=self._api_key)
+            self._client = cohere.ClientV2(api_key=self._api_key, timeout=30.0, max_retries=2)
         return self._client
 
     def rerank(

--- a/core/src/core/types/responses.py
+++ b/core/src/core/types/responses.py
@@ -14,7 +14,7 @@ class HarnessARequest(BaseModel):
     for it (alongside the missing-field case).
     """
 
-    query: str = Field(min_length=1)
+    query: str = Field(min_length=1, max_length=2000)
 
 
 class CitedPassage(BaseModel):


### PR DESCRIPTION
Adds content-level validation, hosted API client timeouts, and input length caps as required by docs/security-mvp-guide.md (ADR-0018):

- POST /query query string capped at max_length=2000
- POST /ingest title capped at max_length=500
- Magic byte validation (PDF/EPUB) at route level before save
- Explicit timeout + max_retries on OpenAI (30s/2) and Cohere (30s/2) clients and LLM client (60s/2)
- .env.example synced with all Settings fields