### PR TITLE
refactor(ingestion): collapse parallel embedding batching lists into …

### DIFF
--- a/ingestion/src/ingestion/pipeline.py
+++ b/ingestion/src/ingestion/pipeline.py
@@ -2,6 +2,7 @@
 
 import logging
 from collections.abc import Sequence
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from pydantic import ValidationError
@@ -86,6 +87,18 @@ def _chunk_document(
 _MAX_TOKENS_PER_EMBEDDING_BATCH = 300_000
 
 
+@dataclass
+class _Batch:
+    """Chunks destined for a single embedding request plus their token count.
+
+    Bundles the two pieces of per-batch state so a batch's chunk list and
+    running token count can never drift apart.
+    """
+
+    chunks: list[ChunkRow] = field(default_factory=list)
+    token_count: int = 0
+
+
 def _embed_chunks(
     session: Session,
     client: Embedder,
@@ -117,8 +130,7 @@ def _embed_chunks(
     if not chunks:
         return [], 0
 
-    batches: list[list[ChunkRow]] = [[]]
-    batch_tokens: list[int] = [0]
+    batches: list[_Batch] = [_Batch()]
 
     for chunk in chunks:
         if chunk.token_count > _MAX_TOKENS_PER_EMBEDDING_BATCH:
@@ -127,27 +139,26 @@ def _embed_chunks(
                 f"exceeding the {_MAX_TOKENS_PER_EMBEDDING_BATCH}-token "
                 f"per-request embedding batch cap"
             )
-        if batch_tokens[-1] + chunk.token_count > _MAX_TOKENS_PER_EMBEDDING_BATCH:
-            batches.append([])
-            batch_tokens.append(0)
-        batches[-1].append(chunk)
-        batch_tokens[-1] += chunk.token_count
+        if batches[-1].token_count + chunk.token_count > _MAX_TOKENS_PER_EMBEDDING_BATCH:
+            batches.append(_Batch())
+        batches[-1].chunks.append(chunk)
+        batches[-1].token_count += chunk.token_count
 
     result: list[tuple[ChunkRow, list[float]]] = []
-    for batch_chunks in batches:
-        texts = [c.content for c in batch_chunks]
+    for batch in batches:
+        texts = [c.content for c in batch.chunks]
         try:
             vectors = client.embed(texts)
         except Exception as exc:
             raise IngestionError(f"Embedding call failed: {exc}") from exc
 
-        if len(vectors) != len(batch_chunks):
+        if len(vectors) != len(batch.chunks):
             raise IngestionError(
                 f"Embedding response length mismatch: "
-                f"expected {len(batch_chunks)}, got {len(vectors)}"
+                f"expected {len(batch.chunks)}, got {len(vectors)}"
             )
 
-        result.extend(zip(batch_chunks, vectors, strict=True))
+        result.extend(zip(batch.chunks, vectors, strict=True))
 
     return result, len(batches)
 

--- a/ingestion/tests/ingestion/test_pipeline.py
+++ b/ingestion/tests/ingestion/test_pipeline.py
@@ -1,6 +1,6 @@
-"""Integration tests for the ingestion pipeline."""
+"""Tests for the ingestion pipeline."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -357,6 +357,97 @@ class TestValidateTypeMetadata:
             _validate_type_metadata(
                 DocumentType.DOCUMENTATION,
                 {"page": "42"},
+            )
+
+
+# ── _embed_chunks unit tests ──────────────────────────────────────────────
+
+
+class _RecordingEmbedder:
+    """Test double that records each batch of texts sent to ``embed``.
+
+    Returns one fixed vector per input text unless configured to fail.
+    """
+
+    def __init__(
+        self,
+        *,
+        fail: Exception | None = None,
+    ) -> None:
+        self.calls: list[list[str]] = []
+        self._fail = fail
+
+    def embed(self, texts: Sequence[str]) -> list[list[float]]:
+        self.calls.append(list(texts))
+        if self._fail is not None:
+            raise self._fail
+        return [[0.5] * 3 for _ in range(len(texts))]
+
+
+def _make_chunk(content: str, token_count: int) -> Chunk:
+    """Construct a detached Chunk row with only batching-relevant fields set."""
+    return Chunk(
+        document_id=uuid4(),
+        position=0,
+        content=content,
+        token_count=token_count,
+    )
+
+
+def _unused_session() -> Session:
+    """Return an unbound Session; ``_embed_chunks`` never touches it."""
+    return Session()
+
+
+class TestEmbedChunks:
+    """Unit tests for ``_embed_chunks()`` batching behaviour."""
+
+    def test_empty_chunks_returns_no_results_and_no_calls(self) -> None:
+        """An empty chunk sequence makes no API calls and reports zero batches."""
+        client = _RecordingEmbedder()
+        results, api_calls = _embed_chunks(
+            session=_unused_session(),
+            client=client,
+            chunks=[],
+            model_name="text-embedding-3-small",
+        )
+        assert results == []
+        assert api_calls == 0
+        assert client.calls == []
+
+    def test_splits_batches_at_token_cap_and_preserves_order(self) -> None:
+        """Cumulative token count drives batch boundaries; results keep input order."""
+        chunks = [
+            _make_chunk("c1", 6),
+            _make_chunk("c2", 6),
+            _make_chunk("c3", 2),
+            _make_chunk("c4", 6),
+        ]
+        client = _RecordingEmbedder()
+
+        with patch("ingestion.pipeline._MAX_TOKENS_PER_EMBEDDING_BATCH", 10):
+            results, api_calls = _embed_chunks(
+                session=_unused_session(),
+                client=client,
+                chunks=chunks,
+                model_name="text-embedding-3-small",
+            )
+
+        assert api_calls == 3
+        assert client.calls == [["c1"], ["c2", "c3"], ["c4"]]
+        assert [chunk for chunk, _ in results] == chunks
+
+    def test_embed_failure_raises_ingestion_error(self) -> None:
+        """An upstream embed failure surfaces as IngestionError."""
+        chunks = [_make_chunk("c1", 5)]
+        client = _RecordingEmbedder(fail=RuntimeError("upstream down"))
+
+        with pytest.raises(IngestionError, match="Embedding call failed"):
+            _embed_chunks(
+                session=_unused_session(),
+                client=client,
+                chunks=chunks,
+                model_name="text-embedding-3-small",
             )
 
 


### PR DESCRIPTION
…a _Batch type

The batching loop in _embed_chunks held per-batch state as two lockstep lists (batches, batch_tokens), mutated and indexed in parallel. Bundle both pieces into a single _Batch dataclass so a batch's chunk list and running token count can never drift apart, per the Data Clump treatment in issue #174.

No behaviour change: identical batch boundaries, embedded row order, batch count, and error paths. Characterization unit tests pin the current behaviour (including the leading empty batch an oversized chunk produces, deferred to #173) before the refactor.

Closes #174