### PR TITLE
fix(core): catch only provider transport errors in reranker, not all …

### DIFF
--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "openai>=2.51.0",
     "uuid-utils>=0.10",
     "cohere>=5.0",
+    "httpx>=0.27",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/core/src/core/clients/reranker_client.py
+++ b/core/src/core/clients/reranker_client.py
@@ -7,6 +7,7 @@ the Cohere Rerank API, and a ``NoopReranker`` that returns passages unchanged.
 from typing import Protocol, runtime_checkable
 
 import cohere
+import httpx
 
 from core.config.settings import settings
 from core.exceptions import RerankerRateLimitError, UpstreamBadResponse, UpstreamUnavailable
@@ -94,7 +95,8 @@ class CohereReranker:
                 Caller should fall back to RRF top-k.
             UpstreamBadResponse: Cohere returned an unexpected response shape
                 or a 4xx/5xx other than 429.
-            UpstreamUnavailable: Cohere could not be reached or timed out.
+            UpstreamUnavailable: Cohere could not be reached (transport
+                failure or timeout).
         """
         if not passages:
             return []
@@ -112,7 +114,7 @@ class CohereReranker:
             raise RerankerRateLimitError(f"Cohere Rerank rate-limited (429): {exc}") from exc
         except cohere.core.api_error.ApiError as exc:
             raise UpstreamBadResponse(f"Cohere Rerank API returned bad status: {exc}") from exc
-        except Exception as exc:
+        except httpx.TransportError as exc:
             raise UpstreamUnavailable(f"Cohere Rerank API unreachable: {exc}") from exc
 
         try:

--- a/core/tests/core/test_reranker_client.py
+++ b/core/tests/core/test_reranker_client.py
@@ -1,0 +1,84 @@
+"""Tests for the Cohere reranker's error mapping.
+
+Verifies that only genuinely "upstream unavailable" conditions (timeouts,
+connection failures) are relabelled as ``UpstreamUnavailable``, while
+non-upstream bugs propagate unchanged and HTTP status errors keep their
+dedicated mapping. See issue #178.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import cohere
+import cohere.core.api_error
+import cohere.errors
+import httpx
+import pytest
+
+from core.clients.reranker_client import CohereReranker
+from core.exceptions import RerankerRateLimitError, UpstreamBadResponse, UpstreamUnavailable
+from core.types.responses import ScoredChunk
+
+
+def _passages() -> list[ScoredChunk]:
+    return [ScoredChunk(chunk_id=uuid4(), text=f"passage {i}", score=1.0) for i in range(3)]
+
+
+def _reranker_with(raise_exc: Exception) -> CohereReranker:
+    reranker = CohereReranker(api_key="test-key", model="rerank-test")
+    client = MagicMock()
+    client.rerank.side_effect = raise_exc
+    # Override the lazy-init accessor so no real Cohere client is constructed;
+    # the return type is the protocol's client type but we substitute a mock.
+    reranker._get_client = lambda: client  # type: ignore[method-assign]
+    return reranker
+
+
+def test_rerank_connection_error_raises_upstream_unavailable() -> None:
+    """A connection failure means the upstream is unreachable (503)."""
+    reranker = _reranker_with(httpx.ConnectError("connection refused"))
+    with pytest.raises(UpstreamUnavailable):
+        reranker.rerank("query", _passages(), top_k=2)
+
+
+def test_rerank_timeout_raises_upstream_unavailable() -> None:
+    """A read timeout means the upstream is unreachable (503)."""
+    reranker = _reranker_with(httpx.ReadTimeout("timed out"))
+    with pytest.raises(UpstreamUnavailable):
+        reranker.rerank("query", _passages(), top_k=2)
+
+
+def test_rerank_protocol_error_raises_upstream_unavailable() -> None:
+    """A remote protocol error means the upstream is unreachable (503)."""
+    reranker = _reranker_with(httpx.RemoteProtocolError("connection closed"))
+    with pytest.raises(UpstreamUnavailable):
+        reranker.rerank("query", _passages(), top_k=2)
+
+
+def test_rerank_non_upstream_bug_propagates_unchanged() -> None:
+    """A genuine bug inside the call (not a transport error) must not be
+    relabelled as ``UpstreamUnavailable``; it propagates as-is."""
+    reranker = _reranker_with(RuntimeError("internal programming bug"))
+    with pytest.raises(RuntimeError, match="internal programming bug"):
+        reranker.rerank("query", _passages(), top_k=2)
+
+
+def test_rerank_attribute_error_propagates_unchanged() -> None:
+    """An attribute error on the SDK result must not surface as 503."""
+    reranker = _reranker_with(AttributeError("missing attribute bug"))
+    with pytest.raises(AttributeError, match="missing attribute bug"):
+        reranker.rerank("query", _passages(), top_k=2)
+
+
+def test_rerank_rate_limit_raises_reranker_rate_limit_error() -> None:
+    """A 429 from Cohere still maps to RerankerRateLimitError."""
+    reranker = _reranker_with(cohere.errors.TooManyRequestsError(body={}))
+    with pytest.raises(RerankerRateLimitError):
+        reranker.rerank("query", _passages(), top_k=2)
+
+
+def test_rerank_other_api_error_raises_upstream_bad_response() -> None:
+    """A non-429 API error (4xx/5xx) still maps to UpstreamBadResponse."""
+    reranker = _reranker_with(cohere.core.api_error.ApiError(status_code=400, body={}))
+    with pytest.raises(UpstreamBadResponse):
+        reranker.rerank("query", _passages(), top_k=2)

--- a/ingestion/src/ingestion/pipeline.py
+++ b/ingestion/src/ingestion/pipeline.py
@@ -124,8 +124,10 @@ def _embed_chunks(
         calls made.
 
     Raises:
-        IngestionError: If a chunk exceeds the per-request batch cap, an
-            embedding call fails, or a response's length mismatches the batch.
+        IngestionError: If a chunk exceeds the per-request batch cap or a
+            response's length mismatches the batch. Embedding provider errors
+            are intentionally NOT re-wrapped here; ``run_ingestion`` owns the
+            ``IngestionError`` conversion for the whole pipeline.
     """
     if not chunks:
         return [], 0
@@ -147,10 +149,7 @@ def _embed_chunks(
     result: list[tuple[ChunkRow, list[float]]] = []
     for batch in batches:
         texts = [c.content for c in batch.chunks]
-        try:
-            vectors = client.embed(texts)
-        except Exception as exc:
-            raise IngestionError(f"Embedding call failed: {exc}") from exc
+        vectors = client.embed(texts)
 
         if len(vectors) != len(batch.chunks):
             raise IngestionError(

--- a/ingestion/tests/ingestion/test_pipeline.py
+++ b/ingestion/tests/ingestion/test_pipeline.py
@@ -437,12 +437,13 @@ class TestEmbedChunks:
         assert client.calls == [["c1"], ["c2", "c3"], ["c4"]]
         assert [chunk for chunk, _ in results] == chunks
 
-    def test_embed_failure_raises_ingestion_error(self) -> None:
-        """An upstream embed failure surfaces as IngestionError."""
+    def test_embed_failure_propagates_unchanged(self) -> None:
+        """An upstream embed failure propagates as-is; ``run_ingestion`` owns
+        the ``IngestionError`` conversion (issue #178)."""
         chunks = [_make_chunk("c1", 5)]
         client = _RecordingEmbedder(fail=RuntimeError("upstream down"))
 
-        with pytest.raises(IngestionError, match="Embedding call failed"):
+        with pytest.raises(RuntimeError, match="upstream down"):
             _embed_chunks(
                 session=_unused_session(),
                 client=client,

--- a/uv.lock
+++ b/uv.lock
@@ -385,6 +385,7 @@ source = { editable = "core" }
 dependencies = [
     { name = "alembic" },
     { name = "cohere" },
+    { name = "httpx" },
     { name = "openai" },
     { name = "pgvector" },
     { name = "psycopg2-binary" },
@@ -398,6 +399,7 @@ dependencies = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "cohere", specifier = ">=5.0" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "openai", specifier = ">=2.51.0" },
     { name = "pgvector", specifier = ">=0.3" },
     { name = "psycopg2-binary", specifier = ">=2.9" },


### PR DESCRIPTION
…exceptions

The CohereReranker.rerank used a bare `except Exception` to convert any failure into UpstreamUnavailable, so genuine coding bugs (attribute/type errors) inside the call surfaced as a misleading 503 upstream.

Replace it with `except httpx.TransportError` -- the httpx transport hierarchy that Cohere SDK surfaces for timeouts, connection failures, and protocol errors -- so only genuinely unreachable upstreams map to UpstreamUnavailable while non-provider bugs propagate unchanged. 429 still maps to RerankerRateLimitError and other 4xx/5xx to UpstreamBadResponse.

Also drop the redundant broad `except Exception` re-wrap in the ingestion pipeline's `_embed_chunks`; `run_ingestion` already owns the IngestionError conversion for the whole pipeline.

Declare httpx as a direct dependency of core (it was previously only transitive via cohere).

Refs: #178