### PR TITLE
fix(ingestion): raise _MAX_TOKENS_PER_EMBEDDING_BATCH from 100k to 300k

### DIFF
--- a/ingestion/src/ingestion/pipeline.py
+++ b/ingestion/src/ingestion/pipeline.py
@@ -67,7 +67,7 @@ def _chunk_document(
     return _chunk_inputs(chunker_class().chunk(file_path))
 
 
-_MAX_TOKENS_PER_EMBEDDING_BATCH = 100_000
+_MAX_TOKENS_PER_EMBEDDING_BATCH = 300_000
 
 
 def _embed_chunks(

--- a/uv.lock
+++ b/uv.lock
@@ -1070,8 +1070,8 @@ dev = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "reportlab", specifier = ">=4.0" },
     { name = "ruff", specifier = ">=0.16.0" },
-    { name = "types-pyyaml", specifier = ">=6.0" },
-    { name = "types-reportlab", specifier = ">=4.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20260724" },
+    { name = "types-reportlab", specifier = ">=4.5.1.20260724" },
 ]
 
 [[package]]


### PR DESCRIPTION
Aligns the constant with the OpenAI per-request token limit documented in the _embed_chunks docstring. The previous value of 100_000 was out of sync with the stated 300k intent.

Closes #128