### PR TITLE
refactor(ingestion): rename recursive_fixed_size_split to fixed_size_…

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,7 +35,7 @@ Testing-effect and scheduling-based learning mechanisms (quizzes on captured pas
 The enclosing structural unit (section, chapter, API page) produced by a Document-Type Chunker. Not embedded directly. Contains one or more Child Chunks. At retrieval time, the parent replaces matched child chunks before being handed to the LLM for generation.
 
 ## Child Chunk
-A fixed-size (~512 tokens, 15% overlap) recursive split of a Parent Chunk. Embedded and indexed for retrieval (both dense pgvector and sparse tsvector). A child points to its parent via `parent_chunk_id`. Only children are matched by the query; the parent is what reaches generation.
+A fixed-size (~512 tokens, 15% overlap) sliding-window split of a Parent Chunk. Embedded and indexed for retrieval (both dense pgvector and sparse tsvector). A child points to its parent via `parent_chunk_id`. Only children are matched by the query; the parent is what reaches generation.
 
 ## Hybrid Search
 A retrieval strategy combining dense (embedding-based pgvector cosine search) and sparse (PostgreSQL `tsvector` full-text search) passes, fused via Reciprocal Rank Fusion. Recovers exact-match queries (function names, API endpoints, error codes, symbols) that pure dense retrieval misses.

--- a/ingestion/src/ingestion/pipeline.py
+++ b/ingestion/src/ingestion/pipeline.py
@@ -16,7 +16,7 @@ from core.exceptions import IngestionError
 from core.types.chunk import Chunk
 from core.types.document import DocumentStatus, DocumentType
 from ingestion.models import PendingIngestion
-from ingestion.splitting import recursive_fixed_size_split
+from ingestion.splitting import fixed_size_split
 from retrieval_qa.chunking import chunker_registry, get_chunker_class
 
 logger = logging.getLogger(__name__)
@@ -185,7 +185,7 @@ def run_ingestion(
     1. Structure-aware chunking produces parent chunks.
     2. Each parent is stored as a row (not embedded).
     3. Each parent is split into fixed-size child chunks (512 tokens, 15%
-       overlap) via ``recursive_fixed_size_split``.
+       overlap) via ``fixed_size_split``.
     4. Child chunks inherit ``type_metadata`` from the parent unchanged.
     5. Only child chunks are embedded and indexed for retrieval: each child
        row's ``content_search`` tsvector is populated application-side, and
@@ -229,7 +229,7 @@ def run_ingestion(
         # ── Phase 2: Split parents into children ──
         child_rows: list[ChunkRow] = []
         for parent in parent_rows:
-            child_splits = recursive_fixed_size_split(parent.content, parent.token_count)
+            child_splits = fixed_size_split(parent.content, parent.token_count)
             for child_split in child_splits:
                 child_metadata = dict(parent.type_metadata)
                 child_content = _sanitize_text(child_split.content)

--- a/ingestion/src/ingestion/splitting.py
+++ b/ingestion/src/ingestion/splitting.py
@@ -1,8 +1,9 @@
-"""Recursive fixed-size text splitter for parent-child chunking.
+"""Fixed-size text splitter for parent-child chunking.
 
 Per ADR-0016, structure-aware chunks (parents) are split into fixed-size
-child chunks of 512 tokens with 15% contextual overlap. Only child chunks
-are embedded and indexed for retrieval.
+child chunks of 512 tokens with 15% contextual overlap. The split is an
+iterative sliding window that never calls itself. Only child chunks are
+embedded and indexed for retrieval.
 """
 
 from dataclasses import dataclass
@@ -12,7 +13,7 @@ from core.utils import count_tokens
 
 @dataclass(frozen=True)
 class ChildSplit:
-    """A single child chunk produced by the recursive splitter.
+    """A single child chunk produced by the fixed-size splitter.
 
     Attributes:
         content: The text content of the child chunk.
@@ -29,7 +30,7 @@ _DEFAULT_CHUNK_SIZE = 512
 _DEFAULT_OVERLAP_RATIO = 0.15
 
 
-def recursive_fixed_size_split(
+def fixed_size_split(
     text: str,
     text_token_count: int | None = None,
     *,
@@ -41,7 +42,7 @@ def recursive_fixed_size_split(
     If the text is at or below ``chunk_size`` tokens, a single child is
     returned (identity split). Otherwise, the text is split into sliding
     windows of ``chunk_size`` tokens with ``overlap_ratio`` fractional
-    overlap between adjacent windows.
+    overlap between adjacent windows, using an iterative loop.
 
     Args:
         text: The parent chunk content to split.
@@ -89,4 +90,4 @@ def recursive_fixed_size_split(
     return children
 
 
-__all__ = ["ChildSplit", "recursive_fixed_size_split"]
+__all__ = ["ChildSplit", "fixed_size_split"]

--- a/ingestion/tests/ingestion/test_splitting.py
+++ b/ingestion/tests/ingestion/test_splitting.py
@@ -1,13 +1,13 @@
-"""Tests for the recursive fixed-size text splitter."""
+"""Tests for the fixed-size text splitter."""
 
-from ingestion.splitting import recursive_fixed_size_split
+from ingestion.splitting import fixed_size_split
 
 
 def test_identity_split_when_under_limit() -> None:
     """A parent ≤512 tokens produces exactly one child (identity split)."""
     content = "small chunk"
     parent_token_count = 2
-    result = recursive_fixed_size_split(content, parent_token_count)
+    result = fixed_size_split(content, parent_token_count)
     assert len(result) == 1
     assert result[0].content == content
     assert result[0].token_count == 2
@@ -18,7 +18,7 @@ def test_identity_split_at_exact_limit() -> None:
     """A parent at exactly 512 tokens produces exactly one child."""
     tokens = ["token"] * 512
     content = " ".join(tokens)
-    result = recursive_fixed_size_split(content, 512)
+    result = fixed_size_split(content, 512)
     assert len(result) == 1
     assert result[0].position == 0
 
@@ -27,7 +27,7 @@ def test_splits_into_multiple_children() -> None:
     """A parent >512 tokens produces multiple child chunks."""
     tokens = ["token"] * 1200
     content = " ".join(tokens)
-    result = recursive_fixed_size_split(content, 1200)
+    result = fixed_size_split(content, 1200)
     assert len(result) >= 2
 
 
@@ -35,7 +35,7 @@ def test_each_child_within_token_limit() -> None:
     """Each child chunk is ≤512 tokens."""
     tokens = ["token"] * 2000
     content = " ".join(tokens)
-    result = recursive_fixed_size_split(content, 2000)
+    result = fixed_size_split(content, 2000)
     for child in result:
         assert child.token_count <= 512, f"Child has {child.token_count} tokens, exceeds 512"
 
@@ -44,7 +44,7 @@ def test_overlapping_boundary_content() -> None:
     """Adjacent children share overlapping content."""
     tokens = [f"word{i}" for i in range(1500)]
     content = " ".join(tokens)
-    result = recursive_fixed_size_split(content, 1500)
+    result = fixed_size_split(content, 1500)
 
     # Adjacent children should share some tokens
     for i in range(len(result) - 1):
@@ -58,7 +58,7 @@ def test_position_enumerates_within_parent() -> None:
     """Child position enumerates from 0 within the parent."""
     tokens = ["token"] * 2000
     content = " ".join(tokens)
-    result = recursive_fixed_size_split(content, 2000)
+    result = fixed_size_split(content, 2000)
     for i, child in enumerate(result):
         assert child.position == i, f"Expected position {i}, got {child.position}"
 
@@ -67,7 +67,7 @@ def test_children_ordered_correctly() -> None:
     """Children are ordered by position, first child starts with parent content."""
     words = [f"unique_word_{i}" for i in range(600)]
     content = " ".join(words)
-    result = recursive_fixed_size_split(content, 600)
+    result = fixed_size_split(content, 600)
     assert len(result) >= 2
     assert result[0].content.startswith("unique_word_0")
     assert result[-1].content.endswith("unique_word_599")
@@ -77,7 +77,7 @@ def test_small_chunk_size() -> None:
     """Works correctly with very small chunk sizes."""
     tokens = ["a"] * 50
     content = " ".join(tokens)
-    result = recursive_fixed_size_split(content, 50, chunk_size=10, overlap_ratio=0.0)
+    result = fixed_size_split(content, 50, chunk_size=10, overlap_ratio=0.0)
     assert len(result) == 5
     for child in result:
         assert child.token_count <= 10
@@ -87,7 +87,7 @@ def test_zero_overlap() -> None:
     """With 0% overlap, children partition the content without sharing."""
     tokens = [f"w{i}" for i in range(600)]
     content = " ".join(tokens)
-    result = recursive_fixed_size_split(content, 600, overlap_ratio=0.0)
+    result = fixed_size_split(content, 600, overlap_ratio=0.0)
     assert len(result) >= 2
 
 
@@ -96,12 +96,12 @@ def test_empty_content_raises() -> None:
     import pytest
 
     with pytest.raises(ValueError, match="cannot be empty"):
-        recursive_fixed_size_split("", 0)
+        fixed_size_split("", 0)
 
 
 def test_single_token() -> None:
     """A single token produces exactly one child."""
-    result = recursive_fixed_size_split("hello", 1)
+    result = fixed_size_split("hello", 1)
     assert len(result) == 1
     assert result[0].content == "hello"
     assert result[0].token_count == 1

--- a/scripts/generate_eval_vectors.py
+++ b/scripts/generate_eval_vectors.py
@@ -11,7 +11,7 @@ unique source document:
     1. Runs structure-aware parent chunking once (parent chunks are invariant
        across child split sizes).
     2. For each of the three chunk-size configs (256/10%, 512/15%, 1024/20%):
-       recursively splits each parent chunk, embeds the resulting children,
+       splits each parent chunk, embeds the resulting children,
        and writes a variant sidecar JSON file.
 
 Sidecar files are written to ``eval_corpus/eval_vectors_{size}_{overlap}.json``.
@@ -33,7 +33,7 @@ import yaml
 from core.clients.embeddings_client import Embedder, EmbeddingsClient, InMemoryEmbedder
 from core.config.settings import Settings
 from core.types.document import DocumentType
-from ingestion.splitting import recursive_fixed_size_split
+from ingestion.splitting import fixed_size_split
 from retrieval_qa.chunking import get_chunker
 
 # ── Constants ───────────────────────────────────────────────────────────────
@@ -124,12 +124,12 @@ def _build_parent_entries(
     """Build parent entries with children for a single chunk-size config.
 
     Each parent chunk is split into child chunks via
-    ``recursive_fixed_size_split``.  The result is a list of dicts ready to
+    ``fixed_size_split``.  The result is a list of dicts ready to
     be serialised into the sidecar tree.
     """
     parent_entries: list[dict[str, Any]] = []
     for parent in parents:
-        children = recursive_fixed_size_split(
+        children = fixed_size_split(
             parent.content,
             parent.token_count,
             chunk_size=chunk_size,
@@ -285,7 +285,7 @@ def build_all_sidecars(
     Algorithm per document:
       1. Run structure-aware parent chunking once (parent chunks are invariant
          across child split sizes).
-      2. For each config (256/10%, 512/15%, 1024/20%): recursively split each
+      2. For each config (256/10%, 512/15%, 1024/20%): split each
          parent chunk, embed the children, write the sidecar.
 
     Args:


### PR DESCRIPTION
…split

The splitter is an iterative sliding-window while loop, never recursive. The old name misled readers and contradicted the CONTEXT.md glossary. Behaviour, signature, and ChildSplit are unchanged; all imports, docstrings, and test references now use the new name, and the glossary wording now describes a sliding-window split.

Closes #177