### PR TITLE
feat(scripts): add eval_metrics.py with is_hit, RecallAtKMetric, and …

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""Scripts for the Learning Hub monorepo.
+
+Contains standalone utility scripts including eval metric computation,
+eval vector generation, and manual ingestion smoke tests.
+"""

--- a/scripts/eval_metrics.py
+++ b/scripts/eval_metrics.py
@@ -1,0 +1,83 @@
+"""Pure-computation evaluation metrics for retrieval tuning.
+
+Provides substring-based hit detection (``is_hit``) and rank-based metrics
+(``RecallAtKMetric``, ``MRRMetric``) used by the chunk-size tuning harness.
+
+All functions and classes are pure computation — no I/O, no database, no API
+calls.  Each metric accepts an iterable of booleans (hit or miss per rank
+position) and returns a float in [0, 1].
+"""
+
+import itertools
+from collections.abc import Iterable
+
+
+def is_hit(chunk_text: str, expected_signature: str) -> bool:
+    """Check whether ``expected_signature`` is a substring of ``chunk_text``.
+
+    Args:
+        chunk_text: The content of a retrieved chunk.
+        expected_signature: The expected text pattern to search for.
+
+    Returns:
+        ``True`` if ``expected_signature`` is found as a substring
+        of ``chunk_text``, ``False`` otherwise.
+    """
+    return expected_signature in chunk_text
+
+
+class RecallAtKMetric:
+    """Recall@k computed from a ranked list of hit/miss results.
+
+    Recall@k is the fraction of the top-``k`` results that are hits.  When
+    the result list has fewer than ``k`` items, the missing positions are
+    treated as misses (the denominator is always ``k``).
+
+    Args:
+        k: The rank cutoff.  Must be >= 1.
+    """
+
+    def __init__(self, k: int) -> None:
+        if k < 1:
+            raise ValueError(f"k must be >= 1, got {k}")
+        self.k = k
+
+    def compute(self, results: Iterable[bool]) -> float:
+        """Compute recall@k from ranked hit/miss results.
+
+        Args:
+            results: Iterable of booleans ordered by rank (position 1 first).
+                     ``True`` indicates a hit; ``False`` indicates a miss.
+
+        Returns:
+            A float in [0, 1] — the fraction of top-``k`` results that
+            are hits.
+        """
+        hits = sum(1 for hit in itertools.islice(results, self.k) if hit)
+        return hits / self.k
+
+
+class MRRMetric:
+    """Mean Reciprocal Rank (MRR) computed from a ranked list of hit/miss results.
+
+    For a single ranked result list this is the reciprocal rank of the first
+    hit (1 / rank).  Returns 0.0 when no hit is found.  Average multiple
+    queries at the call site to obtain a true *mean* reciprocal rank.
+    """
+
+    @staticmethod
+    def compute(results: Iterable[bool]) -> float:
+        """Compute the reciprocal rank of the first hit.
+
+        Args:
+            results: Iterable of booleans ordered by rank (position 1 first).
+                     ``True`` indicates a hit; ``False`` indicates a miss.
+
+        Returns:
+            A float in [0, 1] — the reciprocal rank of the first hit,
+            or 0.0 if no hit is found.
+        """
+        for rank, hit in enumerate(results, start=1):
+            if hit:
+                return 1.0 / rank
+        return 0.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+"""Root-level test package.
+
+Houses tests for root-level ``scripts/`` modules.  Per-package tests live
+under their respective package ``tests/`` directories.
+"""

--- a/tests/scripts/__init__.py
+++ b/tests/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for root-level ``scripts/`` modules."""

--- a/tests/scripts/test_eval_metrics.py
+++ b/tests/scripts/test_eval_metrics.py
@@ -1,0 +1,98 @@
+"""Tests for scripts/eval_metrics.py.
+
+Covers the three pure-computation evaluation metric components:
+``is_hit``, ``RecallAtKMetric``, and ``MRRMetric``.
+"""
+
+import sys
+from pathlib import Path
+
+# Ensure the repo root is on sys.path so that ``scripts`` is importable.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.eval_metrics import MRRMetric, RecallAtKMetric, is_hit  # noqa: E402
+
+
+def test_is_hit_returns_true_when_signature_present() -> None:
+    assert is_hit("The quick brown fox jumps over the lazy dog.", "fox")
+
+
+def test_is_hit_returns_false_when_signature_absent() -> None:
+    assert not is_hit("The quick brown fox jumps over the lazy dog.", "cat")
+
+
+def test_is_hit_case_sensitive() -> None:
+    assert not is_hit("The quick brown FOX jumps.", "fox")
+
+
+def test_is_hit_empty_chunk_text() -> None:
+    assert not is_hit("", "fox")
+
+
+def test_is_hit_empty_signature() -> None:
+    assert is_hit("any text", "")
+
+
+def test_is_hit_exact_match() -> None:
+    assert is_hit("fox", "fox")
+
+
+def test_recall_at_k_all_hits() -> None:
+    assert RecallAtKMetric(k=10).compute([True] * 10) == 1.0
+
+
+def test_recall_at_k_no_hits() -> None:
+    assert RecallAtKMetric(k=10).compute([False] * 10) == 0.0
+
+
+def test_recall_at_k_partial_hits() -> None:
+    assert RecallAtKMetric(k=10).compute([True] * 3 + [False] * 7) == 0.3
+
+
+def test_recall_at_k_ignores_results_beyond_k() -> None:
+    assert RecallAtKMetric(k=3).compute([True, False, True, True, True]) == 2 / 3
+
+
+def test_recall_at_k_fewer_results_than_k() -> None:
+    assert RecallAtKMetric(k=10).compute([True, True, True]) == 0.3
+
+
+def test_recall_at_k_empty_results() -> None:
+    assert RecallAtKMetric(k=10).compute([]) == 0.0
+
+
+def test_recall_at_k_k_of_one() -> None:
+    assert RecallAtKMetric(k=1).compute([True, False, False]) == 1.0
+    assert RecallAtKMetric(k=1).compute([False, True, False]) == 0.0
+
+
+def test_recall_at_k_accepts_generator() -> None:
+    gen = (b for b in [True, False, True])
+    assert RecallAtKMetric(k=3).compute(gen) == 2 / 3
+
+
+def test_mrr_first_hit_at_position_one() -> None:
+    assert MRRMetric.compute([True, False, False]) == 1.0
+
+
+def test_mrr_first_hit_at_position_three() -> None:
+    assert MRRMetric.compute([False, False, True, False]) == 1 / 3
+
+
+def test_mrr_no_hits() -> None:
+    assert MRRMetric.compute([False, False, False]) == 0.0
+
+
+def test_mrr_empty_results() -> None:
+    assert MRRMetric.compute([]) == 0.0
+
+
+def test_mrr_first_hit_at_position_one_among_many() -> None:
+    assert MRRMetric.compute([True, True, True, True]) == 1.0
+
+
+def test_mrr_accepts_generator() -> None:
+    gen = (b for b in [False, True])
+    assert MRRMetric.compute(gen) == 0.5


### PR DESCRIPTION
…MRRMetric

Create pure-computation evaluation metric components for the chunk-size tuning harness (parent #145):

- is_hit(chunk_text, expected_signature) -> bool — substring containment check invariant to chunk boundaries
- RecallAtKMetric(k) — recall@k from ranked hit/miss flags
- MRRMetric — reciprocal rank of first hit (MRR over queries at caller)

Closes #148