### PR TITLE
test(ingestion): assert status transition sequence in smoke script an…

### DIFF
--- a/ingestion/tests/integration/test_real_ingestion.py
+++ b/ingestion/tests/integration/test_real_ingestion.py
@@ -11,6 +11,7 @@ import os
 from pathlib import Path
 
 import pytest
+from sqlalchemy import event
 from sqlalchemy.orm import Session
 
 from core.clients.embeddings_client import EmbeddingsClient
@@ -104,17 +105,38 @@ def test_real_ingestion_end_to_end(
     pending = _make_pending_document(test_session, real_document_path, document_type_for)
     client = EmbeddingsClient()  # picks up settings.openai_api_key / OPENAI_API_KEY
 
-    run_ingestion(
-        pending=pending,
-        session=test_session,
-        embeddings_client=client,
-        model_name=settings.embedding_model,
-    )
+    captured_statuses: list[DocumentStatus] = [DocumentStatus.VALIDATING]
+
+    @event.listens_for(Document, "before_update")
+    def _capture_status(mapper: object, connection: object, target: Document) -> None:
+        if target.document_id == pending.document_id:
+            captured_statuses.append(target.status)
+
+    try:
+        run_ingestion(
+            pending=pending,
+            session=test_session,
+            embeddings_client=client,
+            model_name=settings.embedding_model,
+        )
+    finally:
+        event.remove(Document, "before_update", _capture_status)
+
     test_session.commit()
 
     document = test_session.get(Document, pending.document_id)
     assert document is not None
     assert document.status == DocumentStatus.READY, document.error_message
+    expected_statuses = [
+        DocumentStatus.VALIDATING,
+        DocumentStatus.CHUNKING,
+        DocumentStatus.EMBEDDING,
+        DocumentStatus.READY,
+    ]
+    assert captured_statuses == expected_statuses, (
+        f"Expected status transition {[s.value for s in expected_statuses]}, "
+        f"got {[s.value for s in captured_statuses]}"
+    )
 
     all_chunks = (
         test_session.query(ChunkRow).filter(ChunkRow.document_id == pending.document_id).all()

--- a/scripts/manual_ingest_smoke.py
+++ b/scripts/manual_ingest_smoke.py
@@ -43,6 +43,7 @@ DEFAULT_BASE_URL = "http://localhost:8000"
 POLL_INTERVAL_SECONDS = 2
 POLL_TIMEOUT_SECONDS = 180
 TERMINAL_STATUSES = {"ready", "failed"}
+EXPECTED_TRANSITIONS = ("validating", "chunking", "embedding", "ready")
 
 
 def ingest(base_url: str, file_path: Path, document_type: str, title: str) -> str:
@@ -83,7 +84,7 @@ def ingest(base_url: str, file_path: Path, document_type: str, title: str) -> st
     return str(document_id)
 
 
-def poll_until_terminal(base_url: str, document_id: str) -> dict[str, Any]:
+def poll_until_terminal(base_url: str, document_id: str) -> tuple[dict[str, Any], list[str]]:
     """Poll GET /documents/{id} until the document reaches a terminal status.
 
     Args:
@@ -91,25 +92,27 @@ def poll_until_terminal(base_url: str, document_id: str) -> dict[str, Any]:
         document_id: The document ID returned by ingest().
 
     Returns:
-        The final document status dict (status, title, etc.).
+        A tuple of ``(final_status_dict, observed_statuses)`` where
+        ``observed_statuses`` is the chronological list of distinct status
+        values seen during polling.
 
     Raises:
         TimeoutError: If the document does not reach a terminal status
             within POLL_TIMEOUT_SECONDS.
     """
     start = time.monotonic()
-    last_status = None
+    observed_statuses: list[str] = []
     while time.monotonic() - start < POLL_TIMEOUT_SECONDS:
         resp = requests.get(f"{base_url}/documents/{document_id}", timeout=10)
         resp.raise_for_status()
         body = resp.json()
         status = str(body.get("status", "")).lower()
-        if status != last_status:
+        if not observed_statuses or status != observed_statuses[-1]:
             elapsed = time.monotonic() - start
             print(f"[poll] t={elapsed:5.1f}s status={status}")
-            last_status = status
+            observed_statuses.append(status)
         if status in TERMINAL_STATUSES:
-            return dict(body)
+            return dict(body), observed_statuses
         time.sleep(POLL_INTERVAL_SECONDS)
     raise TimeoutError(
         f"Document {document_id} did not reach a terminal status in {POLL_TIMEOUT_SECONDS}s"
@@ -161,12 +164,21 @@ def main() -> int:
     started = time.monotonic()
 
     document_id = ingest(args.base_url, args.file, args.type, title)
-    final = poll_until_terminal(args.base_url, document_id)
+    final, observed_statuses = poll_until_terminal(args.base_url, document_id)
     elapsed = time.monotonic() - started
 
     status = str(final.get("status", "")).lower()
     if status != "ready":
         print(f"[FAIL] ingestion ended in status={status!r}: {final}")
+        return 1
+
+    # Check that observed statuses contain the expected sequence in order.
+    expected_iter = iter(s for s in observed_statuses if s in EXPECTED_TRANSITIONS)
+    if not all(exp in expected_iter for exp in EXPECTED_TRANSITIONS):
+        print(
+            f"[FAIL] Expected status transition {list(EXPECTED_TRANSITIONS)}, "
+            f"got {observed_statuses}"
+        )
         return 1
 
     print(f"[PASS] ingestion READY in {elapsed:.1f}s")


### PR DESCRIPTION
…d integration test

The manual smoke script prints statuses during polling but never asserts the documented sequence validating -> chunking -> embedding -> ready. A skipped status would go undetected.

- Track all observed distinct status changes during polling in the smoke script, then assert they contain the expected transitions in order after the document reaches ready.
- Use a SQLAlchemy before_update event listener in the pytest integration test to capture status transitions during run_ingestion() and verify the complete VALIDATING -> CHUNKING -> EMBEDDING -> READY sequence.

Closes #134