### PR TITLE
feat(scripts): add run_chunk_tuning.py tuning orchestrator

### DIFF
--- a/scripts/run_chunk_tuning.py
+++ b/scripts/run_chunk_tuning.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Top-level orchestrator for the chunk-size tuning harness.
+
+Checks sidecar availability, seeds each config, runs all eval queries,
+collects hit flags, computes fused metrics, determines the best config,
+and writes results.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from core.clients.embeddings_client import Embedder, EmbeddingsClient, InMemoryEmbedder
+from core.config.settings import Settings
+from core.database.connection import get_engine
+from core.types.responses import RetrievalResult
+from core.types.retrieval_config import RetrievalConfig
+from retrieval_qa.retrieval.query import retrieve_relevant_chunks
+from scripts.eval_metrics import MRRMetric, RecallAtKMetric, is_hit
+from scripts.seed_schema import CONFIG_NAMES, seed_schema, teardown_schema
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_TUNING_YAML = _REPO_ROOT / "eval_corpus" / "eval_set_tuning.yaml"
+_EVAL_CORPUS_DIR = _REPO_ROOT / "eval_corpus"
+
+DEFAULT_TOP_K = 10
+
+RETRIEVAL_MODES = ("dense", "sparse", "fused")
+
+
+@dataclass
+class QueryEval:
+    """Results of evaluating a single query for a single config."""
+
+    query: str
+    stratum: str
+    hits: dict[str, list[bool]]
+
+
+@dataclass
+class ConfigResult:
+    """Aggregated metrics for one chunk-size config."""
+
+    config_key: str
+    query_count: int
+    overall: dict[str, dict[str, float]]
+    per_stratum: dict[str, dict[str, dict[str, float]]]
+    per_query_hits: list[QueryEval] = field(repr=False)
+
+
+# ── Pure computation helpers (testable without I/O) ───────────────────────────
+
+
+def check_sidecars(corpus_dir: Path, config_names: frozenset[str]) -> list[str]:
+    """Check which sidecar files are missing.
+
+    Args:
+        corpus_dir: Directory containing sidecar JSON files.
+        config_names: Set of config keys to check (e.g. ``256_10``).
+
+    Returns:
+        A sorted list of missing config keys. Empty list means all present.
+    """
+    missing: list[str] = []
+    for c in sorted(config_names):
+        path = corpus_dir / f"eval_vectors_{c}.json"
+        if not path.exists():
+            missing.append(c)
+    return missing
+
+
+def score_retrieval_result(
+    result: RetrievalResult,
+    expected_signature: str,
+    top_k: int,
+) -> dict[str, list[bool]]:
+    """Score each retrieval mode against the expected signature.
+
+    The result is padded with ``False`` if a mode returns fewer than ``top_k``
+    results.
+
+    Args:
+        result: The retrieval result with dense, sparse, and fused paths.
+        expected_signature: Substring to search for in each chunk text.
+        top_k: Number of ranked results to consider.
+
+    Returns:
+        A dict mapping mode name to a list of bools (hit per rank).
+    """
+    hits: dict[str, list[bool]] = {}
+    for mode in RETRIEVAL_MODES:
+        chunks = getattr(result, mode)
+        mode_hits = [is_hit(c.text, expected_signature) for c in chunks[:top_k]]
+        while len(mode_hits) < top_k:
+            mode_hits.append(False)
+        hits[mode] = mode_hits
+    return hits
+
+
+def compute_config_metrics(
+    config_key: str,
+    query_evals: list[QueryEval],
+    top_k: int,
+) -> ConfigResult:
+    """Aggregate per-query results into per-config metrics.
+
+    For each retrieval mode computes mean recall@k and mean MRR across
+    all queries, with per-stratum breakdowns.
+
+    Args:
+        config_key: The chunk-size config key (e.g. ``256_10``).
+        query_evals: Per-query evaluation results.
+        top_k: The rank cutoff used during evaluation.
+
+    Returns:
+        A ``ConfigResult`` with overall and per-stratum metrics.
+    """
+    recall_metric = RecallAtKMetric(top_k)
+
+    strata: set[str] = {qe.stratum for qe in query_evals}
+    per_stratum_hits: dict[str, dict[str, list[list[bool]]]] = {
+        s: {m: [] for m in RETRIEVAL_MODES} for s in strata
+    }
+    all_hits: dict[str, list[list[bool]]] = {m: [] for m in RETRIEVAL_MODES}
+
+    for qe in query_evals:
+        for mode in RETRIEVAL_MODES:
+            all_hits[mode].append(qe.hits[mode])
+            per_stratum_hits[qe.stratum][mode].append(qe.hits[mode])
+
+    def _mean(values: list[float]) -> float:
+        return sum(values) / len(values) if values else 0.0
+
+    recall_key = f"recall@{top_k}"
+
+    overall: dict[str, dict[str, float]] = {}
+    for mode in RETRIEVAL_MODES:
+        mode_all_hits = all_hits[mode]
+        overall[mode] = {
+            recall_key: _mean([recall_metric.compute(h) for h in mode_all_hits]),
+            "mrr": _mean([MRRMetric.compute(h) for h in mode_all_hits]),
+        }
+
+    per_stratum_metrics: dict[str, dict[str, dict[str, float]]] = {}
+    for stratum in sorted(strata):
+        per_stratum_metrics[stratum] = {}
+        for mode in RETRIEVAL_MODES:
+            mode_hits = per_stratum_hits[stratum][mode]
+            if not mode_hits:
+                per_stratum_metrics[stratum][mode] = {recall_key: 0.0, "mrr": 0.0}
+            else:
+                per_stratum_metrics[stratum][mode] = {
+                    recall_key: _mean([recall_metric.compute(h) for h in mode_hits]),
+                    "mrr": _mean([MRRMetric.compute(h) for h in mode_hits]),
+                }
+
+    return ConfigResult(
+        config_key=config_key,
+        query_count=len(query_evals),
+        overall=overall,
+        per_stratum=per_stratum_metrics,
+        per_query_hits=query_evals,
+    )
+
+
+def determine_winner(
+    config_results: list[ConfigResult],
+    top_k: int,
+) -> tuple[str, str | None]:
+    """Determine the winning chunk-size config.
+
+    Primary: all configs within 0.02 of the highest fused recall@k are
+    candidates. Among those, the config with the highest fused MRR wins.
+    Runner-up is the second-best candidate by MRR (or ``None``).
+
+    Args:
+        config_results: List of aggregated results per config.
+        top_k: The rank cutoff used during evaluation.
+
+    Returns:
+        A tuple of ``(winner_config_key, runner_up_config_key_or_None)``.
+    """
+    if not config_results:
+        return ("", None)
+
+    recall_key = f"recall@{top_k}"
+
+    max_recall = max(cr.overall["fused"][recall_key] for cr in config_results)
+
+    candidates: list[tuple[str, float]] = [
+        (cr.config_key, cr.overall["fused"]["mrr"])
+        for cr in config_results
+        if max_recall - cr.overall["fused"][recall_key] <= 0.02
+    ]
+
+    candidates.sort(key=lambda x: -x[1])
+
+    winner_key = candidates[0][0]
+    runner_up: str | None = candidates[1][0] if len(candidates) > 1 else None
+
+    return (winner_key, runner_up)
+
+
+def format_results_table(
+    config_results: list[ConfigResult],
+    winner_key: str | None,
+    top_k: int,
+) -> str:
+    """Format the tuning results as a human-readable table.
+
+    Includes a config x retrieval-mode x metric matrix, per-stratum fused
+    recall@k breakdown, and winner recommendation.
+
+    Args:
+        config_results: List of aggregated results per config.
+        winner_key: The winning config key, or ``None``.
+        top_k: The rank cutoff used during evaluation.
+
+    Returns:
+        A formatted string suitable for stdout.
+    """
+    lines: list[str] = []
+    lines.append("Chunk-Size Tuning Results")
+    lines.append("=" * 60)
+    lines.append("")
+
+    mode_label = {"dense": "Dense", "sparse": "Sparse", "fused": "Fused"}
+    recall_key = f"recall@{top_k}"
+
+    header = f"{'Config':<12}"
+    for mode in RETRIEVAL_MODES:
+        header += f"  {mode_label[mode]:<14}"
+    header += f"  {'Winner':<8}"
+    lines.append(header)
+    lines.append("-" * len(header))
+
+    for cr in config_results:
+        row = f"{cr.config_key:<12}"
+        for mode in RETRIEVAL_MODES:
+            r = cr.overall[mode][recall_key]
+            m = cr.overall[mode]["mrr"]
+            row += f"  {r:.4f}/{m:.4f}  "
+        is_winner = "\u2713" if cr.config_key == winner_key else ""
+        row += f"  {is_winner:<8}"
+        lines.append(row)
+
+    lines.append("")
+    strata = sorted({s for cr in config_results for s in cr.per_stratum})
+    if strata:
+        lines.append("Per-Stratum Fused Recall@k")
+        lines.append("-" * 40)
+        lines.append("")
+
+        s_header = f"{'Config':<12}"
+        for s in strata:
+            s_header += f"  {s:<22}"
+        lines.append(s_header)
+        lines.append("-" * len(s_header))
+
+        for cr in config_results:
+            s_row = f"{cr.config_key:<12}"
+            for s in strata:
+                val = cr.per_stratum.get(s, {}).get("fused", {}).get(recall_key, 0.0)
+                s_row += f"  {val:.4f}            "
+            lines.append(s_row)
+
+    lines.append("")
+    if winner_key:
+        lines.append(f"Recommended config: {winner_key}")
+    else:
+        lines.append("No winner could be determined.")
+
+    return "\n".join(lines)
+
+
+def build_results_json(
+    config_results: list[ConfigResult],
+    winner_key: str | None,
+    top_k: int,
+) -> dict[str, Any]:
+    """Build the full results dict for JSON serialisation.
+
+    Args:
+        config_results: List of aggregated results per config.
+        winner_key: The winning config key, or ``None``.
+        top_k: The rank cutoff used during evaluation.
+
+    Returns:
+        A dict ready for ``json.dumps``.
+    """
+    return {
+        "top_k": top_k,
+        "winner": winner_key or "",
+        "configs": [
+            {
+                "config_key": cr.config_key,
+                "query_count": cr.query_count,
+                "overall": cr.overall,
+                "per_stratum": cr.per_stratum,
+            }
+            for cr in config_results
+        ],
+    }
+
+
+# ── Orchestration (I/O-bound, database-backed) ────────────────────────────────
+
+
+def run_tuning(args: argparse.Namespace) -> int:
+    """Full tuning harness: check, seed, evaluate, aggregate, report.
+
+    Args:
+        args: Parsed CLI arguments (``.in_memory``, ``.top_k``).
+
+    Returns:
+        Exit code (0 = success).
+    """
+    top_k = getattr(args, "top_k", DEFAULT_TOP_K)
+
+    # 1. Check sidecars
+    missing = check_sidecars(_EVAL_CORPUS_DIR, CONFIG_NAMES)
+    if missing:
+        print(
+            f"Error: missing sidecar files for config(s): {', '.join(missing)}. "
+            f"Run `uv run python scripts/generate_eval_vectors.py` first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # 2. Load eval set
+    if not _TUNING_YAML.exists():
+        print(f"Error: tuning eval set not found: {_TUNING_YAML}", file=sys.stderr)
+        return 1
+
+    with open(_TUNING_YAML) as f:
+        data = yaml.safe_load(f)
+    queries: list[dict[str, Any]] = data.get("queries", [])
+    if not queries:
+        print("Error: no queries found in tuning eval set.", file=sys.stderr)
+        return 1
+
+    # 3. Set up embedder and retrieval config
+    embedder: Embedder = (
+        InMemoryEmbedder() if getattr(args, "in_memory", False) else EmbeddingsClient()
+    )
+    settings = Settings()
+    retrieval_config = RetrievalConfig(
+        model_name=settings.embedding_model,
+        ef_search=settings.hnsw_ef_search,
+        top_k=top_k,
+        hybrid_search=True,
+        reranker=False,
+    )
+
+    from sqlalchemy.orm import Session, sessionmaker
+
+    engine = get_engine()
+    config_results: list[ConfigResult] = []
+
+    # 4. For each config, seed → evaluate → tear down
+    for config_key in sorted(CONFIG_NAMES):
+        print(f"\n--- Config: {config_key} ---")
+
+        exit_code = seed_schema(config_key, engine=engine)
+        if exit_code != 0:
+            print(f"Error: failed to seed schema for {config_key}", file=sys.stderr)
+            return exit_code
+
+        schema_name = f"chunks_{config_key}"
+        engine_with_schema = engine.execution_options(schema_translate_map={None: schema_name})
+        SessionClass = sessionmaker(bind=engine_with_schema)
+
+        query_evals: list[QueryEval] = []
+
+        for i, q in enumerate(queries):
+            query_text: str = q["query"]
+            expected_signature: str = q["expected_signature"]
+            stratum: str = q["stratum"]
+
+            query_vectors = embedder.embed([query_text])
+            query_vector = query_vectors[0]
+
+            session: Session = SessionClass()
+            try:
+                result = retrieve_relevant_chunks(
+                    query_vector=query_vector,
+                    session=session,
+                    config=retrieval_config,
+                    query_text=query_text,
+                )
+            finally:
+                session.close()
+
+            hits = score_retrieval_result(result, expected_signature, top_k)
+            query_evals.append(QueryEval(query=query_text, stratum=stratum, hits=hits))
+
+            if (i + 1) % 10 == 0:
+                print(f"  evaluated {i + 1}/{len(queries)} queries")
+
+        config_result = compute_config_metrics(config_key, query_evals, top_k)
+        config_results.append(config_result)
+        print(f"  done — recall@{top_k}={config_result.overall['fused'][f'recall@{top_k}']:.4f}")
+
+        teardown_schema(config_key, engine=engine)
+
+    # 5. Determine winner
+    winner_key, runner_up = determine_winner(config_results, top_k)
+    if runner_up:
+        print(f"\nRunner-up: {runner_up}")
+
+    # 6. Output
+    report = format_results_table(config_results, winner_key, top_k)
+    print("\n" + report)
+
+    json_path = _REPO_ROOT / "tuning_results.json"
+    json_data = build_results_json(config_results, winner_key, top_k)
+    json_path.write_text(json.dumps(json_data, indent=2))
+    print(f"\nWrote full results to {json_path}")
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Args:
+        argv: Argument list (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        Exit code (0 = success).
+    """
+    parser = argparse.ArgumentParser(
+        description="Run the chunk-size tuning harness end to end.",
+    )
+    parser.add_argument(
+        "--in-memory",
+        action="store_true",
+        help="Use InMemoryEmbedder instead of the real API (for testing).",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=DEFAULT_TOP_K,
+        help=f"Number of results to consider per query (default: {DEFAULT_TOP_K}).",
+    )
+    args = parser.parse_args(argv)
+    return run_tuning(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_run_chunk_tuning.py
+++ b/scripts/tests/test_run_chunk_tuning.py
@@ -1,0 +1,411 @@
+"""Tests for scripts/run_chunk_tuning.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from core.types.responses import RetrievalResult, ScoredChunk
+from scripts.run_chunk_tuning import (
+    RETRIEVAL_MODES,
+    ConfigResult,
+    QueryEval,
+    build_results_json,
+    check_sidecars,
+    compute_config_metrics,
+    determine_winner,
+    format_results_table,
+    score_retrieval_result,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_chunk(text: str, score: float = 1.0, chunk_id: UUID | None = None) -> ScoredChunk:
+    return ScoredChunk(
+        chunk_id=chunk_id or uuid4(),
+        text=text,
+        score=score,
+    )
+
+
+def _make_retrieval_result(
+    dense_texts: list[str] | None = None,
+    sparse_texts: list[str] | None = None,
+    fused_texts: list[str] | None = None,
+) -> RetrievalResult:
+    return RetrievalResult(
+        dense=[_make_chunk(t) for t in (dense_texts or [])],
+        sparse=[_make_chunk(t) for t in (sparse_texts or [])],
+        fused=[_make_chunk(t) for t in (fused_texts or [])],
+    )
+
+
+# ── check_sidecars ───────────────────────────────────────────────────────────
+
+
+class TestCheckSidecars:
+    def test_all_present(self, tmp_path: Path) -> None:
+        for name in ("256_10", "512_15", "1024_20"):
+            (tmp_path / f"eval_vectors_{name}.json").write_text("{}")
+        missing = check_sidecars(tmp_path, frozenset({"256_10", "512_15", "1024_20"}))
+        assert missing == []
+
+    def test_one_missing(self, tmp_path: Path) -> None:
+        (tmp_path / "eval_vectors_256_10.json").write_text("{}")
+        (tmp_path / "eval_vectors_1024_20.json").write_text("{}")
+        missing = check_sidecars(tmp_path, frozenset({"256_10", "512_15", "1024_20"}))
+        assert missing == ["512_15"]
+
+    def test_all_missing(self, tmp_path: Path) -> None:
+        missing = check_sidecars(tmp_path, frozenset({"256_10", "512_15", "1024_20"}))
+        assert sorted(missing) == ["1024_20", "256_10", "512_15"]
+
+    def test_empty_config_set(self, tmp_path: Path) -> None:
+        missing = check_sidecars(tmp_path, frozenset())
+        assert missing == []
+
+
+# ── score_retrieval_result ────────────────────────────────────────────────────
+
+
+class TestScoreRetrievalResult:
+    def test_all_modes_scored(self) -> None:
+        result = _make_retrieval_result(
+            dense_texts=["alpha", "beta", "gamma"],
+            sparse_texts=["delta", "epsilon"],
+            fused_texts=["zeta", "eta", "theta", "iota"],
+        )
+        hits = score_retrieval_result(result, "eta", top_k=3)
+        assert set(hits.keys()) == {"dense", "sparse", "fused"}
+        assert len(hits["dense"]) == 3
+        assert len(hits["sparse"]) == 3
+        assert len(hits["fused"]) == 3
+
+    def test_hit_in_fused(self) -> None:
+        result = _make_retrieval_result(
+            dense_texts=["not relevant"],
+            sparse_texts=["also not"],
+            fused_texts=["miss", "eta is here", "also miss"],
+        )
+        hits = score_retrieval_result(result, "eta is here", top_k=3)
+        assert hits["fused"] == [False, True, False]
+        assert hits["dense"] == [False, False, False]
+        assert hits["sparse"] == [False, False, False]
+
+    def test_hit_in_dense(self) -> None:
+        result = _make_retrieval_result(
+            dense_texts=["target text", "other"],
+            sparse_texts=["wrong"],
+            fused_texts=["wrong"],
+        )
+        hits = score_retrieval_result(result, "target text", top_k=2)
+        assert hits["dense"] == [True, False]
+
+    def test_hit_in_sparse(self) -> None:
+        result = _make_retrieval_result(
+            dense_texts=["x"],
+            sparse_texts=["found it here"],
+            fused_texts=["y"],
+        )
+        hits = score_retrieval_result(result, "found it here", top_k=2)
+        assert hits["sparse"] == [True, False]
+
+    def test_partial_hits(self) -> None:
+        result = _make_retrieval_result(
+            dense_texts=["a", "b", "c", "d", "e"],
+            sparse_texts=[],
+            fused_texts=["a", "b", "c", "d", "e"],
+        )
+        hits = score_retrieval_result(result, "c", top_k=5)
+        assert hits["dense"] == [False, False, True, False, False]
+
+    def test_empty_results(self) -> None:
+        result = _make_retrieval_result()
+        hits = score_retrieval_result(result, "anything", top_k=3)
+        assert hits["dense"] == [False, False, False]
+        assert hits["sparse"] == [False, False, False]
+        assert hits["fused"] == [False, False, False]
+
+    def test_fewer_results_than_top_k_padded_with_false(self) -> None:
+        result = _make_retrieval_result(
+            dense_texts=["hit"],
+            fused_texts=["hit"],
+        )
+        hits = score_retrieval_result(result, "hit", top_k=5)
+        assert hits["dense"] == [True, False, False, False, False]
+        assert hits["fused"] == [True, False, False, False, False]
+
+
+# ── compute_config_metrics ────────────────────────────────────────────────────
+
+
+def _qe(
+    query: str = "q",
+    stratum: str = "concept_lookup",
+    hits: dict[str, list[bool]] | None = None,
+) -> QueryEval:
+    return QueryEval(query=query, stratum=stratum, hits=hits or {})
+
+
+class TestComputeConfigMetrics:
+    def test_single_query_all_hits(self) -> None:
+        evals = [
+            _qe(hits={"dense": [True, True], "sparse": [True, False], "fused": [True, True]}),
+        ]
+        result = compute_config_metrics("256_10", evals, top_k=2)
+        assert result.config_key == "256_10"
+        assert result.query_count == 1
+        assert result.overall["dense"]["recall@2"] == 1.0
+        assert result.overall["dense"]["mrr"] == 1.0
+        assert result.overall["fused"]["recall@2"] == 1.0
+        assert result.overall["sparse"]["recall@2"] == 0.5
+
+    def test_single_query_no_hits(self) -> None:
+        evals = [
+            _qe(hits={"dense": [False, False], "sparse": [False, False], "fused": [False, False]}),
+        ]
+        result = compute_config_metrics("512_15", evals, top_k=2)
+        assert result.overall["fused"]["recall@2"] == 0.0
+        assert result.overall["fused"]["mrr"] == 0.0
+
+    def test_multiple_queries_averages(self) -> None:
+        evals = [
+            _qe(hits={"dense": [True, True], "sparse": [True, True], "fused": [True, True]}),
+            _qe(hits={"dense": [False, False], "sparse": [False, False], "fused": [False, False]}),
+        ]
+        result = compute_config_metrics("1024_20", evals, top_k=2)
+        assert result.overall["fused"]["recall@2"] == 0.5
+        assert result.overall["dense"]["recall@2"] == 0.5
+        assert result.overall["sparse"]["recall@2"] == 0.5
+
+    def test_mrr_first_hit_early_ranks_higher(self) -> None:
+        mrr1 = 1.0 / 1  # first hit at rank 1
+        mrr2 = 1.0 / 3  # first hit at rank 3
+        misses = [False, False, False]
+        evals = [
+            _qe(hits={"dense": misses, "sparse": misses, "fused": [True, False, False]}),
+            _qe(hits={"dense": misses, "sparse": misses, "fused": [False, False, True]}),
+        ]
+        result = compute_config_metrics("256_10", evals, top_k=3)
+        expected_mrr = (mrr1 + mrr2) / 2
+        assert result.overall["fused"]["mrr"] == pytest.approx(expected_mrr)
+
+    def test_per_stratum_breakdown(self) -> None:
+        misses = [False, False]
+        evals = [
+            _qe(
+                stratum="concept_lookup",
+                hits={"dense": misses, "sparse": misses, "fused": [True, False]},
+            ),
+            _qe(
+                stratum="concept_lookup",
+                hits={"dense": misses, "sparse": misses, "fused": [True, True]},
+            ),
+            _qe(
+                stratum="exact_match",
+                hits={"dense": misses, "sparse": misses, "fused": [False, False]},
+            ),
+        ]
+        result = compute_config_metrics("256_10", evals, top_k=2)
+        assert result.per_stratum["concept_lookup"]["fused"]["recall@2"] == 0.75
+        assert result.per_stratum["exact_match"]["fused"]["recall@2"] == 0.0
+        assert len(result.per_stratum) == 2
+
+    def test_stratum_all_modes_present(self) -> None:
+        evals = [
+            _qe(
+                stratum="multi_hop",
+                hits={
+                    "dense": [True, False],
+                    "sparse": [False, False],
+                    "fused": [True, False],
+                },
+            ),
+        ]
+        result = compute_config_metrics("256_10", evals, top_k=2)
+        for mode in RETRIEVAL_MODES:
+            assert mode in result.per_stratum["multi_hop"]
+
+    def test_empty_query_list(self) -> None:
+        result = compute_config_metrics("256_10", [], top_k=2)
+        assert result.query_count == 0
+        for mode in RETRIEVAL_MODES:
+            assert result.overall[mode]["recall@2"] == 0.0
+            assert result.overall[mode]["mrr"] == 0.0
+        assert result.per_stratum == {}
+
+
+# ── determine_winner ─────────────────────────────────────────────────────────
+
+
+def _config_result(
+    key: str,
+    fused_recall: float,
+    fused_mrr: float = 0.0,
+) -> ConfigResult:
+    recall_key = "recall@10"
+    overall: dict[str, dict[str, float]] = {
+        mode: {recall_key: 0.0, "mrr": 0.0} for mode in RETRIEVAL_MODES
+    }
+    overall["fused"][recall_key] = fused_recall
+    overall["fused"]["mrr"] = fused_mrr
+    return ConfigResult(
+        config_key=key,
+        query_count=1,
+        overall=overall,
+        per_stratum={},
+        per_query_hits=[],
+    )
+
+
+class TestDetermineWinner:
+    def test_clear_winner(self) -> None:
+        results = [
+            _config_result("256_10", fused_recall=0.80),
+            _config_result("512_15", fused_recall=0.92),
+            _config_result("1024_20", fused_recall=0.88),
+        ]
+        winner, runner_up = determine_winner(results, top_k=10)
+        assert winner == "512_15"
+        # 0.92 - 0.88 = 0.04 > 0.02, so no runner-up
+        assert runner_up is None
+
+    def test_tie_break_by_mrr(self) -> None:
+        """When configs are within 0.02 of max recall, MRR decides."""
+        results = [
+            _config_result("256_10", fused_recall=0.90, fused_mrr=0.70),
+            _config_result("512_15", fused_recall=0.91, fused_mrr=0.85),
+            _config_result("1024_20", fused_recall=0.90, fused_mrr=0.80),
+        ]
+        winner, runner_up = determine_winner(results, top_k=10)
+        assert winner == "512_15"
+        # All three are within 0.02 of max (0.91). MRR ranking: 512_15 > 1024_20 > 256_10
+        assert runner_up == "1024_20"
+
+    def test_within_threshold_tie_break(self) -> None:
+        """Both configs within 0.02 of max recall; higher MRR wins."""
+        results = [
+            _config_result("256_10", fused_recall=0.90, fused_mrr=0.70),
+            _config_result("512_15", fused_recall=0.89, fused_mrr=0.95),
+        ]
+        winner, runner_up = determine_winner(results, top_k=10)
+        # Max recall=0.90. Both within 0.02. 512_15 has higher MRR.
+        assert winner == "512_15"
+        assert runner_up == "256_10"
+
+    def test_outside_threshold_no_runner_up(self) -> None:
+        results = [
+            _config_result("256_10", fused_recall=0.95, fused_mrr=0.70),
+            _config_result("512_15", fused_recall=0.80, fused_mrr=0.95),
+        ]
+        winner, runner_up = determine_winner(results, top_k=10)
+        assert winner == "256_10"
+        assert runner_up is None
+
+    def test_tie_winner_top_recall(self) -> None:
+        results = [
+            _config_result("256_10", fused_recall=0.88),
+            _config_result("512_15", fused_recall=0.88, fused_mrr=0.9),
+            _config_result("1024_20", fused_recall=0.88, fused_mrr=0.8),
+        ]
+        winner, runner_up = determine_winner(results, top_k=10)
+        assert winner == "512_15"  # highest MRR among ties
+        assert runner_up == "1024_20"
+
+    def test_single_config(self) -> None:
+        results = [_config_result("256_10", fused_recall=0.75)]
+        winner, runner_up = determine_winner(results, top_k=10)
+        assert winner == "256_10"
+        assert runner_up is None
+
+    def test_empty_results(self) -> None:
+        winner, runner_up = determine_winner([], top_k=10)
+        assert winner == ""
+        assert runner_up is None
+
+
+# ── format_results_table ──────────────────────────────────────────────────────
+
+
+class TestFormatResultsTable:
+    def test_output_contains_all_configs(self) -> None:
+        results = [
+            _config_result("256_10", fused_recall=0.80, fused_mrr=0.70),
+            _config_result("512_15", fused_recall=0.90, fused_mrr=0.85),
+        ]
+        output = format_results_table(results, "512_15", top_k=10)
+        assert "256_10" in output
+        assert "512_15" in output
+        assert "Chunk-Size Tuning Results" in output
+
+    def test_winner_marked(self) -> None:
+        results = [
+            _config_result("256_10", fused_recall=0.80),
+            _config_result("512_15", fused_recall=0.90),
+        ]
+        output = format_results_table(results, "512_15", top_k=10)
+        lines = output.split("\n")
+        # Find the line with 512_15 and check it has the checkmark
+        for line in lines:
+            if line.strip().startswith("512_15"):
+                assert "✓" in line
+
+    def test_no_winner_shows_message(self) -> None:
+        results = [
+            _config_result("256_10", fused_recall=0.80),
+        ]
+        output = format_results_table(results, None, top_k=10)
+        assert "No winner could be determined" in output
+
+    def test_per_stratum_section_present(self) -> None:
+        recall_key = "recall@10"
+        overall: dict[str, dict[str, float]] = {
+            m: {recall_key: 0.0, "mrr": 0.0} for m in RETRIEVAL_MODES
+        }
+        result = ConfigResult(
+            config_key="256_10",
+            query_count=1,
+            overall=overall,
+            per_stratum={
+                "concept_lookup": {"fused": {recall_key: 0.5, "mrr": 0.3}},
+                "exact_match": {"fused": {recall_key: 0.7, "mrr": 0.4}},
+            },
+            per_query_hits=[],
+        )
+        output = format_results_table([result], "256_10", top_k=10)
+        assert "Per-Stratum Fused" in output
+        assert "concept_lookup" in output
+        assert "exact_match" in output
+
+
+# ── build_results_json ────────────────────────────────────────────────────────
+
+
+class TestBuildResultsJson:
+    def test_structure(self) -> None:
+        results = [
+            _config_result("256_10", fused_recall=0.80, fused_mrr=0.70),
+            _config_result("512_15", fused_recall=0.90, fused_mrr=0.85),
+        ]
+        data = build_results_json(results, "512_15", top_k=10)
+        assert data["top_k"] == 10
+        assert data["winner"] == "512_15"
+        assert len(data["configs"]) == 2
+        assert data["configs"][0]["config_key"] == "256_10"
+        assert data["configs"][1]["config_key"] == "512_15"
+
+    def test_empty_winner(self) -> None:
+        data = build_results_json([], None, top_k=5)
+        assert data["winner"] == ""
+        assert data["configs"] == []
+
+    def test_serializable(self) -> None:
+        results = [
+            _config_result("256_10", fused_recall=0.80, fused_mrr=0.70),
+        ]
+        data = build_results_json(results, "256_10", top_k=10)
+        json.dumps(data)  # should not raise


### PR DESCRIPTION
Implements the chunk-size tuning harness: checks sidecar availability, seeds each config via seed_schema, runs all 50 eval queries through retrieve_relevant_chunks, computes fused recall@10 and MRR (overall + per-stratum), determines winner by highest fused recall@10 with MRR tie-break within 0.02, and outputs a tabular report + tuning_results.json.

Closes #152