### PR TITLE
feat(ingestion): add cost tracking logs to ingestion pipeline

### DIFF
--- a/ingestion/src/ingestion/pipeline.py
+++ b/ingestion/src/ingestion/pipeline.py
@@ -1,5 +1,6 @@
 """Background ingestion pipeline for uploaded documents."""
 
+import logging
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -15,6 +16,20 @@ from core.types.document import DocumentStatus, DocumentType
 from ingestion.models import PendingIngestion
 from ingestion.splitting import recursive_fixed_size_split
 from retrieval_qa.chunking import chunker_registry, get_chunker_class
+
+logger = logging.getLogger(__name__)
+
+# Per-model cost in USD per 1M input tokens (source: OpenAI pricing page).
+_EMBEDDING_MODEL_PRICES: dict[str, float] = {
+    "text-embedding-3-small": 0.02,
+    "text-embedding-3-large": 0.13,
+    "text-embedding-ada-002": 0.02,
+    "text-embedding-004": 0.02,
+}
+
+
+def _get_embedding_cost(model_name: str) -> float:
+    return _EMBEDDING_MODEL_PRICES.get(model_name, 0.02)
 
 
 def _validate_type_metadata(
@@ -75,14 +90,19 @@ def _embed_chunks(
     client: Embedder,
     chunks: Sequence[ChunkRow],
     model_name: str,
-) -> list[tuple[ChunkRow, list[float]]]:
-    """Embed chunk contents and return (chunk, vector) pairs.
+) -> tuple[list[tuple[ChunkRow, list[float]]], int]:
+    """Embed chunk contents and return (chunk, vector) pairs and API call count.
 
     Batches chunks by cumulative token count to stay within the
     embedding API's per-request token limit (OpenAI enforces 300k).
+
+    Returns:
+        A tuple of (results, api_calls) where ``results`` is a list of
+        (chunk, vector) pairs and ``api_calls`` is the number of API
+        calls made.
     """
     if not chunks:
-        return []
+        return [], 0
 
     batches: list[list[ChunkRow]] = [[]]
     batch_tokens: list[int] = [0]
@@ -110,7 +130,7 @@ def _embed_chunks(
 
         result.extend(zip(batch_chunks, vectors, strict=True))
 
-    return result
+    return result, len(batches)
 
 
 def _sanitize_text(text: str) -> str:
@@ -196,7 +216,7 @@ def run_ingestion(
         session.flush()
 
         # ── Phase 3: Embed only child chunks ──
-        embedded = _embed_chunks(session, embeddings_client, child_rows, model_name)
+        embedded, api_calls = _embed_chunks(session, embeddings_client, child_rows, model_name)
         for chunk, vector in embedded:
             session.add(
                 Embedding(
@@ -212,6 +232,21 @@ def run_ingestion(
         raise
     except Exception as exc:
         raise IngestionError(f"Unexpected ingestion failure: {exc}") from exc
+
+    total_chunks = len(parent_rows) + len(child_rows)
+    total_tokens = sum(c.token_count for c in child_rows)
+    cost_per_1m = _get_embedding_cost(model_name)
+    estimated_cost = total_tokens / 1_000_000 * cost_per_1m
+    logger.info(
+        "Ingestion complete for %s: %d chunks (%d parents + %d children), "
+        "%d embedding API calls, ~$%.4f estimated cost",
+        pending.title,
+        total_chunks,
+        len(parent_rows),
+        len(child_rows),
+        api_calls,
+        estimated_cost,
+    )
 
 
 __all__ = ["run_ingestion"]

--- a/ingestion/tests/integration/test_real_ingestion.py
+++ b/ingestion/tests/integration/test_real_ingestion.py
@@ -6,6 +6,7 @@ and costs real money. It reuses the existing conftest.py fixtures
 pgvector database, not a mock.
 """
 
+import logging
 import os
 from pathlib import Path
 
@@ -82,6 +83,7 @@ def test_real_ingestion_end_to_end(
     test_session: Session,
     real_document_path: Path,
     document_type_for: DocumentType,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Full pipeline against real Postgres + real OpenAI embeddings.
 
@@ -93,8 +95,11 @@ def test_real_ingestion_end_to_end(
       - every child chunk has exactly one embedding at the right dimensionality
       - embeddings aren't degenerate (all-zero or constant), which is how a
         silent upstream failure tends to show up rather than raising
+      - cost tracking log includes chunk count, API call count, and estimated cost
     """
     _skip_unless_live()
+
+    caplog.set_level(logging.INFO)
 
     pending = _make_pending_document(test_session, real_document_path, document_type_for)
     client = EmbeddingsClient()  # picks up settings.openai_api_key / OPENAI_API_KEY
@@ -135,6 +140,16 @@ def test_real_ingestion_end_to_end(
         assert any(v != 0 for v in vector), "embedding is all-zero -- likely a silent API failure"
         assert len({round(v, 6) for v in vector}) > 1, "embedding is constant -- suspicious"
         assert emb.model_name == settings.embedding_model
+
+    # Verify cost tracking log is present
+    cost_records = [r for r in caplog.records if "estimated cost" in r.message]
+    assert cost_records, "expected cost tracking log message"
+    assert "chunks" in cost_records[0].message, (
+        f"expected 'chunks' in cost log, got: {cost_records[0].message}"
+    )
+    assert "embedding API calls" in cost_records[0].message, (
+        f"expected 'embedding API calls' in cost log, got: {cost_records[0].message}"
+    )
 
 
 def test_real_ingestion_is_grounded(


### PR DESCRIPTION
After a document finishes READY, the pipeline now logs chunk count, embedding API call count, and estimated cost. The log is placed outside the try/except block so a logging failure cannot undo a successful ingestion.

- Add logger, pricing constants dict, and _get_embedding_cost helper
- _embed_chunks now returns (results, api_calls) tuple
- run_ingestion logs cost info after READY + flush
- test_real_ingestion_end_to_end verifies cost log presence

Closes #133