### PR TITLE
fix(ingestion): sanitize NUL bytes from PDF-extracted text

### DIFF
--- a/ingestion/src/ingestion/pipeline.py
+++ b/ingestion/src/ingestion/pipeline.py
@@ -91,6 +91,11 @@ def _embed_chunks(
     return list(zip(chunks, vectors, strict=True))
 
 
+def _sanitize_text(text: str) -> str:
+    """Remove characters that PostgreSQL text columns cannot store."""
+    return text.replace("\x00", "")
+
+
 def run_ingestion(
     pending: PendingIngestion,
     session: Session,
@@ -137,7 +142,7 @@ def run_ingestion(
             parent = ChunkRow(
                 document_id=pending.document_id,
                 position=parent_position,
-                content=content,
+                content=_sanitize_text(content),
                 token_count=token_count,
                 type_metadata=type_metadata,
                 parent_chunk_id=None,
@@ -157,7 +162,7 @@ def run_ingestion(
                 child = ChunkRow(
                     document_id=pending.document_id,
                     position=child_split.position,
-                    content=child_split.content,
+                    content=_sanitize_text(child_split.content),
                     token_count=child_split.token_count,
                     type_metadata=child_metadata,
                     parent_chunk_id=parent.chunk_id,

--- a/scripts/manual_ingest_smoke.py
+++ b/scripts/manual_ingest_smoke.py
@@ -73,7 +73,9 @@ def poll_until_terminal(base_url: str, document_id: str) -> dict:
         if status in TERMINAL_STATUSES:
             return body
         time.sleep(POLL_INTERVAL_SECONDS)
-    raise TimeoutError(f"Document {document_id} did not reach a terminal status in {POLL_TIMEOUT_SECONDS}s")
+    raise TimeoutError(
+        f"Document {document_id} did not reach a terminal status in {POLL_TIMEOUT_SECONDS}s"
+    )
 
 
 def query(base_url: str, query_text: str) -> dict:
@@ -83,7 +85,9 @@ def query(base_url: str, query_text: str) -> dict:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument("file", type=Path, help="Path to a real PDF or EPUB")
     parser.add_argument("--type", required=True, choices=["paper", "book", "documentation"])
     parser.add_argument("--title", default=None)
@@ -123,7 +127,7 @@ def main() -> int:
                 for p in cited
             )
             if not grounded or not hit:
-                print(f"[FAIL] expected substring {args.expect!r} not found in grounded cited passages")
+                print(f"[FAIL] substring {args.expect!r} not found in grounded cited passages")
                 return 1
             print("[PASS] grounded, expected content found in cited passages")
 


### PR DESCRIPTION
## Problem

`pypdf`'s `page.extract_text()` can produce NUL (0x00) bytes from embedded fonts in some PDFs (e.g. FlashAttention-paper.pdf). PostgreSQL text columns reject these, causing ingestion to fail with:

`A string literal cannot contain NUL (0x00) characters.`

## Fix

Add `_sanitize_text()` to `ingestion/src/ingestion/pipeline.py` that strips NUL bytes before writing chunk `content` to the database. Applied at both parent-row creation and child-split creation so all paths are covered.

## Verification

- ✅ `ruff check`, `ruff format --check`, `mypy` all pass
- ✅ FlashAttention-paper.pdf ingested successfully via HTTP smoke test (was failing before the fix)
- ✅ vLLM-paper.pdf still ingests successfully (regression check)