### PR TITLE
fix(ingestion): reject over-cap chunks before embedding call (#173)

### DIFF
--- a/ingestion/src/ingestion/pipeline.py
+++ b/ingestion/src/ingestion/pipeline.py
@@ -94,13 +94,25 @@ def _embed_chunks(
 ) -> tuple[list[tuple[ChunkRow, list[float]]], int]:
     """Embed chunk contents and return (chunk, vector) pairs and API call count.
 
-    Batches chunks by cumulative token count to stay within the
-    embedding API's per-request token limit (OpenAI enforces 300k).
+    Batches chunks by cumulative token count so every request stays within the
+    embedding API's per-request token limit (OpenAI enforces 300k). A chunk
+    whose ``token_count`` alone exceeds the cap would make any batch containing
+    it over the limit, so it is rejected before the provider is called.
+
+    Args:
+        session: Unused; kept for API symmetry with the rest of the pipeline.
+        client: Provider that produces one vector per chunk text.
+        chunks: Child chunk rows to embed, in document order.
+        model_name: Unused; kept for API symmetry with the rest of the pipeline.
 
     Returns:
         A tuple of (results, api_calls) where ``results`` is a list of
         (chunk, vector) pairs and ``api_calls`` is the number of API
         calls made.
+
+    Raises:
+        IngestionError: If a chunk exceeds the per-request batch cap, an
+            embedding call fails, or a response's length mismatches the batch.
     """
     if not chunks:
         return [], 0
@@ -109,6 +121,12 @@ def _embed_chunks(
     batch_tokens: list[int] = [0]
 
     for chunk in chunks:
+        if chunk.token_count > _MAX_TOKENS_PER_EMBEDDING_BATCH:
+            raise IngestionError(
+                f"Chunk at position {chunk.position} has {chunk.token_count} tokens, "
+                f"exceeding the {_MAX_TOKENS_PER_EMBEDDING_BATCH}-token "
+                f"per-request embedding batch cap"
+            )
         if batch_tokens[-1] + chunk.token_count > _MAX_TOKENS_PER_EMBEDDING_BATCH:
             batches.append([])
             batch_tokens.append(0)

--- a/ingestion/tests/ingestion/test_pipeline.py
+++ b/ingestion/tests/ingestion/test_pipeline.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import pytest
 from sqlalchemy.orm import Session
@@ -11,7 +12,12 @@ from core.database.schema import Chunk, Document, Embedding
 from core.exceptions import IngestionError
 from core.types.document import DocumentStatus, DocumentType
 from ingestion.models import PendingIngestion
-from ingestion.pipeline import _validate_type_metadata, run_ingestion
+from ingestion.pipeline import (
+    _MAX_TOKENS_PER_EMBEDDING_BATCH,
+    _embed_chunks,
+    _validate_type_metadata,
+    run_ingestion,
+)
 
 
 @pytest.fixture
@@ -791,3 +797,99 @@ class TestParentChildIngestion:
                 assert child.position == i, (
                     f"Child at index {i} of parent {parent.chunk_id} has position {child.position}"
                 )
+
+
+# ── _embed_chunks batching unit tests ─────────────────────────────────────
+
+
+def _chunk_row(token_count: int, position: int = 0) -> Chunk:
+    """Build a Chunk row for batching tests without touching the database."""
+    return Chunk(
+        document_id=uuid4(),
+        position=position,
+        content=f"chunk content {position}",
+        token_count=token_count,
+    )
+
+
+class TestEmbedChunksBatching:
+    """Unit tests for ``_embed_chunks`` batching (bug #173)."""
+
+    def test_cumulative_tokens_over_cap_produce_multiple_api_calls(self) -> None:
+        """A corpus whose cumulative tokens exceed the 300k cap is split."""
+        chunks = [_chunk_row(_MAX_TOKENS_PER_EMBEDDING_BATCH // 2, i) for i in range(3)]
+        client = MagicMock()
+        client.embed.side_effect = lambda texts: [[0.1] for _ in texts]
+
+        _, api_calls = _embed_chunks(
+            session=MagicMock(),
+            client=client,
+            chunks=chunks,
+            model_name="text-embedding-3-small",
+        )
+
+        assert api_calls == 2
+        assert [len(call.args[0]) for call in client.embed.call_args_list] == [2, 1]
+
+    def test_batch_results_concatenated_in_chunk_order(self) -> None:
+        """Per-batch vectors come back in original chunk order."""
+        chunks = [_chunk_row(_MAX_TOKENS_PER_EMBEDDING_BATCH // 2, i) for i in range(3)]
+        client = MagicMock()
+        client.embed.side_effect = lambda texts: [[int(text.split()[-1]) + 1.0] for text in texts]
+
+        results, _ = _embed_chunks(
+            session=MagicMock(),
+            client=client,
+            chunks=chunks,
+            model_name="text-embedding-3-small",
+        )
+
+        assert [vector for _, vector in results] == [[1.0], [2.0], [3.0]]
+
+    def test_over_cap_chunk_raises_ingestion_error_before_provider_call(self) -> None:
+        """A single chunk over the cap is rejected before hitting the provider."""
+        chunks = [_chunk_row(_MAX_TOKENS_PER_EMBEDDING_BATCH + 1)]
+        client = MagicMock()
+
+        with pytest.raises(
+            IngestionError,
+            match=f"exceeding the {_MAX_TOKENS_PER_EMBEDDING_BATCH}-token",
+        ):
+            _embed_chunks(
+                session=MagicMock(),
+                client=client,
+                chunks=chunks,
+                model_name="text-embedding-3-small",
+            )
+
+        client.embed.assert_not_called()
+
+    def test_at_cap_chunk_is_allowed(self) -> None:
+        """A single chunk exactly at the cap occupies one request but is allowed."""
+        chunks = [_chunk_row(_MAX_TOKENS_PER_EMBEDDING_BATCH)]
+        client = MagicMock()
+        client.embed.side_effect = lambda texts: [[0.1] for _ in texts]
+
+        results, api_calls = _embed_chunks(
+            session=MagicMock(),
+            client=client,
+            chunks=chunks,
+            model_name="text-embedding-3-small",
+        )
+
+        assert api_calls == 1
+        assert len(results) == 1
+
+    def test_batch_length_mismatch_raises_ingestion_error(self) -> None:
+        """A batch returning fewer vectors than chunks raises IngestionError."""
+        chunks = [_chunk_row(10, i) for i in range(2)]
+        client = MagicMock()
+        client.embed.side_effect = lambda texts: [[0.1]]
+
+        with pytest.raises(IngestionError):
+            _embed_chunks(
+                session=MagicMock(),
+                client=client,
+                chunks=chunks,
+                model_name="text-embedding-3-small",
+            )


### PR DESCRIPTION
_embed_chunks split batches by cumulative token_count, but a chunk whose token_count alone exceeded _MAX_TOKENS_PER_EMBEDDING_BATCH was placed in its own batch and sent to the provider unguarded, silently bypassing the 300k per-request cap invariant. Reject such chunks with a clear IngestionError before the provider is called, and pin the batching behavior with unit tests: multi-batch splitting, ordered concatenation, the over-cap rejection, the at-cap boundary, and per-batch mismatch.