### PR TITLE
refactor(core): deduplicate whitespace count_tokens into shared core …

### DIFF
--- a/core/src/core/__init__.py
+++ b/core/src/core/__init__.py
@@ -1,3 +1,3 @@
 """Shared core package for the Learning Hub monorepo."""
 
-__all__ = ["clients", "config", "database", "exceptions", "types"]
+__all__ = ["clients", "config", "database", "exceptions", "types", "utils"]

--- a/core/src/core/utils.py
+++ b/core/src/core/utils.py
@@ -1,0 +1,17 @@
+"""Shared text utilities for the Learning Hub monorepo."""
+
+
+def count_tokens(text: str) -> int:
+    """Approximate token count for chunk sizing.
+
+    Uses a simple whitespace split; this is sufficient for MVP chunk ordering
+    and sanity checks. More precise counting can be swapped in later without
+    changing the chunker interface.
+
+    Args:
+        text: The text to count tokens for.
+
+    Returns:
+        The number of whitespace-separated words, with a minimum of one.
+    """
+    return max(1, len(text.split()))

--- a/core/tests/core/test_utils.py
+++ b/core/tests/core/test_utils.py
@@ -1,0 +1,23 @@
+"""Tests for shared core text utilities."""
+
+from core.utils import count_tokens
+
+
+def test_count_tokens_counts_whitespace_separated_words() -> None:
+    """A sentence counts as the number of whitespace-separated words."""
+    assert count_tokens("the quick brown fox") == 4
+
+
+def test_count_tokens_empty_text_counts_one() -> None:
+    """Empty text never reports zero, matching the chunker convention."""
+    assert count_tokens("") == 1
+
+
+def test_count_tokens_single_word_counts_one() -> None:
+    """A single word counts as one token."""
+    assert count_tokens("hello") == 1
+
+
+def test_count_tokens_collapses_whitespace() -> None:
+    """Multiple consecutive whitespace characters count as one separator."""
+    assert count_tokens("a   b\n\t c") == 3

--- a/docs/ai-system-tree.md
+++ b/docs/ai-system-tree.md
@@ -45,6 +45,7 @@ learning-hub/
 │   │   │   ├── schema.py
 │   │   │   └── migrations/
 │   │   ├── exceptions.py             # Named exception types
+│   │   ├── utils.py                  # Shared text utilities (e.g. count_tokens)
 │   │   └── __init__.py
 │   ├── tests/core/                   # types, clients, migration tests
 │   ├── pyproject.toml

--- a/ingestion/src/ingestion/splitting.py
+++ b/ingestion/src/ingestion/splitting.py
@@ -7,6 +7,8 @@ are embedded and indexed for retrieval.
 
 from dataclasses import dataclass
 
+from core.utils import count_tokens
+
 
 @dataclass(frozen=True)
 class ChildSplit:
@@ -25,11 +27,6 @@ class ChildSplit:
 
 _DEFAULT_CHUNK_SIZE = 512
 _DEFAULT_OVERLAP_RATIO = 0.15
-
-
-def _count_tokens(text: str) -> int:
-    """Approximate token count matching the convention in retrieval_qa._utils."""
-    return max(1, len(text.split()))
 
 
 def recursive_fixed_size_split(
@@ -63,7 +60,7 @@ def recursive_fixed_size_split(
     if not text:
         raise ValueError("text cannot be empty")
 
-    token_count = text_token_count if text_token_count is not None else _count_tokens(text)
+    token_count = text_token_count if text_token_count is not None else count_tokens(text)
 
     if token_count <= chunk_size:
         return [ChildSplit(content=text, token_count=token_count, position=0)]

--- a/retrieval_qa/src/retrieval_qa/_utils.py
+++ b/retrieval_qa/src/retrieval_qa/_utils.py
@@ -3,15 +3,5 @@
 from hashlib import sha256
 
 
-def count_tokens(text: str) -> int:
-    """Approximate token count for chunk sizing.
-
-    Uses a simple whitespace split; this is sufficient for MVP chunk ordering
-    and sanity checks. More precise counting can be swapped in later without
-    changing the chunker interface.
-    """
-    return max(1, len(text.split()))
-
-
 def _sha256(text: str) -> str:
     return sha256(text.encode()).hexdigest()

--- a/retrieval_qa/src/retrieval_qa/chunking/book_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/book_chunker.py
@@ -19,7 +19,7 @@ from pypdf import PdfReader
 from core.exceptions import IngestionError
 from core.types.chunk import BookChunkMetadata, Chunk
 from core.types.document import DocumentType
-from retrieval_qa._utils import count_tokens
+from core.utils import count_tokens
 from retrieval_qa.chunking._html_utils import _BaseHTMLTextExtractor
 from retrieval_qa.chunking.base import DocumentChunker, register_chunker
 

--- a/retrieval_qa/src/retrieval_qa/chunking/documentation_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/documentation_chunker.py
@@ -20,7 +20,7 @@ from pypdf import PdfReader
 from core.exceptions import IngestionError
 from core.types.chunk import Chunk, DocumentationChunkMetadata
 from core.types.document import DocumentType
-from retrieval_qa._utils import count_tokens
+from core.utils import count_tokens
 from retrieval_qa.chunking._html_utils import _BaseHTMLTextExtractor
 from retrieval_qa.chunking.base import DocumentChunker, register_chunker
 

--- a/retrieval_qa/src/retrieval_qa/chunking/paper_chunker.py
+++ b/retrieval_qa/src/retrieval_qa/chunking/paper_chunker.py
@@ -14,7 +14,7 @@ from pypdf import PdfReader
 from core.exceptions import IngestionError
 from core.types.chunk import Chunk, PaperChunkMetadata
 from core.types.document import DocumentType
-from retrieval_qa._utils import count_tokens
+from core.utils import count_tokens
 from retrieval_qa.chunking.base import DocumentChunker, register_chunker
 
 # Matches lines that look like paper section headers, e.g.:


### PR DESCRIPTION
…utility

The approximate whitespace token-count convention (max(1, len(text.split()))) existed twice with identical bodies: retrieval_qa._utils.count_tokens and ingestion._splitting._count_tokens. Two copies of one convention invite silent divergence.

Move the canonical helper into core.utils (the only package both retrieval_qa and ingestion may depend on per ADR-0011), delete the ingestion private copy, and point the retrieval_qa chunkers at the shared helper directly.

Closes #175