### PR TITLE
refactor(ingestion): drop dead child_of metadata key from child chunks

### DIFF
--- a/ingestion/src/ingestion/pipeline.py
+++ b/ingestion/src/ingestion/pipeline.py
@@ -186,8 +186,7 @@ def run_ingestion(
     2. Each parent is stored as a row (not embedded).
     3. Each parent is split into fixed-size child chunks (512 tokens, 15%
        overlap) via ``recursive_fixed_size_split``.
-    4. Child chunks inherit ``type_metadata`` from the parent with an
-       additional ``"child_of"`` lineage key.
+    4. Child chunks inherit ``type_metadata`` from the parent unchanged.
     5. Only child chunks are embedded and indexed for retrieval: each child
        row's ``content_search`` tsvector is populated application-side, and
        only children receive embeddings. Parent rows keep ``content_search``
@@ -233,7 +232,6 @@ def run_ingestion(
             child_splits = recursive_fixed_size_split(parent.content, parent.token_count)
             for child_split in child_splits:
                 child_metadata = dict(parent.type_metadata)
-                child_metadata["child_of"] = str(parent.chunk_id)
                 child_content = _sanitize_text(child_split.content)
                 child = ChunkRow(
                     document_id=pending.document_id,

--- a/ingestion/tests/ingestion/test_pipeline.py
+++ b/ingestion/tests/ingestion/test_pipeline.py
@@ -85,7 +85,7 @@ def test_pipeline_happy_path_reaches_ready(
         assert p.position < len(parents)
     for child in children:
         assert child.parent_chunk_id is not None
-        assert "child_of" in child.type_metadata
+        assert "child_of" not in child.type_metadata
 
     embeddings = test_session.query(Embedding).all()
     assert len(embeddings) == len(children)
@@ -174,7 +174,7 @@ def test_pipeline_book_happy_path_reaches_ready(
         .all()
     )
     assert len(chunks) >= 1
-    # Parents have original metadata; children inherit with "child_of" key.
+    # Parents have original metadata; children inherit it unchanged.
     for chunk in chunks:
         assert "chapter" in chunk.type_metadata
         assert isinstance(chunk.type_metadata["chapter"], int)
@@ -182,7 +182,7 @@ def test_pipeline_book_happy_path_reaches_ready(
     children = [c for c in chunks if c.parent_chunk_id is not None]
     assert len(children) >= 1
     for child in children:
-        assert "child_of" in child.type_metadata
+        assert "child_of" not in child.type_metadata
 
     embeddings = test_session.query(Embedding).all()
     assert len(embeddings) == len(children)
@@ -237,7 +237,7 @@ def test_pipeline_documentation_happy_path_reaches_ready(
     children = [c for c in chunks if c.parent_chunk_id is not None]
     assert len(children) >= 1
     for child in children:
-        assert "child_of" in child.type_metadata
+        assert "child_of" not in child.type_metadata
 
 
 def test_reingestion_creates_new_document_id(
@@ -738,7 +738,6 @@ class TestParentChildIngestion:
         assert len(children) >= 2
         for child in children:
             assert child.parent_chunk_id == parents[0].chunk_id
-            assert child.type_metadata.get("child_of") == str(parents[0].chunk_id)
 
     def test_small_parent_produces_one_child(
         self,
@@ -786,12 +785,12 @@ class TestParentChildIngestion:
         assert len(children) == 1
         assert children[0].content == small_content
 
-    def test_child_inherits_type_metadata_with_child_of(
+    def test_child_inherits_parent_type_metadata_unchanged(
         self,
         test_session: Session,
         fake_embeddings_client: MagicMock,
     ) -> None:
-        """Children inherit type_metadata from parent and add 'child_of' key."""
+        """Children inherit parent type_metadata unchanged (no child_of key)."""
         content = "inherit_metadata_test_word " * 400
         document = Document(
             title="Inherit Test",
@@ -830,10 +829,7 @@ class TestParentChildIngestion:
         for child in children:
             assert child.type_metadata.get("chapter") == 5
             assert child.type_metadata.get("heading") == "Deep Dive"
-            assert "child_of" in child.type_metadata
-            child_of_val = child.type_metadata["child_of"]
-            assert isinstance(child_of_val, str)
-            assert len(child_of_val) > 0
+            assert "child_of" not in child.type_metadata
 
     def test_positions_enumerate_within_parent(
         self,


### PR DESCRIPTION
Child chunks now carry exactly one lineage reference: parent_chunk_id. The child_of key was written into every child's type_metadata but never read anywhere except tests; it duplicated parent_chunk_id. Children still inherit the parent's other type_metadata unchanged.

Closes #176