### PR TITLE
fix(retrieval_qa): narrow score and threshold in is_successful

### DIFF
--- a/retrieval_qa/tests/eval/test_eval.py
+++ b/retrieval_qa/tests/eval/test_eval.py
@@ -93,7 +93,9 @@ class RecallAtKMetric(BaseMetric):  # type: ignore[no-untyped-call]
         return self.measure(test_case, *args, **kwargs)
 
     def is_successful(self) -> bool:
-        return self.score is not None and self.score >= self.threshold
+        score = self.score
+        threshold = self.threshold
+        return score is not None and threshold is not None and score >= threshold
 
     @property
     def __name__(self) -> str:


### PR DESCRIPTION
Fixes the mypy failure in `retrieval_qa/tests/eval/test_eval.py` surfaced on dependabot PR #187.

`deepeval`'s `BaseMetric` declares `threshold` as `Optional[float]`, so `is_successful` must narrow both `score` and `threshold` before the `>=` comparison, else mypy reports unsupported operand types float vs None.

- `uv run mypy .` passes (102 files)
- `uv run ruff check` / format pass
- `uv run pytest retrieval_qa/tests/eval/` passes (4 passed)