### PR TITLE
fix(retrieval-qa): populate content_search so sparse query uses GIN i…

### DIFF
--- a/docs/adr/0016-retrieval-qa-critical-gaps-parent-child-hybrid-rerank.md
+++ b/docs/adr/0016-retrieval-qa-critical-gaps-parent-child-hybrid-rerank.md
@@ -24,6 +24,8 @@ Rationale for fixed-size (not semantic) splitting: the reference notes that some
 ### 2. Hybrid search (dense + sparse)
 Add a PostgreSQL `tsvector` column and GIN index on child chunk content. At query time, run both a pgvector cosine search (unchanged) and a `ts_rank` full-text search against the same child chunk rows. Fuse results via Reciprocal Rank Fusion (RRF). Retrieve top-20 from each path, fuse into a single ranked set, then swap to parents.
 
+`content_search` is populated **application-side** during ingestion (the child-write phase of `ingestion/pipeline.py` and the eval seed in `scripts/seed_schema.py`) — not via a Postgres trigger. This keeps the population path explicit and adjacent to the child-row writes it mirrors (ADR-0003's transparency principle), and it only ever fires for children, matching "only child chunks are indexed." The sparse query reads the `content_search` column so the GIN index (`ix_chunks_content_search_gin`) is exercised. A trigger is rejected as a future option to reconsider only if application-layer writes prove unreliable in practice.
+
 Rationale for tsvector over pg_bm25/pg_textsearch: zero new infrastructure. The existing `pgvector/pgvector:pg16` Docker image works unchanged. No custom Docker image, no C extension build, no CI pipeline changes. Postgres FTS (`ts_rank`) is sufficient for MVP-level exact-match recovery; BM25-level scoring is a quantitative improvement that can be swapped in later if the eval set shows it matters.
 
 ### 3. Cross-encoder reranking

--- a/ingestion/src/ingestion/pipeline.py
+++ b/ingestion/src/ingestion/pipeline.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from pydantic import ValidationError
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from core.clients import Embedder
@@ -158,7 +159,10 @@ def run_ingestion(
        overlap) via ``recursive_fixed_size_split``.
     4. Child chunks inherit ``type_metadata`` from the parent with an
        additional ``"child_of"`` lineage key.
-    5. Only child chunks are embedded and indexed for retrieval.
+    5. Only child chunks are embedded and indexed for retrieval: each child
+       row's ``content_search`` tsvector is populated application-side, and
+       only children receive embeddings. Parent rows keep ``content_search``
+       NULL (ADR-0016).
 
     Args:
         pending: Document-identity fields for the ingestion.
@@ -201,13 +205,18 @@ def run_ingestion(
             for child_split in child_splits:
                 child_metadata = dict(parent.type_metadata)
                 child_metadata["child_of"] = str(parent.chunk_id)
+                child_content = _sanitize_text(child_split.content)
                 child = ChunkRow(
                     document_id=pending.document_id,
                     position=child_split.position,
-                    content=_sanitize_text(child_split.content),
+                    content=child_content,
                     token_count=child_split.token_count,
                     type_metadata=child_metadata,
                     parent_chunk_id=parent.chunk_id,
+                    # Only children are sparse-indexed (ADR-0016); the
+                    # tsvector feeds the GIN index that the sparse query
+                    # reads (parents stay NULL/unindexed).
+                    content_search=func.to_tsvector("english", child_content),
                 )
                 session.add(child)
                 child_rows.append(child)

--- a/ingestion/tests/ingestion/test_pipeline.py
+++ b/ingestion/tests/ingestion/test_pipeline.py
@@ -484,6 +484,59 @@ class TestPipelineValidation:
 class TestParentChildIngestion:
     """Tests for parent-child chunking in the ingestion pipeline."""
 
+    def test_children_have_content_search_parents_do_not(
+        self,
+        test_session: Session,
+        fake_embeddings_client: MagicMock,
+        sample_paper_pdf: bytes,
+        temp_file: Callable[..., Path],
+    ) -> None:
+        """Child rows get a populated content_search tsvector; parents stay NULL.
+
+        Per ADR-0016 only children are indexed (sparse tsvector), so the
+        ``content_search`` column carries a non-null tsvector on every child
+        row and stays NULL on parent rows.
+        """
+        pdf_path = temp_file(sample_paper_pdf, "sample.pdf")
+        document = Document(
+            title="Searchable Paper",
+            document_type=DocumentType.PAPER,
+            source_filename="sample.pdf",
+        )
+        test_session.add(document)
+        test_session.flush()
+
+        run_ingestion(
+            pending=PendingIngestion(
+                document_id=document.document_id,
+                title="Searchable Paper",
+                document_type=DocumentType.PAPER,
+                source_filename="sample.pdf",
+                file_path=pdf_path,
+            ),
+            session=test_session,
+            embeddings_client=fake_embeddings_client,
+            model_name="text-embedding-3-small",
+        )
+
+        test_session.commit()
+        chunks = (
+            test_session.query(Chunk)
+            .filter(Chunk.document_id == document.document_id)
+            .order_by(Chunk.position)
+            .all()
+        )
+        parents = [c for c in chunks if c.parent_chunk_id is None]
+        children = [c for c in chunks if c.parent_chunk_id is not None]
+        assert len(parents) >= 1
+        assert len(children) >= 1
+
+        for parent in parents:
+            assert parent.content_search is None
+        for child in children:
+            assert child.content_search is not None
+            assert str(child.content_search) != ""
+
     def test_parents_not_embedded_children_are(
         self,
         test_session: Session,

--- a/retrieval_qa/src/retrieval_qa/retrieval/query.py
+++ b/retrieval_qa/src/retrieval_qa/retrieval/query.py
@@ -17,9 +17,12 @@ Implements the retrieval half of Harness A's RAG pipeline (ADR-0014):
 
 When ``RetrievalConfig.hybrid_search`` is True (default, ADR-0016):
 
-- A parallel sparse search via ``to_tsvector`` / ``websearch_to_tsquery`` on
-  chunk content recovers exact-match queries (function names, API endpoints,
-  error codes) that pure dense retrieval misses.
+- A parallel sparse search via ``ts_rank`` / ``websearch_to_tsquery`` over
+  the precomputed ``chunks.content_search`` tsvector column (populated by the
+  ingestion pipeline for child chunks; ADR-0016) recovers exact-match queries
+  (function names, API endpoints, error codes) that pure dense retrieval
+  misses. Reading the column — rather than an inline ``to_tsvector`` — lets
+  the query use ``ix_chunks_content_search_gin``.
 - Dense and sparse results are fused via Reciprocal Rank Fusion (RRF) with
   k=60, producing a single ranked set with no duplicates.
 - After fusion, matched child chunks are swapped to their parent chunks
@@ -88,13 +91,13 @@ _SPARSE_SQL = text(
         chunks.content           AS text,
         chunks.parent_chunk_id   AS parent_chunk_id,
         ts_rank(
-            to_tsvector('english', chunks.content),
+            chunks.content_search,
             websearch_to_tsquery('english', :query_text)
         ) AS rank
     FROM chunks
     JOIN documents ON documents.document_id = chunks.document_id
     WHERE documents.status = 'ready'
-      AND to_tsvector('english', chunks.content)
+      AND chunks.content_search
           @@ websearch_to_tsquery('english', :query_text)
     ORDER BY rank DESC
     LIMIT :top_k

--- a/retrieval_qa/tests/retrieval_qa/retrieval/test_query.py
+++ b/retrieval_qa/tests/retrieval_qa/retrieval/test_query.py
@@ -3,7 +3,8 @@
 from unittest.mock import MagicMock
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import func, text
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
 from core.clients.reranker_client import NoopReranker
@@ -38,6 +39,7 @@ def _seed_paper(
             position=position,
             content=content,
             token_count=max(1, len(content.split())),
+            content_search=func.to_tsvector("english", content),
         )
         session.add(chunk)
         session.flush()
@@ -90,6 +92,9 @@ def _seed_parent_child_paper(
             content=content,
             token_count=max(1, len(content.split())),
             parent_chunk_id=parent.chunk_id,
+            # Only children are sparse-indexed (ADR-0016); the parent stays
+            # content_search=NULL.
+            content_search=func.to_tsvector("english", content),
         )
         session.add(child)
         session.flush()
@@ -653,6 +658,52 @@ def test_hybrid_search_returns_empty_list_when_no_results_from_either_path(
     )
 
     assert results.fused == []
+
+
+def test_sparse_query_exercises_gin_index(
+    test_session: Session,
+    test_engine: Engine,
+) -> None:
+    """EXPLAIN shows the sparse query reading content_search via the GIN index.
+
+    The migration creates ``ix_chunks_content_search_gin`` on the
+    ``content_search`` column; the sparse query must read that column (not an
+    inline ``to_tsvector``) or the plan falls back to a per-row scan.
+    """
+    from retrieval_qa.retrieval.query import _SPARSE_SQL
+
+    content = "postgresql full text search with tsvector and gin indexes"
+    vector = [0.5] * 1536
+    _seed_paper(
+        test_session,
+        title="GIN",
+        chunks=[(content, vector, "gin")],
+    )
+    test_session.commit()
+
+    # The test_session fixture creates tables via metadata.create_all, which
+    # does not carry the migration-only GIN index. Recreate it here so the
+    # plan can use it.
+    with test_engine.connect() as conn:
+        conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS ix_chunks_content_search_gin "
+                "ON chunks USING gin (content_search)"
+            )
+        )
+        conn.commit()
+
+    with test_engine.connect() as conn:
+        trans = conn.begin()
+        conn.execute(text("SET LOCAL enable_seqscan = off"))
+        plan = conn.execute(
+            text(f"EXPLAIN {_SPARSE_SQL!s}"),
+            {"query_text": "postgresql", "top_k": 5},
+        ).fetchall()
+        trans.rollback()
+
+    plan_text = "\n".join(row[0] for row in plan)
+    assert "ix_chunks_content_search_gin" in plan_text
 
 
 def test_sparse_only_parent_swap_returns_parent_content(

--- a/scripts/seed_schema.py
+++ b/scripts/seed_schema.py
@@ -13,7 +13,8 @@ The ``seed`` subcommand:
 2. Creates a dedicated PostgreSQL schema ``chunks_{config}``.
 3. Creates enum types and tables inside that schema.
 4. Inserts document, chunk (parent + child), and embedding rows.
-5. Builds a pgvector HNSW index on the embedding column.
+5. Builds a pgvector HNSW index on the embedding column and a GIN index on
+   child ``content_search`` (mirroring the Alembic migration).
 
 The ``teardown`` subcommand drops the schema with ``CASCADE``.
 """
@@ -26,7 +27,7 @@ import sys
 from pathlib import Path
 from typing import Any, cast
 
-from sqlalchemy import Engine, text
+from sqlalchemy import Engine, func, text
 from sqlalchemy.orm import Session, sessionmaker
 
 from core.database.connection import get_engine
@@ -156,6 +157,10 @@ def _insert_sidecar(
                     token_count=child_data["token_count"],
                     type_metadata={},
                     parent_chunk_id=parent.chunk_id,
+                    # Mirror the ingestion pipeline (ADR-0016): only children
+                    # are sparse-indexed, so they get a populated tsvector
+                    # while parents stay NULL.
+                    content_search=func.to_tsvector("english", child_data["content"]),
                 )
                 session.add(child)
                 session.flush()
@@ -183,6 +188,24 @@ def _build_hnsw_index(engine: Engine, schema_name: str) -> None:
                 f'ON "{clean_schema}".embeddings '
                 "USING hnsw (embedding vector_cosine_ops) "
                 "WITH (m = 16, ef_construction = 64)"
+            )
+        )
+        conn.commit()
+
+
+def _build_content_search_gin_index(engine: Engine, schema_name: str) -> None:
+    """Create the GIN index on child ``content_search``, mirroring the Alembic migration.
+
+    The migration creates ``ix_chunks_content_search_gin`` on the production
+    schema; the eval seed recreates it here so sparse queries use the index
+    during chunk-size tuning.
+    """
+    clean_schema = schema_name.replace('"', '""')
+    with engine.connect() as conn:
+        conn.execute(
+            text(
+                f"CREATE INDEX IF NOT EXISTS ix_chunks_content_search_gin "
+                f'ON "{clean_schema}".chunks USING gin (content_search)'
             )
         )
         conn.commit()
@@ -237,6 +260,7 @@ def seed_schema(
         session.close()
 
     _build_hnsw_index(engine, schema_name)
+    _build_content_search_gin_index(engine, schema_name)
     print(f"Seeded schema {schema_name!r} from {sidecar_path.name}")
     return 0
 

--- a/tests/scripts/test_seed_schema.py
+++ b/tests/scripts/test_seed_schema.py
@@ -187,6 +187,14 @@ class TestSeedAndTeardown:
                 parent = parents[0]
                 for child in children:
                     assert child.parent_chunk_id == parent.chunk_id
+
+                # content_search mirrors the ingestion pipeline: children get
+                # a non-null tsvector, parents stay NULL (ADR-0016).
+                for parent in parents:
+                    assert parent.content_search is None
+                for child in children:
+                    assert child.content_search is not None
+                    assert str(child.content_search) != ""
             finally:
                 session.close()
         finally:
@@ -299,6 +307,28 @@ class TestSeedAndTeardown:
                     {"schema": "chunks_256_10", "pat": "ix_embeddings_hnsw_%"},
                 ).fetchone()
                 assert row is not None, "HNSW index was not created"
+        finally:
+            teardown_schema("256_10", engine=test_engine)
+
+    def test_content_search_gin_index_exists_after_seed(
+        self, test_engine: Engine, tmp_path: Path
+    ) -> None:
+        sidecar = _make_test_sidecar()
+        sidecar_path = tmp_path / "eval_vectors_256_10.json"
+        sidecar_path.write_text(json.dumps(sidecar))
+
+        try:
+            seed_schema("256_10", engine=test_engine, sidecar_override=sidecar_path)
+
+            with test_engine.connect() as conn:
+                row = conn.execute(
+                    text(
+                        "SELECT indexname FROM pg_indexes "
+                        "WHERE schemaname = :schema AND indexname = :name"
+                    ),
+                    {"schema": "chunks_256_10", "name": "ix_chunks_content_search_gin"},
+                ).fetchone()
+                assert row is not None, "GIN index on content_search was not created"
         finally:
             teardown_schema("256_10", engine=test_engine)
 


### PR DESCRIPTION
…ndex (#168)

The content_search tsvector column and its GIN index were dead schema: nothing wrote the column, so the sparse query computed to_tsvector inline per row (full scan, index never used).

Populate content_search application-side on child rows in the ingestion pipeline (ADR-0016: only children are indexed; parents stay NULL) and in scripts/seed_schema.py so the eval seed keeps working once the sparse query reads the column. seed_schema also builds the GIN index for eval parity.

_SPARSE_SQL now reads chunks.content_search, letting the planner use ix_chunks_content_search_gin (verified via EXPLAIN).