### PR TITLE
refactor(api): drop redundant api_key/model plumbing in get_reranker

### DIFF
--- a/api/src/api/dependencies.py
+++ b/api/src/api/dependencies.py
@@ -40,10 +40,7 @@ def get_reranker() -> Reranker:
     allowing the system to run without a Cohere API key during development.
     """
     if settings.cohere_api_key:
-        return CohereReranker(
-            api_key=settings.cohere_api_key,
-            model=settings.reranker_model,
-        )
+        return CohereReranker()
     return NoopReranker()
 
 


### PR DESCRIPTION
CohereReranker() already defaults both to settings.cohere_api_key and settings.reranker_model, so the explicit pass-through created two sources of truth for the same configuration. Closes #179.