### PR TITLE
feat(core): add ScoredChunk and RetrievalResult types, migrate retrie…

### DIFF
--- a/api/src/api/controllers/qa_controller.py
+++ b/api/src/api/controllers/qa_controller.py
@@ -24,7 +24,7 @@ from sqlalchemy.orm import Session
 
 from api.prompt import build_messages
 from core.clients import CompletionProvider, Embedder, Reranker
-from core.types.responses import HarnessAResponse
+from core.types.responses import CitedPassage, HarnessAResponse
 from core.types.retrieval_config import RetrievalConfig
 from retrieval_qa.retrieval.query import retrieve_relevant_chunks
 
@@ -67,7 +67,7 @@ def run_query(
     query_vectors = embeddings_client.embed([query])
     query_vector = query_vectors[0]
 
-    chunks = retrieve_relevant_chunks(
+    result = retrieve_relevant_chunks(
         query_vector=query_vector,
         session=session,
         config=config,
@@ -75,13 +75,13 @@ def run_query(
         reranker=reranker,
     )
 
-    messages = build_messages(query, chunks)
+    messages = build_messages(query, result.fused)
     answer = llm_client.chat(messages)
 
     return HarnessAResponse(
         answer=answer,
-        cited_passages=list(chunks),
-        grounded=bool(chunks),
+        cited_passages=[CitedPassage(chunk_id=c.chunk_id, text=c.text) for c in result.fused],
+        grounded=bool(result.fused),
     )
 
 

--- a/api/src/api/prompt.py
+++ b/api/src/api/prompt.py
@@ -3,7 +3,7 @@
 from collections.abc import Sequence
 
 from core.types.chat import ChatMessage
-from core.types.responses import CitedPassage
+from core.types.responses import ScoredChunk
 
 SYSTEM_PROMPT = (
     "You answer the user's question using only the provided passages. "
@@ -14,7 +14,7 @@ SYSTEM_PROMPT = (
 
 def build_messages(
     query: str,
-    chunks: Sequence[CitedPassage],
+    chunks: Sequence[ScoredChunk],
 ) -> list[ChatMessage]:
     """Assemble the chat-completions message list for the inference call.
 

--- a/api/tests/api/controllers/test_qa_controller.py
+++ b/api/tests/api/controllers/test_qa_controller.py
@@ -9,7 +9,7 @@ import pytest
 
 from api.controllers.qa_controller import run_query
 from core.exceptions import UpstreamBadResponse, UpstreamUnavailable
-from core.types.responses import CitedPassage, HarnessAResponse
+from core.types.responses import HarnessAResponse, RetrievalResult, ScoredChunk
 from core.types.retrieval_config import RetrievalConfig
 
 
@@ -38,12 +38,12 @@ def _vector(value: float = 0.5) -> list[float]:
 
 
 def test_run_query_grounds_when_retrieval_returns_chunks(
-    patched_retrieve_chunks: Callable[[Sequence[object]], None],
+    patched_retrieve_chunks: Callable[[Sequence[ScoredChunk]], None],
 ) -> None:
     """Relevant chunks yield grounded=True with cited_passages populated."""
     retrieved_chunks = [
-        CitedPassage(chunk_id=uuid4(), text="pgvector supports HNSW indexes."),
-        CitedPassage(chunk_id=uuid4(), text="Cosine distance uses the <=> operator."),
+        ScoredChunk(chunk_id=uuid4(), text="pgvector supports HNSW indexes.", score=0.5),
+        ScoredChunk(chunk_id=uuid4(), text="Cosine distance uses the <=> operator.", score=0.3),
     ]
     patched_retrieve_chunks(retrieved_chunks)
 
@@ -102,9 +102,9 @@ def test_run_query_embeds_query_before_retrieval(monkeypatch: pytest.MonkeyPatch
     captured: dict[str, object] = {}
     embeddings_client = _fake_embeddings_client(_vector(0.7))
 
-    def _capture_retrieve(**kwargs: object) -> list[object]:
+    def _capture_retrieve(**kwargs: object) -> RetrievalResult:
         captured.update(kwargs)
-        return []
+        return RetrievalResult(dense=[], sparse=[], fused=[])
 
     monkeypatch.setattr(
         "api.controllers.qa_controller.retrieve_relevant_chunks",
@@ -164,10 +164,10 @@ def test_run_query_propagates_upstream_bad_response_from_embeddings(
 
 
 def test_run_query_propagates_upstream_unavailable_from_inference(
-    patched_retrieve_chunks: Callable[[Sequence[object]], None],
+    patched_retrieve_chunks: Callable[[Sequence[ScoredChunk]], None],
 ) -> None:
     """Inference client unreachable surfaces UpstreamUnavailable for the route to map to 503."""
-    patched_retrieve_chunks([MagicMock(chunk_id=uuid4(), text="chunk text")])
+    patched_retrieve_chunks([ScoredChunk(chunk_id=uuid4(), text="chunk text", score=0.5)])
 
     with pytest.raises(UpstreamUnavailable):
         run_query(
@@ -183,10 +183,10 @@ def test_run_query_propagates_upstream_unavailable_from_inference(
 
 
 def test_run_query_propagates_upstream_bad_response_from_inference(
-    patched_retrieve_chunks: Callable[[Sequence[object]], None],
+    patched_retrieve_chunks: Callable[[Sequence[ScoredChunk]], None],
 ) -> None:
     """Inference bad response surfaces UpstreamBadResponse for the route to map to 502."""
-    patched_retrieve_chunks([MagicMock(chunk_id=uuid4(), text="chunk text")])
+    patched_retrieve_chunks([ScoredChunk(chunk_id=uuid4(), text="chunk text", score=0.5)])
 
     with pytest.raises(UpstreamBadResponse):
         run_query(
@@ -202,10 +202,10 @@ def test_run_query_propagates_upstream_bad_response_from_inference(
 
 
 def test_run_query_passes_chunks_to_llm_prompt(
-    patched_retrieve_chunks: Callable[[Sequence[object]], None],
+    patched_retrieve_chunks: Callable[[Sequence[ScoredChunk]], None],
 ) -> None:
     """The injected-context prompt embeds referenced chunk text into the user message."""
-    retrieved = [CitedPassage(chunk_id=uuid4(), text="chunk A text")]
+    retrieved = [ScoredChunk(chunk_id=uuid4(), text="chunk A text", score=0.5)]
     patched_retrieve_chunks(retrieved)
 
     llm_client = _fake_llm_client("answer")

--- a/api/tests/api/test_prompt.py
+++ b/api/tests/api/test_prompt.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 from api.prompt import SYSTEM_PROMPT, build_messages
 from core.types.chat import ChatMessage
-from core.types.responses import CitedPassage
+from core.types.responses import ScoredChunk
 
 
 def test_build_messages_includes_system_prompt() -> None:
@@ -17,8 +17,8 @@ def test_build_messages_includes_system_prompt() -> None:
 def test_build_messages_includes_context_when_present() -> None:
     """The user message includes enumerated context when chunks are provided."""
     chunks = [
-        CitedPassage(chunk_id=uuid4(), text="first passage"),
-        CitedPassage(chunk_id=uuid4(), text="second passage"),
+        ScoredChunk(chunk_id=uuid4(), text="first passage", score=0.5),
+        ScoredChunk(chunk_id=uuid4(), text="second passage", score=0.3),
     ]
     messages = build_messages("what is RAG?", chunks)
     user = next(m for m in messages if m.role == "user")

--- a/api/tests/api/test_query.py
+++ b/api/tests/api/test_query.py
@@ -26,12 +26,12 @@ from api.tests.conftest import (
 )
 from core.database.schema import Chunk
 from core.exceptions import UpstreamBadResponse, UpstreamUnavailable
-from core.types.responses import CitedPassage
+from core.types.responses import ScoredChunk
 
 
-def _fake_chunk(*, text: str = "chunk text") -> CitedPassage:
-    """Build a CitedPassage chunk for test fixtures."""
-    return CitedPassage(chunk_id=uuid.uuid4(), text=text)
+def _fake_chunk(*, text: str = "chunk text") -> ScoredChunk:
+    """Build a ScoredChunk for test fixtures."""
+    return ScoredChunk(chunk_id=uuid.uuid4(), text=text, score=0.5)
 
 
 # ============================================================
@@ -101,7 +101,7 @@ def test_query_embeddings_unavailable_returns_503(client: TestClient) -> None:
 
 
 def test_query_inference_bad_response_returns_502(
-    client: TestClient, patched_retrieve_chunks: Callable[[Sequence[object]], None]
+    client: TestClient, patched_retrieve_chunks: Callable[[Sequence[ScoredChunk]], None]
 ) -> None:
     """A mocked inference provider returning a bad response maps to 502."""
 
@@ -122,7 +122,7 @@ def test_query_inference_bad_response_returns_502(
 
 
 def test_query_inference_unavailable_returns_503(
-    client: TestClient, patched_retrieve_chunks: Callable[[Sequence[object]], None]
+    client: TestClient, patched_retrieve_chunks: Callable[[Sequence[ScoredChunk]], None]
 ) -> None:
     """A mocked inference provider that's unreachable/timeout maps to 503."""
 
@@ -176,7 +176,7 @@ def test_query_response_has_exactly_three_fields(
 
 
 def test_query_grounds_with_mocked_retrieval(
-    client: TestClient, patched_retrieve_chunks: Callable[[Sequence[object]], None]
+    client: TestClient, patched_retrieve_chunks: Callable[[Sequence[ScoredChunk]], None]
 ) -> None:
     """The route glue produces grounded=True and cited_passages from the retrieved chunks."""
     set_dependency_override(client, get_completion_provider, _default_fake_llm_provider)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -17,6 +17,7 @@ from fastapi.testclient import TestClient
 from api.dependencies import get_completion_provider, get_embedder, get_reranker
 from api.server import create_app
 from core.clients import InMemoryEmbedder, MockCompletionProvider, NoopReranker
+from core.types.responses import RetrievalResult, ScoredChunk
 
 IngestADocument = Callable[[str], str]
 
@@ -41,14 +42,14 @@ def patched_empty_retrieval(monkeypatch: pytest.MonkeyPatch) -> None:
     """Patch ``retrieve_relevant_chunks`` to return an empty list (not-grounded)."""
     monkeypatch.setattr(
         "api.controllers.qa_controller.retrieve_relevant_chunks",
-        lambda **kwargs: [],
+        lambda **kwargs: RetrievalResult(dense=[], sparse=[], fused=[]),
     )
 
 
 @pytest.fixture
 def patched_retrieve_chunks(
     monkeypatch: pytest.MonkeyPatch,
-) -> Callable[[Sequence[object]], None]:
+) -> Callable[[Sequence[ScoredChunk]], None]:
     """Return a factory that patches retrieval with the given chunks.
 
     Usage in a test::
@@ -57,10 +58,10 @@ def patched_retrieve_chunks(
             patched_retrieve_chunks([CitedPassage(chunk_id=uuid4(), text="...")])
     """
 
-    def _factory(chunks: Sequence[object]) -> None:
+    def _factory(chunks: Sequence[ScoredChunk]) -> None:
         monkeypatch.setattr(
             "api.controllers.qa_controller.retrieve_relevant_chunks",
-            lambda **kwargs: chunks,
+            lambda **kwargs: RetrievalResult(dense=[], sparse=[], fused=list(chunks)),
         )
 
     return _factory

--- a/core/src/core/clients/reranker_client.py
+++ b/core/src/core/clients/reranker_client.py
@@ -10,7 +10,7 @@ import cohere
 
 from core.config.settings import settings
 from core.exceptions import RerankerRateLimitError, UpstreamBadResponse, UpstreamUnavailable
-from core.types.responses import CitedPassage
+from core.types.responses import ScoredChunk
 
 
 @runtime_checkable
@@ -25,9 +25,9 @@ class Reranker(Protocol):
     def rerank(
         self,
         query: str,
-        passages: list[CitedPassage],
+        passages: list[ScoredChunk],
         top_k: int,
-    ) -> list[CitedPassage]:
+    ) -> list[ScoredChunk]:
         """Rerank passages by relevance to the query and return the top-k.
 
         Args:
@@ -76,9 +76,9 @@ class CohereReranker:
     def rerank(
         self,
         query: str,
-        passages: list[CitedPassage],
+        passages: list[ScoredChunk],
         top_k: int,
-    ) -> list[CitedPassage]:
+    ) -> list[ScoredChunk]:
         """Rerank passages via the Cohere Rerank API and return the top-k.
 
         Args:
@@ -122,7 +122,7 @@ class CohereReranker:
                 f"Cohere Rerank API returned unexpected response shape: {exc}"
             ) from exc
 
-        reranked: list[CitedPassage] = []
+        reranked: list[ScoredChunk] = []
         for result in results:
             idx = result.index
             if 0 <= idx < len(passages):
@@ -141,9 +141,9 @@ class NoopReranker:
     def rerank(
         self,
         query: str,
-        passages: list[CitedPassage],
+        passages: list[ScoredChunk],
         top_k: int,
-    ) -> list[CitedPassage]:
+    ) -> list[ScoredChunk]:
         """Return the first top_k passages unchanged.
 
         Args:

--- a/core/src/core/types/__init__.py
+++ b/core/src/core/types/__init__.py
@@ -16,6 +16,8 @@ from core.types.responses import (
     CitedPassage,
     HarnessARequest,
     HarnessAResponse,
+    RetrievalResult,
+    ScoredChunk,
 )
 from core.types.retrieval_config import RetrievalConfig
 
@@ -32,4 +34,6 @@ __all__ = [
     "HarnessAResponse",
     "PaperChunkMetadata",
     "RetrievalConfig",
+    "RetrievalResult",
+    "ScoredChunk",
 ]

--- a/core/src/core/types/responses.py
+++ b/core/src/core/types/responses.py
@@ -28,6 +28,39 @@ class CitedPassage(BaseModel):
     text: str
 
 
+class ScoredChunk(BaseModel):
+    """A retrieved chunk with its relevance score.
+
+    ``chunk_id``, ``text`` mirror ``CitedPassage`` so downstream consumers
+    that access ``.chunk_id`` and ``.text`` continue to work. ``score`` is
+    the RRF combined relevance score; ``parent_chunk_id`` is the chunk id
+    of the parent for child chunks, or ``None`` for standalone/parent
+    chunks.
+    """
+
+    chunk_id: UUID
+    text: str
+    score: float
+    parent_chunk_id: UUID | None = None
+
+
+class RetrievalResult(BaseModel):
+    """Result of a retrieval operation preserving pre-fusion candidate depth.
+
+    ``dense``: results from the dense (pgvector) path with their scores.
+    ``sparse``: results from the sparse (tsvector) path with their scores.
+    ``fused``: the final fused/reranked list of ``ScoredChunk`` instances.
+
+    Production callers access ``.fused`` (behaviourally identical to the
+    previous ``list[CitedPassage]``). Test and introspection code can
+    inspect ``.dense`` and ``.sparse`` separately.
+    """
+
+    dense: list[ScoredChunk]
+    sparse: list[ScoredChunk]
+    fused: list[ScoredChunk]
+
+
 class HarnessAResponse(BaseModel):
     """Response body for ``POST /query``.
 

--- a/core/tests/core/types/test_responses.py
+++ b/core/tests/core/types/test_responses.py
@@ -2,7 +2,13 @@
 
 from uuid import UUID, uuid4
 
-from core.types.responses import CitedPassage, HarnessARequest, HarnessAResponse
+from core.types.responses import (
+    CitedPassage,
+    HarnessARequest,
+    HarnessAResponse,
+    RetrievalResult,
+    ScoredChunk,
+)
 
 
 def test_harness_a_request_accepts_bare_query_string() -> None:
@@ -83,3 +89,49 @@ def test_harness_a_response_answer_is_required_str_not_nullable() -> None:
     assert answer_field.is_required()
     # The annotation should be plain str, not str | None.
     assert answer_field.annotation is str
+
+
+def test_scored_chunk_has_all_fields() -> None:
+    """ScoredChunk exposes chunk_id, text, score, and parent_chunk_id."""
+    from uuid import UUID
+
+    fields = set(ScoredChunk.model_fields)
+    assert fields == {"chunk_id", "text", "score", "parent_chunk_id"}
+    assert ScoredChunk.model_fields["chunk_id"].annotation is UUID
+    assert ScoredChunk.model_fields["text"].annotation is str
+    assert ScoredChunk.model_fields["score"].annotation is float
+    from typing import get_args, get_origin
+
+    parent = ScoredChunk.model_fields["parent_chunk_id"].annotation
+    origin = get_origin(parent)
+    if origin is not None:
+        args = get_args(parent)
+        assert UUID in args and type(None) in args
+    else:
+        assert parent is UUID
+
+
+def test_scored_chunk_defaults_parent_chunk_id_to_none() -> None:
+    """ScoredChunk.parent_chunk_id defaults to None."""
+    chunk = ScoredChunk(chunk_id=uuid4(), text="text", score=0.5)
+    assert chunk.parent_chunk_id is None
+
+
+def test_retrieval_result_has_dense_sparse_fused() -> None:
+    """RetrievalResult exposes dense, sparse, and fused lists."""
+    fields = set(RetrievalResult.model_fields)
+    assert fields == {"dense", "sparse", "fused"}
+    assert RetrievalResult.model_fields["dense"].annotation == list[ScoredChunk]
+    assert RetrievalResult.model_fields["sparse"].annotation == list[ScoredChunk]
+    assert RetrievalResult.model_fields["fused"].annotation == list[ScoredChunk]
+
+
+def test_retrieval_result_constructs_with_lists() -> None:
+    """RetrievalResult accepts three ScoredChunk lists."""
+    chunk = ScoredChunk(chunk_id=uuid4(), text="test", score=0.5)
+    result = RetrievalResult(dense=[chunk], sparse=[], fused=[chunk])
+    assert len(result.dense) == 1
+    assert len(result.sparse) == 0
+    assert len(result.fused) == 1
+    assert result.fused[0].text == "test"
+    assert result.fused[0].score == 0.5

--- a/ingestion/tests/integration/test_real_ingestion.py
+++ b/ingestion/tests/integration/test_real_ingestion.py
@@ -218,15 +218,15 @@ def test_real_ingestion_is_grounded(
         top_k=settings.query_top_k,
     )
 
-    passages = retrieve_relevant_chunks(
+    result = retrieve_relevant_chunks(
         query_vector=query_vector,
         session=test_session,
         config=config,
         query_text=query_text,
     )
 
-    assert passages, f"expected at least one retrieved chunk for query: {query_text!r}"
-    passage_texts = [p.text for p in passages]
+    assert result.fused, f"expected at least one retrieved chunk for query: {query_text!r}"
+    passage_texts = [p.text for p in result.fused]
     assert any(expected_substring in text for text in passage_texts), (
         f"expected substring {expected_substring!r} not found in passages. "
         f"Retrieved: {[t[:100] for t in passage_texts]}"

--- a/retrieval_qa/src/retrieval_qa/retrieval/query.py
+++ b/retrieval_qa/src/retrieval_qa/retrieval/query.py
@@ -51,7 +51,7 @@ from sqlalchemy.orm import Session
 
 from core.clients.reranker_client import Reranker
 from core.exceptions import RerankerRateLimitError, UpstreamUnavailable
-from core.types.responses import CitedPassage
+from core.types.responses import RetrievalResult, ScoredChunk
 from core.types.retrieval_config import RetrievalConfig
 
 logger = logging.getLogger(__name__)
@@ -65,8 +65,9 @@ _RERANK_CANDIDATE_COUNT = 20
 _DENSE_SQL = text(
     """
     SELECT
-        chunks.chunk_id AS chunk_id,
-        chunks.content  AS text
+        chunks.chunk_id          AS chunk_id,
+        chunks.content           AS text,
+        chunks.parent_chunk_id   AS parent_chunk_id
     FROM embeddings
     JOIN chunks  ON chunks.chunk_id  = embeddings.chunk_id
     JOIN documents ON documents.document_id = chunks.document_id
@@ -80,8 +81,9 @@ _DENSE_SQL = text(
 _SPARSE_SQL = text(
     """
     SELECT
-        chunks.chunk_id AS chunk_id,
-        chunks.content  AS text,
+        chunks.chunk_id          AS chunk_id,
+        chunks.content           AS text,
+        chunks.parent_chunk_id   AS parent_chunk_id,
         ts_rank(
             to_tsvector('english', chunks.content),
             websearch_to_tsquery('english', :query_text)
@@ -99,7 +101,8 @@ _SPARSE_SQL = text(
 _PARENT_SWAP_SQL = text(
     """
     SELECT
-        children.chunk_id       AS child_chunk_id,
+        children.chunk_id                      AS child_chunk_id,
+        parents.parent_chunk_id                AS parent_parent_chunk_id,
         COALESCE(parents.chunk_id, children.chunk_id) AS chunk_id,
         COALESCE(parents.content, children.content)   AS text
     FROM chunks children
@@ -114,8 +117,8 @@ def _dense_retrieve(
     query_vector: list[float],
     config: RetrievalConfig,
     limit: int | None = None,
-) -> OrderedDict[UUID, float]:
-    """Run dense (pgvector cosine) search and return chunk_id -> RRF score."""
+) -> list[ScoredChunk]:
+    """Run dense (pgvector cosine) search and return ScoredChunk list."""
     top_k = limit if limit is not None else config.top_k
     result = session.execute(
         _DENSE_SQL,
@@ -125,11 +128,17 @@ def _dense_retrieve(
             "top_k": top_k,
         },
     )
-    scored: OrderedDict[UUID, float] = OrderedDict()
+    chunks: list[ScoredChunk] = []
     for rank, row in enumerate(result.fetchall(), 1):
-        chunk_id = row._mapping["chunk_id"]
-        scored[chunk_id] = 1.0 / (_RRF_K + rank)
-    return scored
+        chunks.append(
+            ScoredChunk(
+                chunk_id=row._mapping["chunk_id"],
+                text=row._mapping["text"],
+                score=1.0 / (_RRF_K + rank),
+                parent_chunk_id=row._mapping.get("parent_chunk_id"),
+            )
+        )
+    return chunks
 
 
 def _sparse_retrieve(
@@ -137,8 +146,8 @@ def _sparse_retrieve(
     query_text: str,
     config: RetrievalConfig,
     limit: int | None = None,
-) -> OrderedDict[UUID, float]:
-    """Run sparse (tsvector ts_rank) search and return chunk_id -> RRF score."""
+) -> list[ScoredChunk]:
+    """Run sparse (tsvector ts_rank) search and return ScoredChunk list."""
     top_k = limit if limit is not None else config.top_k
     result = session.execute(
         _SPARSE_SQL,
@@ -147,11 +156,17 @@ def _sparse_retrieve(
             "top_k": top_k,
         },
     )
-    scored: OrderedDict[UUID, float] = OrderedDict()
+    chunks: list[ScoredChunk] = []
     for rank, row in enumerate(result.fetchall(), 1):
-        chunk_id = row._mapping["chunk_id"]
-        scored[chunk_id] = 1.0 / (_RRF_K + rank)
-    return scored
+        chunks.append(
+            ScoredChunk(
+                chunk_id=row._mapping["chunk_id"],
+                text=row._mapping["text"],
+                score=1.0 / (_RRF_K + rank),
+                parent_chunk_id=row._mapping.get("parent_chunk_id"),
+            )
+        )
+    return chunks
 
 
 def _rrf_fuse(
@@ -188,7 +203,7 @@ def _rrf_fuse(
 def _parent_swap(
     session: Session,
     scored_chunks: OrderedDict[UUID, float],
-) -> list[CitedPassage]:
+) -> list[ScoredChunk]:
     """Swap matched child chunks to their parents and deduplicate.
 
     For each chunk in scored_chunks (ordered by descending RRF score),
@@ -204,7 +219,7 @@ def _parent_swap(
         scored_chunks: chunk_id -> RRF score, ordered descending by score.
 
     Returns:
-        A deduplicated list of CitedPassage instances preserving RRF rank order.
+        A deduplicated list of ScoredChunk instances preserving RRF rank order.
     """
     if not scored_chunks:
         return []
@@ -215,29 +230,35 @@ def _parent_swap(
         {"chunk_ids": chunk_ids},
     )
 
-    # Build child -> (parent_chunk_id, parent_text) map
-    child_to_parent: dict[UUID, tuple[UUID, str]] = {}
+    child_to_parent: dict[UUID, tuple[UUID, str, UUID | None]] = {}
     for row in result.fetchall():
         child_id = row._mapping["child_chunk_id"]
         parent_id = row._mapping["chunk_id"]
         parent_text = row._mapping["text"]
-        child_to_parent[child_id] = (parent_id, parent_text)
+        parent_parent_chunk_id = row._mapping["parent_parent_chunk_id"]
+        child_to_parent[child_id] = (parent_id, parent_text, parent_parent_chunk_id)
 
-    # Walk the scored chunks in RRF rank order, deduplicating by parent
     seen_parents: set[UUID] = set()
-    passages: list[CitedPassage] = []
+    passages: list[ScoredChunk] = []
 
     for child_chunk_id in scored_chunks:
         parent_info = child_to_parent.get(child_chunk_id)
         if parent_info is None:
             continue
-        parent_id, parent_text = parent_info
+        parent_id, parent_text, parent_parent_chunk_id = parent_info
 
         if parent_id in seen_parents:
             continue
         seen_parents.add(parent_id)
 
-        passages.append(CitedPassage(chunk_id=parent_id, text=parent_text))
+        passages.append(
+            ScoredChunk(
+                chunk_id=parent_id,
+                text=parent_text,
+                score=scored_chunks[child_chunk_id],
+                parent_chunk_id=parent_parent_chunk_id,
+            )
+        )
 
     return passages
 
@@ -249,7 +270,7 @@ def retrieve_relevant_chunks(
     config: RetrievalConfig,
     query_text: str | None = None,
     reranker: Reranker | None = None,
-) -> list[CitedPassage]:
+) -> RetrievalResult:
     """Retrieve the top-k closest chunks for ``query_vector`` by cosine distance.
 
     Issues ``SET LOCAL hnsw.ef_search`` inside the caller's transaction and
@@ -280,9 +301,10 @@ def retrieve_relevant_chunks(
             directly.
 
     Returns:
-        Chunks in descending relevance order. An empty list signals the
-        not-found case (empty corpus or no relevant chunks), which is a valid
-        response per ADR-0009 — never raised as an exception.
+        A ``RetrievalResult`` with ``.fused`` holding the final ranked
+        chunks. An empty ``.fused`` list signals the not-found case (empty
+        corpus or no relevant chunks), which is a valid response per
+        ADR-0009 — never raised as an exception.
 
     Raises:
         UpstreamUnavailable: The database is unreachable (maps to 503 per
@@ -298,43 +320,33 @@ def retrieve_relevant_chunks(
         retrieval_limit = _RERANK_CANDIDATE_COUNT if should_rerank else config.top_k
 
         if config.hybrid_search and query_text:
-            dense_scored = _dense_retrieve(session, query_vector, config, limit=retrieval_limit)
-            sparse_scored = _sparse_retrieve(session, query_text, config, limit=retrieval_limit)
-            fused = _rrf_fuse(dense_scored, sparse_scored, retrieval_limit)
-            passages = _parent_swap(session, fused)
+            dense_chunks = _dense_retrieve(session, query_vector, config, limit=retrieval_limit)
+            sparse_chunks = _sparse_retrieve(session, query_text, config, limit=retrieval_limit)
+            dense_scored = OrderedDict((c.chunk_id, c.score) for c in dense_chunks)
+            sparse_scored = OrderedDict((c.chunk_id, c.score) for c in sparse_chunks)
+            fused_scores = _rrf_fuse(dense_scored, sparse_scored, retrieval_limit)
+            fused_chunks = _parent_swap(session, fused_scores)
         else:
             # Dense-only path (hybrid_search=False or no query_text provided)
-            rows = session.execute(
-                _DENSE_SQL,
-                {
-                    "model_name": config.model_name,
-                    "query_vector": str(query_vector),
-                    "top_k": retrieval_limit,
-                },
-            )
-            passages = [
-                CitedPassage(
-                    chunk_id=row._mapping["chunk_id"],
-                    text=row._mapping["text"],
-                )
-                for row in rows.fetchall()
-            ]
+            dense_chunks = _dense_retrieve(session, query_vector, config, limit=retrieval_limit)
+            sparse_chunks = []
+            fused_chunks = dense_chunks[:]
 
-        if should_rerank and passages and reranker is not None:
+        if should_rerank and fused_chunks and reranker is not None:
             try:
-                passages = reranker.rerank(
+                fused_chunks = reranker.rerank(
                     query=query_text or "",
-                    passages=passages,
+                    passages=fused_chunks,
                     top_k=config.top_k,
                 )
             except RerankerRateLimitError as exc:
                 logger.warning("Reranker rate-limited, falling back to RRF top-k: %s", exc)
-                passages = passages[: config.top_k]
+                fused_chunks = fused_chunks[: config.top_k]
 
-        return passages
+        return RetrievalResult(dense=dense_chunks, sparse=sparse_chunks, fused=fused_chunks)
 
     except (OperationalError, InterfaceError) as exc:
         raise UpstreamUnavailable(f"Database unreachable: {exc}") from exc
 
 
-__all__ = ["CitedPassage", "retrieve_relevant_chunks"]
+__all__ = ["RetrievalResult", "ScoredChunk", "retrieve_relevant_chunks"]

--- a/retrieval_qa/tests/eval/test_eval.py
+++ b/retrieval_qa/tests/eval/test_eval.py
@@ -115,7 +115,7 @@ def test_recall_at_k_retrieves_expected_passages(
     """
     top_k = Settings().query_top_k
     query_vector = query_vectors[query_data.content_sha256]
-    results = retrieve_relevant_chunks(
+    result = retrieve_relevant_chunks(
         query_vector=query_vector,
         session=eval_session,
         config=RetrievalConfig(
@@ -125,7 +125,7 @@ def test_recall_at_k_retrieves_expected_passages(
         ),
     )
 
-    retrieved_texts = [r.text for r in results]
+    retrieved_texts = [r.text for r in result.fused]
     test_case = LLMTestCase(
         input=query_data.query,
         actual_output="",

--- a/retrieval_qa/tests/retrieval_qa/retrieval/test_query.py
+++ b/retrieval_qa/tests/retrieval_qa/retrieval/test_query.py
@@ -9,7 +9,7 @@ from core.clients.reranker_client import NoopReranker
 from core.database.schema import Chunk, Document, Embedding
 from core.exceptions import RerankerRateLimitError
 from core.types.document import DocumentStatus, DocumentType
-from core.types.responses import CitedPassage
+from core.types.responses import CitedPassage, ScoredChunk
 from core.types.retrieval_config import RetrievalConfig
 from retrieval_qa.retrieval.query import retrieve_relevant_chunks
 
@@ -124,10 +124,10 @@ def test_retrieve_returns_closest_chunks_by_cosine(test_session: Session) -> Non
         config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=2),
     )
 
-    assert len(results) == 2
-    assert results[0].text == "near chunk content"
+    assert len(results.fused) == 2
+    assert results.fused[0].text == "near chunk content"
     # Closer-first ordering by cosine distance.
-    assert results[0].chunk_id != results[1].chunk_id
+    assert results.fused[0].chunk_id != results.fused[1].chunk_id
 
 
 def test_retrieve_returns_full_chunk_text_not_truncated(test_session: Session) -> None:
@@ -147,8 +147,8 @@ def test_retrieve_returns_full_chunk_text_not_truncated(test_session: Session) -
         config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=1),
     )
 
-    assert len(results) == 1
-    assert results[0].text == long_text.strip()
+    assert len(results.fused) == 1
+    assert results.fused[0].text == long_text.strip()
 
 
 def test_retrieve_respects_top_k_limit(test_session: Session) -> None:
@@ -167,7 +167,7 @@ def test_retrieve_respects_top_k_limit(test_session: Session) -> None:
         config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=3),
     )
 
-    assert len(results) == 3
+    assert len(results.fused) == 3
 
 
 def test_retrieve_only_returns_chunks_from_ready_documents(
@@ -195,8 +195,8 @@ def test_retrieve_only_returns_chunks_from_ready_documents(
         config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
     )
 
-    assert len(results) == 1
-    assert results[0].text == "visible chunk"
+    assert len(results.fused) == 1
+    assert results.fused[0].text == "visible chunk"
 
 
 def test_retrieve_scopes_embeddings_to_model_name(test_session: Session) -> None:
@@ -214,7 +214,7 @@ def test_retrieve_scopes_embeddings_to_model_name(test_session: Session) -> None
         config=RetrievalConfig(model_name="some-other-model", ef_search=40, top_k=5),
     )
 
-    assert results == []
+    assert results.fused == []
 
 
 def test_retrieve_empty_corpus_returns_empty_list(test_session: Session) -> None:
@@ -224,7 +224,7 @@ def test_retrieve_empty_corpus_returns_empty_list(test_session: Session) -> None
         session=test_session,
         config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5),
     )
-    assert results == []
+    assert results.fused == []
 
 
 def test_cited_passage_is_pydantic_model_with_chunk_id_and_text() -> None:
@@ -343,8 +343,8 @@ def test_hybrid_dense_only_when_no_query_text_falls_back_to_dense(
         query_text=None,
     )
 
-    assert len(results) == 1
-    assert results[0].text == "dense match"
+    assert len(results.fused) == 1
+    assert results.fused[0].text == "dense match"
 
 
 def test_hybrid_search_false_falls_back_to_dense_only(
@@ -371,8 +371,8 @@ def test_hybrid_search_false_falls_back_to_dense_only(
         query_text="some query that would match via sparse if enabled",
     )
 
-    assert len(results) == 1
-    assert results[0].text == "dense only"
+    assert len(results.fused) == 1
+    assert results.fused[0].text == "dense only"
 
 
 def test_sparse_only_matches_exact_keyword_not_in_embedding_space(
@@ -403,8 +403,8 @@ def test_sparse_only_matches_exact_keyword_not_in_embedding_space(
         query_text="checkout orphan",
     )
 
-    assert len(results) >= 1
-    texts = [r.text for r in results]
+    assert len(results.fused) >= 1
+    texts = [r.text for r in results.fused]
     assert any("checkout" in t for t in texts)
 
 
@@ -427,8 +427,8 @@ def test_sparse_path_graceful_degradation_when_no_text_matches(
         query_text="xyznonexistentkeyword12345",
     )
 
-    assert len(results) == 1
-    assert results[0].text == "dense result text"
+    assert len(results.fused) == 1
+    assert results.fused[0].text == "dense result text"
 
 
 def test_sparse_only_finds_result_when_dense_returns_empty(
@@ -453,8 +453,8 @@ def test_sparse_only_finds_result_when_dense_returns_empty(
     )
 
     # Sparse should find the keyword even though the dense vector is far
-    assert len(results) >= 1
-    assert any("zxcvbnm" in r.text for r in results)
+    assert len(results.fused) >= 1
+    assert any("zxcvbnm" in r.text for r in results.fused)
 
 
 def test_parent_swap_replaces_child_content_with_parent_content(
@@ -480,9 +480,9 @@ def test_parent_swap_replaces_child_content_with_parent_content(
         query_text="vector databases embeddings",
     )
 
-    assert len(results) == 1
-    assert results[0].text == parent_text
-    assert results[0].chunk_id == parent.chunk_id
+    assert len(results.fused) == 1
+    assert results.fused[0].text == parent_text
+    assert results.fused[0].chunk_id == parent.chunk_id
 
 
 def test_parent_swap_deduplicates_multiple_children_of_same_parent(
@@ -511,9 +511,9 @@ def test_parent_swap_deduplicates_multiple_children_of_same_parent(
         query_text="Kubernetes pods",
     )
 
-    assert len(results) == 1
-    assert results[0].chunk_id == parent.chunk_id
-    assert results[0].text == parent_text
+    assert len(results.fused) == 1
+    assert results.fused[0].chunk_id == parent.chunk_id
+    assert results.fused[0].text == parent_text
 
 
 def test_parent_swap_returns_standalone_chunks_without_parents_as_is(
@@ -538,8 +538,8 @@ def test_parent_swap_returns_standalone_chunks_without_parents_as_is(
         query_text="standalone chunk",
     )
 
-    assert len(results) == 1
-    assert results[0].text == content
+    assert len(results.fused) == 1
+    assert results.fused[0].text == content
 
 
 def test_hybrid_rrf_fusion_combines_dense_and_sparse_without_duplicates(
@@ -564,8 +564,8 @@ def test_hybrid_rrf_fusion_combines_dense_and_sparse_without_duplicates(
         query_text="pgvector",
     )
 
-    assert len(results) == 1
-    assert results[0].text == content
+    assert len(results.fused) == 1
+    assert results.fused[0].text == content
 
 
 def test_hybrid_search_respects_top_k_limit(test_session: Session) -> None:
@@ -586,7 +586,7 @@ def test_hybrid_search_respects_top_k_limit(test_session: Session) -> None:
         query_text="zeta",
     )
 
-    assert len(results) <= 3
+    assert len(results.fused) <= 3
 
 
 def test_hybrid_search_returns_empty_list_when_no_results_from_either_path(
@@ -612,7 +612,7 @@ def test_hybrid_search_returns_empty_list_when_no_results_from_either_path(
         query_text="xyznonexistentkeyword12345",  # sparse: no text match
     )
 
-    assert results == []
+    assert results.fused == []
 
 
 def test_sparse_only_parent_swap_returns_parent_content(
@@ -644,9 +644,9 @@ def test_sparse_only_parent_swap_returns_parent_content(
         query_text="pgvector",
     )
 
-    assert len(results) == 1
-    assert results[0].chunk_id == parent.chunk_id
-    assert results[0].text == parent_text
+    assert len(results.fused) == 1
+    assert results.fused[0].chunk_id == parent.chunk_id
+    assert results.fused[0].text == parent_text
 
 
 # ── Reranker tests ───────────────────────────────────────────────────────────
@@ -675,9 +675,9 @@ def test_reranker_reorders_passages(test_session: Session) -> None:
         reranker=reverse_reranker,
     )
 
-    assert len(results) == 2
-    assert results[0].text == "chunk gamma"
-    assert results[1].text == "chunk beta"
+    assert len(results.fused) == 2
+    assert results.fused[0].text == "chunk gamma"
+    assert results.fused[1].text == "chunk beta"
 
 
 def test_reranker_respects_top_k_when_narrowing(test_session: Session) -> None:
@@ -700,7 +700,7 @@ def test_reranker_respects_top_k_when_narrowing(test_session: Session) -> None:
         reranker=NoopReranker(),
     )
 
-    assert len(results) == 3
+    assert len(results.fused) == 3
 
 
 def test_reranker_disabled_falls_back_to_rrf_top_k_directly(
@@ -736,7 +736,7 @@ def test_reranker_disabled_falls_back_to_rrf_top_k_directly(
     # With reranker=False, we don't enlarge the retrieval limit, so at most
     # top_k=3 results come back from RRF. Even with a reranker instance
     # passed, it is not called.
-    assert len(results) <= 3
+    assert len(results.fused) <= 3
 
 
 def test_rate_limit_fallback_to_rrf_top_k(test_session: Session) -> None:
@@ -761,8 +761,8 @@ def test_rate_limit_fallback_to_rrf_top_k(test_session: Session) -> None:
         reranker=_RateLimitReranker(),
     )
 
-    assert len(results) == 3
-    for result in results:
+    assert len(results.fused) == 3
+    for result in results.fused:
         assert "fallback" in result.text
 
 
@@ -792,7 +792,7 @@ def test_reranker_with_empty_passages_returns_empty(
         reranker=NoopReranker(),
     )
 
-    assert results == []
+    assert results.fused == []
 
 
 # ── Test double rerankers ────────────────────────────────────────────────────
@@ -804,9 +804,9 @@ class _ReverseReranker:
     def rerank(
         self,
         query: str,
-        passages: list[CitedPassage],
+        passages: list[ScoredChunk],
         top_k: int,
-    ) -> list[CitedPassage]:
+    ) -> list[ScoredChunk]:
         return list(reversed(passages))[:top_k]
 
 
@@ -816,7 +816,7 @@ class _RateLimitReranker:
     def rerank(
         self,
         query: str,
-        passages: list[CitedPassage],
+        passages: list[ScoredChunk],
         top_k: int,
-    ) -> list[CitedPassage]:
+    ) -> list[ScoredChunk]:
         raise RerankerRateLimitError("Simulated rate limit.")


### PR DESCRIPTION
…ve_relevant_chunks

Add ScoredChunk and RetrievalResult to core/types/responses.py. Change retrieve_relevant_chunks return type from list[CitedPassage] to RetrievalResult. Update all production call sites (qa_controller.py, prompt.py) to access .fused. Update Reranker protocol and all implementations to use ScoredChunk. Update all ~28 test call sites, mocks, and integration tests. All existing tests pass.

Closes #146