### PR TITLE
feat(eval): add eval corpus and tuning query set

### DIFF
--- a/eval_corpus/books/ddia-excerpts.md
+++ b/eval_corpus/books/ddia-excerpts.md
@@ -1,0 +1,63 @@
+# Designing Data-Intensive Applications — Excerpts
+
+## Chapter 5: Replication
+
+Replication means keeping a copy of the same data on multiple machines that are connected via a network. Reasons for replication include keeping data geographically close to users, allowing the system to continue working even if some of its parts have failed, and scaling out the number of machines that can serve read queries.
+
+### Leaders and Followers
+
+The most common approach to replication is called leader-based replication (also known as active/passive or master-slave replication). One replica is designated the leader (also known as master or primary). When clients want to write to the database, they must send their requests to the leader, which first writes the new data to its local storage. The other replicas are called followers (read replicas, slaves, secondaries, or hot standbys). Whenever the leader writes new data to its local storage, it also sends the data change to all followers as part of a replication log or change stream. Each follower takes the log from the leader and updates its local copy of the database accordingly, by applying all writes in the same order as they were processed on the leader. When a client wants to read from the database, it can query either the leader or any follower. However, writes are only accepted on the leader.
+
+### Synchronous vs Asynchronous Replication
+
+An important trade-off in replicated systems is whether the replication is synchronous or asynchronous. In synchronous replication, the leader waits until the follower has confirmed that it received the write before reporting success to the user, and before making the write visible to other clients. In asynchronous replication, the leader sends the message but doesn't wait for a response from the follower. The advantage of synchronous replication is that the follower is guaranteed to have an up-to-date copy of the data that is consistent with the leader. The disadvantage is that if the synchronous follower doesn't respond, the write cannot be processed at all.
+
+### Setting Up New Followers
+
+Setting up a follower can often be done without downtime. Theoretically, you could simply copy the leader's data files to the follower and start replicating from that point. However, copying the files requires a filesystem snapshot consistent with the leader's replication log position.
+
+## Chapter 6: Partitioning
+
+Partitioning is the splitting of a large dataset into smaller subsets. Each partition is a small database of its own. Reasons for partitioning include scalability and query throughput. Different partitions can be placed on different nodes in a shared-nothing cluster. A database query can potentially be parallelized across many nodes.
+
+### Partitioning of Key-Value Data
+
+One way of partitioning is to assign each key to a partition by taking the hash of the key and then assigning a range of hashes to each partition. This approach is known as hash-based partitioning or consistent hashing. It has the advantage of distributing keys quite evenly across partitions.
+
+The opposite approach is range-based partitioning, where keys are assigned to partitions based on their actual value ranges. Range-based partitioning is more effective for range-scan queries and when the data has a natural sort order.
+
+### Partitioning and Secondary Indexes
+
+Secondary indexes are the main factor that makes partitioning complicated. The problem is that secondary indexes don't map neatly to partitions. There are two main approaches to partitioning a database with secondary indexes: document-based partitioning (where each partition maintains its own secondary indexes, also known as local indexes) and term-based partitioning (where a global index is partitioned by the indexed term rather than the document).
+
+## Chapter 7: Transactions
+
+The concept of a transaction has been the mechanism for grouping multiple reads and writes into a logical unit. Transactions simplify the programming model by hiding the complexities of concurrency and partial failures.
+
+### ACID
+
+ACID stands for Atomicity, Consistency, Isolation, and Durability. Atomicity means that writes in a transaction are executed as a whole — either all succeed or all fail. Consistency means that the database is in a valid state before and after the transaction. Isolation means that concurrently executing transactions are isolated from each other. Durability means that once a transaction has committed successfully, the data will not be forgotten, even if there is a hardware fault or the database crashes.
+
+### Isolation Levels
+
+Read Committed is the most basic level of isolation. It guarantees that any data read is committed at the moment it is read — it never sees uncommitted data. Snapshot Isolation (also known as Repeatable Read) gives each transaction a consistent snapshot of the database at a point in time. Serializable isolation is the strongest level; it guarantees that even though transactions may execute concurrently, the end result is the same as if they had executed one at a time, in some serial order.
+
+## Chapter 10: Batch Processing
+
+Batch processing is the classic approach to processing large volumes of data. A batch processing job takes a fixed input and produces a fixed output, with no side effects or external interactions during the processing.
+
+### MapReduce
+
+MapReduce is a programming model for processing large datasets in a distributed fashion. A MapReduce job has two phases: the mapper and the reducer. The mapper applies a transformation to each input record independently. The reducer aggregates the mapper's outputs. Between the map and reduce phases, the framework sorts and groups the intermediate data by key.
+
+## Chapter 11: Stream Processing
+
+Stream processing deals with data that arrives continuously, as opposed to batch processing where the input is bounded. The key difference is that streams are unbounded — you never know when the data will end.
+
+### Event Streams
+
+An event is a small, self-contained record of something that happened at some point in time. Events are written by producers and read by consumers. A stream is the sequence of events ordered by time.
+
+### Representing Event Streams
+
+A log is the most natural representation of an event stream. In the context of stream processing, a log is simply an append-only sequence of records. A log can be partitioned across multiple machines, similar to a partitioned database table.

--- a/eval_corpus/books/deep-learning-concepts.md
+++ b/eval_corpus/books/deep-learning-concepts.md
@@ -1,0 +1,69 @@
+# Deep Learning — Core Concepts
+
+## Chapter 1: Neural Network Fundamentals
+
+A neural network is composed of layers of interconnected neurons. Each neuron receives input from the previous layer, applies a weighted sum followed by a non-linear activation function, and passes the result to the next layer. The simplest form is the feedforward neural network, where information flows in one direction without cycles.
+
+### Activation Functions
+
+The ReLU (Rectified Linear Unit) activation function is defined as f(x) = max(0, x). It has become the default activation function for many neural network architectures because it helps mitigate the vanishing gradient problem. Other activation functions include the sigmoid function, which squashes values to the range (0, 1), and the tanh function, which squashes values to the range (-1, 1).
+
+### Loss Functions
+
+The choice of loss function depends on the task. For regression tasks, mean squared error is commonly used. For classification tasks, cross-entropy loss is the standard choice. The loss function measures how far the network's predictions are from the ground truth.
+
+## Chapter 2: Training Neural Networks
+
+### Backpropagation
+
+Backpropagation is the algorithm for computing gradients of the loss function with respect to the network parameters. It works by applying the chain rule from calculus to propagate error signals backward through the network. Once the gradients are computed, an optimization algorithm such as stochastic gradient descent (SGD) uses them to update the parameters.
+
+### Stochastic Gradient Descent
+
+SGD updates parameters in the direction opposite to the gradient of the loss function. The learning rate controls the step size of each update. Mini-batch SGD is a variant that computes gradients on small random subsets of the training data rather than the full dataset.
+
+### Regularization
+
+Regularization techniques prevent overfitting. L1 regularization adds the absolute value of weights to the loss function, encouraging sparse weight matrices. L2 regularization (also known as weight decay) adds the squared magnitude of weights to the loss. Dropout is a regularization technique where randomly selected neurons are omitted during training, forcing the network to learn redundant representations.
+
+## Chapter 3: Convolutional Neural Networks
+
+Convolutional neural networks are designed to process grid-like data such as images. A convolution operation applies a filter (also called a kernel) across the input, producing a feature map. Key properties of convolutions include local connectivity, parameter sharing, and translational equivariance.
+
+### Pooling Layers
+
+Pooling layers reduce the spatial dimensions of feature maps. Max pooling selects the maximum value in each pooling window, while average pooling computes the mean. Pooling provides a form of translational invariance and reduces the computational cost of subsequent layers.
+
+### Common Architectures
+
+LeNet-5 was one of the earliest CNN architectures for handwritten digit recognition. AlexNet demonstrated the effectiveness of deep CNNs on large-scale image classification. ResNet introduced skip connections (residual connections) that allow gradients to flow directly through the network, enabling training of very deep architectures.
+
+## Chapter 4: Recurrent Neural Networks
+
+Recurrent neural networks are designed for sequential data such as text or time series. An RNN maintains a hidden state that is updated at each time step based on the current input and the previous hidden state. This allows the network to capture temporal dependencies.
+
+### The Vanishing Gradient Problem
+
+Standard RNNs struggle to capture long-range dependencies because gradients tend to either vanish or explode as they are backpropagated through many time steps. This is known as the vanishing gradient problem. The hidden state of an RNN at early time steps has diminishing influence on the gradients at later time steps.
+
+### LSTM and GRU
+
+Long Short-Term Memory networks introduce a gating mechanism with input, forget, and output gates that control the flow of information. The cell state in an LSTM acts as a memory that can be preserved across many time steps. Gated Recurrent Units are a simplified variant with only two gates: reset and update.
+
+## Chapter 5: Transformers and Attention
+
+### The Attention Mechanism
+
+The attention mechanism allows a model to focus on relevant parts of the input when producing each element of the output. In the context of sequence-to-sequence models, attention computes a weighted sum of encoder hidden states, where the weights are determined by a compatibility function between the decoder state and each encoder state.
+
+### Self-Attention
+
+Self-attention, also known as intra-attention, computes attention within a single sequence. Each position in the sequence attends to all other positions. The Transformer architecture is built entirely on self-attention, without recurrence or convolution.
+
+### Multi-Head Attention
+
+Multi-head attention runs multiple attention operations in parallel, each with different learned projections. The outputs are concatenated and linearly transformed. This allows the model to attend to information from different representation subspaces at different positions.
+
+### Transformer Architecture
+
+The Transformer consists of an encoder and a decoder, each composed of a stack of identical layers. Each layer has two sub-layers: a multi-head self-attention mechanism and a position-wise feedforward network. Residual connections and layer normalization are applied around each sub-layer. Positional encodings are added to the input embeddings to provide information about the position of each token in the sequence.

--- a/eval_corpus/eval_set_tuning.yaml
+++ b/eval_corpus/eval_set_tuning.yaml
@@ -1,0 +1,256 @@
+queries:
+  # ── DDIA Excerpts (book) ──────────────────────────────────────────────
+  - query: What is leader-based replication in distributed databases?
+    stratum: concept_lookup
+    expected_signature: leader-based replication
+    source_document: eval_corpus/books/ddia-excerpts.md
+
+  - query: What does the ACID acronym stand for in database transactions?
+    stratum: concept_lookup
+    expected_signature: Atomicity, Consistency, Isolation, and Durability
+    source_document: eval_corpus/books/ddia-excerpts.md
+
+  - query: What is the name of the programming model for distributed large-scale data processing described in the chapter?
+    stratum: exact_match
+    expected_signature: MapReduce
+    source_document: eval_corpus/books/ddia-excerpts.md
+
+  - query: What formula computes the combined score in Reciprocal Rank Fusion for hybrid search?
+    stratum: exact_match
+    expected_signature: RRF_score
+    source_document: eval_corpus/synthetic/rag-system-reference.md
+
+  - query: Why can synchronous replication block a write from completing?
+    stratum: context_dependent
+    expected_signature: if the synchronous follower doesn't respond, the write cannot be processed
+    source_document: eval_corpus/books/ddia-excerpts.md
+
+  - query: What is the advantage of hash-based partitioning over range-based partitioning for distributing keys?
+    stratum: context_dependent
+    expected_signature: distributing keys quite evenly across partitions
+    source_document: eval_corpus/books/ddia-excerpts.md
+
+  - query: Compare how batch processing with MapReduce handles data differently from stream processing with event logs?
+    stratum: multi_hop
+    expected_signature: streams are unbounded
+    source_document: eval_corpus/books/ddia-excerpts.md
+
+  - query: How does the choice of isolation level in transactions affect the trade-off between consistency guarantees and system performance?
+    stratum: multi_hop
+    expected_signature: Serializable isolation is the strongest level
+    source_document: eval_corpus/books/ddia-excerpts.md
+
+  # ── Deep Learning Concepts (book) ─────────────────────────────────────
+  - query: What is backpropagation and how does it compute gradients?
+    stratum: concept_lookup
+    expected_signature: applying the chain rule from calculus to propagate error signals backward
+    source_document: eval_corpus/books/deep-learning-concepts.md
+
+  - query: What is the ReLU activation function in neural networks?
+    stratum: concept_lookup
+    expected_signature: f(x) = max(0, x)
+    source_document: eval_corpus/books/deep-learning-concepts.md
+
+  - query: What is dropout regularization and how does it prevent overfitting?
+    stratum: concept_lookup
+    expected_signature: randomly selected neurons are omitted during training
+    source_document: eval_corpus/books/deep-learning-concepts.md
+
+  - query: What loss function is the standard choice for classification tasks?
+    stratum: exact_match
+    expected_signature: cross-entropy loss
+    source_document: eval_corpus/books/deep-learning-concepts.md
+
+  - query: What does the acronym LSTM stand for in recurrent neural network architectures?
+    stratum: exact_match
+    expected_signature: Long Short-Term Memory
+    source_document: eval_corpus/books/deep-learning-concepts.md
+
+  - query: Why do standard RNNs struggle to learn long-range dependencies in sequential data?
+    stratum: context_dependent
+    expected_signature: gradients tend to either vanish or explode
+    source_document: eval_corpus/books/deep-learning-concepts.md
+
+  - query: How do residual connections in ResNet enable training of very deep neural networks?
+    stratum: context_dependent
+    expected_signature: skip connections (residual connections) that allow gradients to flow directly
+    source_document: eval_corpus/books/deep-learning-concepts.md
+
+  - query: Compare how CNNs use convolutions for spatial data with how Transformers use self-attention for sequences.
+    stratum: multi_hop
+    expected_signature: The Transformer architecture is built entirely on self-attention
+    source_document: eval_corpus/books/deep-learning-concepts.md
+
+  - query: How does multi-head attention allow Transformers to capture different types of relationships in the input?
+    stratum: multi_hop
+    expected_signature: attend to information from different representation subspaces at different positions
+    source_document: eval_corpus/books/deep-learning-concepts.md
+
+  # ── FlashAttention (paper) ────────────────────────────────────────────
+  - query: What is the main idea behind the FlashAttention algorithm?
+    stratum: concept_lookup
+    expected_signature: tile the attention computation
+    source_document: eval_corpus/papers/flash-attention.md
+
+  - query: What are the key components of the GPU memory hierarchy relevant to FlashAttention?
+    stratum: concept_lookup
+    expected_signature: HBM to fast SRAM
+    source_document: eval_corpus/papers/flash-attention.md
+
+  - query: What does HBM stand for in the context of GPU memory architecture?
+    stratum: exact_match
+    expected_signature: high-bandwidth memory
+    source_document: eval_corpus/papers/flash-attention.md
+
+  - query: What does SRAM stand for and what role does it play in the GPU memory hierarchy?
+    stratum: exact_match
+    expected_signature: shared memory
+    source_document: eval_corpus/papers/flash-attention.md
+
+  - query: Why does FlashAttention recompute the attention scores during the backward pass instead of storing them?
+    stratum: context_dependent
+    expected_signature: trades off additional FLOPs for reduced memory reads/writes
+    source_document: eval_corpus/papers/flash-attention.md
+
+  - query: How does Block-Sparse FlashAttention reduce computation for very long sequences?
+    stratum: context_dependent
+    expected_signature: block-sparse mask to skip computation and memory access for zero blocks
+    source_document: eval_corpus/papers/flash-attention.md
+
+  - query: How does the tiling strategy in FlashAttention exploit the GPU memory hierarchy to improve performance?
+    stratum: multi_hop
+    expected_signature: loading blocks of data from slow HBM to fast SRAM
+    source_document: eval_corpus/papers/flash-attention.md
+
+  - query: Compare how standard attention materializes the attention matrix versus how FlashAttention avoids doing so.
+    stratum: multi_hop
+    expected_signature: standard attention implementation materializes the N x N attention matrix
+    source_document: eval_corpus/papers/flash-attention.md
+
+  # ── vLLM PagedAttention (paper) ───────────────────────────────────────
+  - query: What is PagedAttention and how does it manage the KV cache?
+    stratum: concept_lookup
+    expected_signature: manages the KV cache in fixed-size blocks
+    source_document: eval_corpus/papers/vllm-paged-attention.md
+
+  - query: What is iteration-level scheduling in the vLLM serving system?
+    stratum: concept_lookup
+    expected_signature: decides which sequences to process at each iteration
+    source_document: eval_corpus/papers/vllm-paged-attention.md
+
+  - query: What mechanism in vLLM allows efficient memory sharing across sequences with common prefixes?
+    stratum: exact_match
+    expected_signature: copy-on-write
+    source_document: eval_corpus/papers/vllm-paged-attention.md
+
+  - query: What data structure maps logical KV cache blocks to physical memory locations in vLLM?
+    stratum: exact_match
+    expected_signature: block table
+    source_document: eval_corpus/papers/vllm-paged-attention.md
+
+  - query: How does PagedAttention eliminate internal memory fragmentation that affects standard KV cache management?
+    stratum: context_dependent
+    expected_signature: allocating blocks on demand, only when tokens are generated
+    source_document: eval_corpus/papers/vllm-paged-attention.md
+
+  - query: How does the memory-aware scheduler in vLLM prevent out-of-memory errors?
+    stratum: context_dependent
+    expected_signature: tracks available physical blocks and only admits sequences when sufficient physical blocks are available
+    source_document: eval_corpus/papers/vllm-paged-attention.md
+
+  - query: How does the block table abstraction in PagedAttention draw inspiration from operating system memory management?
+    stratum: multi_hop
+    expected_signature: analogous to how virtual memory pages map to physical memory frames
+    source_document: eval_corpus/papers/vllm-paged-attention.md
+
+  - query: Compare how PagedAttention enables memory sharing across sequences versus the standard approach to KV cache management.
+    stratum: multi_hop
+    expected_signature: memory sharing across sequences
+    source_document: eval_corpus/papers/vllm-paged-attention.md
+
+  # ── RAG System Reference (synthetic) ──────────────────────────────────
+  - query: What is hybrid search in retrieval-augmented generation?
+    stratum: concept_lookup
+    expected_signature: Hybrid search combines dense
+    source_document: eval_corpus/synthetic/rag-system-reference.md
+
+  - query: What is parent-child chunking and how does it improve retrieval?
+    stratum: concept_lookup
+    expected_signature: child chunks (~512 tokens) are embedded
+    source_document: eval_corpus/synthetic/rag-system-reference.md
+
+  - query: What does BM25 stand for and what type of retrieval does it represent?
+    stratum: exact_match
+    expected_signature: BM25
+    source_document: eval_corpus/synthetic/rag-system-reference.md
+
+  - query: What evaluation metric measures the proportion of relevant documents retrieved in the top-k results?
+    stratum: exact_match
+    expected_signature: Recall@k
+    source_document: eval_corpus/synthetic/rag-system-reference.md
+
+  - query: Why is a cross-encoder reranker preferred over simply using the top results from hybrid search?
+    stratum: context_dependent
+    expected_signature: cross-encoders process query-passage pairs jointly
+    source_document: eval_corpus/synthetic/rag-system-reference.md
+
+  - query: How do document-type chunkers exploit document structure differently from generic text splitters?
+    stratum: context_dependent
+    expected_signature: exploit document structure
+    source_document: eval_corpus/synthetic/rag-system-reference.md
+
+  - query: How does content-signature labeling make eval queries invariant to chunk boundary changes?
+    stratum: multi_hop
+    expected_signature: distinctive substring of their text
+    source_document: eval_corpus/synthetic/rag-system-reference.md
+
+  - query: How do the different strata in the eval query taxonomy target different failure modes in retrieval?
+    stratum: multi_hop
+    expected_signature: strata for systematic evaluation
+    source_document: eval_corpus/synthetic/rag-system-reference.md
+
+  - query: How do hybrid search and reranking work together to provide both recall and precision in a RAG pipeline?
+    stratum: multi_hop
+    expected_signature: top-K candidates from hybrid search (typically 20-50) are reranked
+    source_document: eval_corpus/synthetic/rag-system-reference.md
+
+  # ── SOLID Principles Reference (synthetic) ────────────────────────────
+  - query: What is the Single Responsibility Principle in object-oriented design?
+    stratum: concept_lookup
+    expected_signature: reason to change
+    source_document: eval_corpus/synthetic/solid-principles-reference.md
+
+  - query: What is the Dependency Inversion Principle and how does it affect module design?
+    stratum: concept_lookup
+    expected_signature: depend on abstractions
+    source_document: eval_corpus/synthetic/solid-principles-reference.md
+
+  - query: What does OCP stand for in the SOLID principles acronym?
+    stratum: exact_match
+    expected_signature: Open/Closed Principle
+    source_document: eval_corpus/synthetic/solid-principles-reference.md
+
+  - query: What does ISP stand for and what problem does it address?
+    stratum: exact_match
+    expected_signature: Interface Segregation Principle
+    source_document: eval_corpus/synthetic/solid-principles-reference.md
+
+  - query: How does the Open/Closed Principle apply when designing a Python monorepo with abstract base classes?
+    stratum: context_dependent
+    expected_signature: Define abstract interfaces in a shared package
+    source_document: eval_corpus/synthetic/solid-principles-reference.md
+
+  - query: What is a god class and why is it considered an anti-pattern under the Single Responsibility Principle?
+    stratum: context_dependent
+    expected_signature: knows too much or does too much
+    source_document: eval_corpus/synthetic/solid-principles-reference.md
+
+  - query: Compare how SRP and ISP both address class complexity, but at different levels of granularity?
+    stratum: multi_hop
+    expected_signature: should not be forced to depend on interfaces they do not use
+    source_document: eval_corpus/synthetic/solid-principles-reference.md
+
+  - query: How do the Open-Closed Principle and Dependency Inversion Principle together enable a pluggable architecture?
+    stratum: multi_hop
+    expected_signature: Dependencies should be injected via constructors
+    source_document: eval_corpus/synthetic/solid-principles-reference.md

--- a/eval_corpus/papers/flash-attention.md
+++ b/eval_corpus/papers/flash-attention.md
@@ -1,0 +1,49 @@
+# FlashAttention: Fast and Memory-Efficient Exact Attention with IO-Awareness
+
+## Abstract
+
+FlashAttention is an algorithm that computes exact attention with significantly reduced memory reads and writes. It makes attention faster and more memory-efficient by being aware of the GPU memory hierarchy. The key idea is to tile the attention computation, loading blocks of data from slow HBM to fast SRAM, computing attention over those blocks, and then writing the result back.
+
+## 1. Introduction
+
+The attention mechanism is a fundamental building block of Transformer models. However, the standard attention implementation materializes the N x N attention matrix in HBM (high-bandwidth memory), which has O(N^2) memory complexity. For long sequences, this becomes prohibitive. FlashAttention avoids materializing the full attention matrix by using tiling and recomputation.
+
+## 2. Background: GPU Memory Hierarchy
+
+Modern GPUs have multiple levels of memory. The largest is HBM (high-bandwidth memory, typically 16-80 GB) which has relatively low bandwidth compared to on-chip SRAM. On-chip SRAM (shared memory, typically 192 KB per block on A100) has high bandwidth but very limited capacity. The key to performance is minimizing HBM accesses by maximizing the use of SRAM.
+
+### Memory Hierarchy Details
+
+The A100 GPU has the following memory hierarchy:
+- HBM: 40-80 GB, ~1.5-2.0 TB/s bandwidth
+- L2 cache: 40 MB
+- SRAM/shared memory: 192 KB per streaming multiprocessor (SM), ~19 TB/s aggregate bandwidth
+
+## 3. FlashAttention Algorithm
+
+### Tiling Strategy
+
+FlashAttention tiles the Q, K, and V matrices into blocks that fit in on-chip SRAM. For each block, the algorithm:
+1. Loads blocks of Q, K from HBM to SRAM
+2. Computes the partial attention scores S = Q * K^T
+3. Applies the softmax operation
+4. Computes the weighted sum with V
+5. Writes the result back to HBM
+
+The tiling is done separately along the query dimension and the key dimension. This ensures that the intermediate N x N attention matrix is never fully materialized in HBM.
+
+### Recomputation
+
+To avoid storing the large attention matrix for the backward pass, FlashAttention recomputes the attention scores during the backward pass using the blocks of Q, K, and V stored in HBM. This recomputation trades off additional FLOPs for reduced memory reads/writes, which is beneficial because SRAM-based computation is much faster than HBM bandwidth.
+
+## 4. Results
+
+FlashAttention achieves up to 2x speedup over the standard PyTorch implementation for BERT-base training. For long sequences, the speedup can be even more dramatic. Memory savings scale linearly with sequence length compared to the quadratic memory of standard attention.
+
+## 5. Block-Sparse FlashAttention
+
+For very long sequences, even FlashAttention's tiled approach can be improved by exploiting sparsity. Block-Sparse FlashAttention extends FlashAttention to handle attention matrices where many blocks are known to be zero (for example, due to local or dilated attention patterns). It uses a block-sparse mask to skip computation and memory access for zero blocks.
+
+### Block-Sparsity Mask
+
+The block-sparsity mask is a binary matrix where each entry indicates whether the corresponding block of the attention matrix should be computed. This mask is typically derived from the attention pattern (e.g., local windows, dilated patterns, or learned sparsity). The mask operates on the block level, not on individual elements, to maintain the efficiency of the tiled approach.

--- a/eval_corpus/papers/vllm-paged-attention.md
+++ b/eval_corpus/papers/vllm-paged-attention.md
@@ -1,0 +1,55 @@
+# vLLM: Efficient LLM Serving with PagedAttention
+
+## Abstract
+
+vLLM is a high-throughput LLM serving system that introduces PagedAttention, a novel attention algorithm inspired by virtual memory and paging in operating systems. PagedAttention manages the KV cache in fixed-size blocks (pages), enabling efficient memory sharing and reducing memory waste from fragmentation.
+
+## 1. Introduction
+
+Serving large language models is memory-bound because the KV cache grows with both batch size and sequence length. The standard approach to KV cache management suffers from memory fragmentation and can only accommodate limited memory sharing across sequences. PagedAttention addresses both problems by managing the KV cache as a paged system.
+
+## 2. PagedAttention
+
+### Block-Based KV Cache
+
+In PagedAttention, the KV cache for each sequence is divided into blocks of fixed size (e.g., 16 tokens per block). Each block maps to a physical block in the global block table. This is analogous to how virtual memory pages map to physical memory frames. The block table maintains the mapping from logical blocks to physical blocks.
+
+### Key Operations
+
+PagedAttention operates on blocks rather than individual tokens. When computing attention, the system looks up the physical blocks for the required KV cache entries using the block table. This block-level operation allows efficient memory management because the system allocates memory at block granularity.
+
+## 3. Memory Management
+
+### Fragmentation Elimination
+
+Standard KV cache pre-allocates contiguous memory for the maximum sequence length, leading to internal fragmentation when sequences are shorter than the maximum. PagedAttention eliminates this by allocating blocks on demand, only when tokens are generated. External fragmentation is handled by the block-level allocation.
+
+### Memory Sharing
+
+PagedAttention enables efficient memory sharing across sequences. When multiple sequences share the same prefix (as in beam search or parallel sampling), their initial KV cache blocks can be shared rather than duplicated. The block table supports copy-on-write, where shared blocks are marked as read-only until a sequence writes new KV entries, at which point a new physical block is allocated.
+
+### Copy-on-Write Mechanism
+
+The copy-on-write mechanism works as follows: when a block is shared across multiple sequences, it is designated as read-only. When a sequence needs to write to a shared block, the system allocates a new physical block, copies the old data, and updates the sequence's block table entry. The old block remains available for other sequences.
+
+## 4. Scheduling
+
+### Iteration-Level Scheduling
+
+vLLM uses iteration-level scheduling, where the scheduler decides which sequences to process at each iteration. This is different from request-level scheduling used in traditional systems. Iteration-level scheduling allows the system to dynamically adjust the batch composition based on current memory availability.
+
+### Memory-Aware Scheduling
+
+The scheduler tracks available physical blocks and only admits sequences when sufficient physical blocks are available. This prevents out-of-memory errors and allows the system to maximize throughput by filling available memory.
+
+## 5. System Architecture
+
+The vLLM system consists of a scheduler, a model executor, and a memory manager. The scheduler manages the iteration-level scheduling decisions. The model executor runs the actual model inference. The memory manager handles block allocation, deallocation, and copy-on-write operations.
+
+## 6. Evaluation
+
+vLLM achieves up to 2-4x higher throughput compared to FasterTransformer and Orca. The throughput gain comes primarily from the PagedAttention memory management, which reduces memory waste and enables larger batch sizes. The system also achieves near-linear scaling with the number of GPUs.
+
+## 7. Future Directions
+
+Future work includes extending PagedAttention to multi-GPU settings with distributed block tables, supporting more sophisticated eviction policies, and integrating with prefix caching systems.

--- a/eval_corpus/synthetic/rag-system-reference.md
+++ b/eval_corpus/synthetic/rag-system-reference.md
@@ -1,0 +1,79 @@
+# RAG System Reference Guide
+
+## Overview
+
+Retrieval-Augmented Generation (RAG) combines a retriever and a generator to produce grounded answers. The retriever fetches relevant passages from a knowledge corpus, and the generator produces an answer conditioned on those passages.
+
+## 1. Ingestion Pipeline
+
+### Chunking Strategies
+
+The ingestion pipeline converts source documents into retrievable chunks. Different document types require different chunking strategies.
+
+#### Recursive Character Splitter
+Splits text on separators in order of priority: paragraph breaks, sentence boundaries, word boundaries. This is the simplest strategy and works as a fallback for any text.
+
+#### Semantic Chunking
+Uses embedding similarity to detect natural topic boundaries. When the embedding distance between consecutive sentences exceeds a threshold, a new chunk is started. This preserves semantic coherence but is more expensive than recursive splitting.
+
+#### Document-Type Chunkers
+Structure-aware chunkers that exploit document structure:
+- Paper chunker: splits along IMRaD section boundaries (Introduction, Methods, Results, Discussion)
+- Book chunker: splits along chapter and heading boundaries
+- Documentation chunker: splits along heading hierarchy (h1-h3), preserves code blocks intact
+
+### Metadata
+
+Every chunk should carry metadata: source document ID, title, section heading, position, document type, and timestamp. Metadata enables filtering at retrieval time and helps the LLM cite sources correctly.
+
+## 2. Retrieval
+
+### Embedding-Based Retrieval
+
+Documents are encoded into dense vector embeddings using models like text-embedding-3-small or text-embedding-004. Queries are embedded using the same model. Retrieval finds the nearest neighbors in embedding space using cosine similarity.
+
+### Sparse Retrieval (BM25)
+
+BM25 is a bag-of-words retrieval method that scores documents based on term frequency and inverse document frequency. It excels at exact-match queries where the query contains rare or distinctive terms.
+
+### Hybrid Search
+
+Hybrid search combines dense (embedding) and sparse (BM25) retrieval via Reciprocal Rank Fusion (RRF). RRF combines the rank positions from each method:
+RRF_score(d) = 1/(k + rank_dense(d)) + 1/(k + rank_sparse(d))
+where k is a constant (typically 60). Hybrid search recovers exact-match queries that pure dense retrieval misses.
+
+### Reranking
+
+After initial retrieval, a cross-encoder reranker scores the candidate passages. Unlike bi-encoders (which produce independent embeddings), cross-encoders process query-passage pairs jointly, producing more accurate relevance scores. The top-K candidates from hybrid search (typically 20-50) are reranked, and the top 3-10 are kept for generation.
+
+### Parent-Child Retrieval
+
+In parent-child chunking, small child chunks (~512 tokens) are embedded and matched by the query. The parent chunk (the enclosing section) replaces the matched children before being handed to the LLM. This resolves the precision-vs-context tradeoff.
+
+## 3. Query Processing
+
+### Query Rewriting
+
+Ambiguous or conversational queries are rewritten into standalone, retrieval-friendly forms. This is particularly useful in multi-turn settings.
+
+### Query Decomposition
+
+Complex multi-hop questions are split into simpler sub-queries. Each sub-query is retrieved independently, and results are merged before generation. Decomposition should be gated — only triggered when the query is detected as multi-part.
+
+## 4. Evaluation
+
+### Retrieval Metrics
+
+Recall@k measures the proportion of relevant documents retrieved in the top-k results. Mean Reciprocal Rank (MRR) measures the average rank position of the first relevant document.
+
+### Eval Query Taxonomy
+
+Queries are categorized into four strata for systematic evaluation:
+- Concept lookup (dense-friendly): single-fact lookup
+- Exact match / keyword (sparse-friendly): API names, error codes, CLI flags
+- Context-dependent (parent-child matters): requires the enclosing section
+- Multi-hop / reasoning (decomposition prep): relates two or more concepts
+
+### Content-Signature Labeling
+
+Expected passages are identified by a distinctive substring of their text. This labeling is invariant to chunk boundaries, so the same labeled queries work across any chunk-size configuration without re-labeling.

--- a/eval_corpus/synthetic/solid-principles-reference.md
+++ b/eval_corpus/synthetic/solid-principles-reference.md
@@ -1,0 +1,80 @@
+# SOLID Principles Reference Guide
+
+## Introduction
+
+SOLID is a mnemonic acronym for five design principles intended to make software designs more understandable, flexible, and maintainable. These principles apply to object-oriented design at the class and module level.
+
+## 1. Single Responsibility Principle (SRP)
+
+A class should have one, and only one, reason to change. This means each class should have a single, well-defined responsibility. When a class has multiple responsibilities, changes to one responsibility may affect the other, making the system fragile.
+
+### Application in Python
+
+In a Python monorepo, SRP means:
+- Pydantic models handle validation only
+- Repositories handle data access only
+- Services handle business logic only
+- Route handlers handle HTTP contract only
+
+### Anti-Pattern: God Class
+
+A god class is a class that knows too much or does too much. For example, a UserManager class that validates data, creates database records, sends emails, and logs activity violates SRP. The symptom is a class with many unrelated methods and dependencies.
+
+## 2. Open/Closed Principle (OCP)
+
+Software entities should be open for extension but closed for modification. You should be able to add new functionality without changing existing code. In Python, this is achieved through abstract base classes (ABC), protocols, and dependency injection.
+
+### Implementation Strategy
+
+Define abstract interfaces in a shared package, and implement them in specific packages. Use a factory or registry pattern to select implementations at runtime. Adding a new implementation should not require changing existing code — only registering the new implementation.
+
+### Anti-Pattern: If/Else Chains
+
+Long if/elif/else chains that select behavior based on a type string violate OCP. Adding a new type requires modifying the chain. The fix is to replace the chain with a registry mapping types to implementations.
+
+## 3. Liskov Substitution Principle (LSP)
+
+Subtypes must be substitutable for their base types. If S is a subtype of T, then objects of type T may be replaced with objects of type S without altering the desirable properties of the program.
+
+### Contract Requirements
+
+Subtypes must:
+- Accept the same input types (or broader)
+- Return the same output types (or narrower)
+- Not strengthen preconditions
+- Not weaken postconditions
+- Not remove exceptions that callers expect
+
+### Testing LSP
+
+Substitution tests verify interchangeability. Create test cases that use the parent type and run them against all implementations. These tests catch contract violations early.
+
+## 4. Interface Segregation Principle (ISP)
+
+Clients should not be forced to depend on interfaces they do not use. Large, fat interfaces should be split into smaller, more specific ones. In Python, protocols are the natural tool for ISP.
+
+### Application
+
+Instead of one large Repository interface with CRUD + search + export methods, define separate Reader, Writer, and Deletable protocols. A read-only service only depends on Reader, not on the full Repository.
+
+## 5. Dependency Inversion Principle (DIP)
+
+High-level modules should not depend on low-level modules. Both should depend on abstractions. Abstractions should not depend on details; details should depend on abstractions.
+
+### Implementation
+
+Dependencies should be injected via constructors or function parameters rather than instantiated directly. In FastAPI, use Depends() for dependency injection. This makes the system testable because dependencies can be swapped with mocks.
+
+### Anti-Pattern: Concrete Instantiation
+
+Instantiating concrete classes inside business logic violates DIP. For example, creating a PostgresUserRepository() inside a service method couples the service to the database implementation. The fix is to accept the repository as a parameter or constructor argument.
+
+## Quick Reference Table
+
+| Principle | Goal | Red Flag | Python Pattern |
+|-----------|------|----------|----------------|
+| SRP | One reason to change | Class does 3+ jobs | Separate into service/repository/validator |
+| OCP | Extend without modifying | Adding if/else chains | Use ABC or Protocol for abstraction |
+| LSP | Substitutable types | Subclass breaks parent contract | Ensure type compatibility |
+| ISP | Focused contracts | Clients have unused methods | Split fat interfaces |
+| DIP | Depend on abstractions | Concrete instantiation in functions | Inject via Depends() or constructor |


### PR DESCRIPTION
Create eval_corpus/ at repo root with 6 source documents (2 books, 2 papers, 2 synthetic doc sets) and eval_set_tuning.yaml containing 50 stratified queries for chunk-size tuning evaluation.

Each query carries a stratum tag (concept_lookup | exact_match | context_dependent | multi_hop) and an expected_signature substring for boundary-invariant hit detection, per the Content-Signature Labeling strategy.

Closes #147