### PR TITLE
feat: add root Makefile as thin local-dev compose wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+# Root Makefile: a thin, local-dev-only wrapper around the container lifecycle in
+# docker-compose.yml (Postgres + pgvector). Not a general task runner - lint/test/
+# format stay explicit uv run invocations - not a migration runner (Alembic), and
+# never invoked by CI (workflows provision Postgres via their own services: block).
+
+SHELL := /bin/bash
+.SHELLFLAGS := -eu -o pipefail -c
+.DEFAULT_GOAL := help
+
+# Scope `make logs` to a single service, e.g. `make logs SERVICE=postgres`.
+SERVICE ?=
+
+.PHONY: help
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: check-docker
+check-docker: ## Preflight: fail fast with a clear message if the Docker daemon is down
+	@docker info > /dev/null 2>&1 || (echo "Docker daemon is not running. Start Docker and retry." && exit 1)
+
+.PHONY: up
+up: check-docker ## Start the local dev stack (Postgres + pgvector) in the background
+	docker compose up -d
+
+.PHONY: logs
+logs: check-docker ## Tail logs (all services, or SERVICE=<name> for one)
+	docker compose logs -f --tail=200 $(SERVICE)
+
+.PHONY: down
+down: check-docker ## Stop and remove containers/network (never deletes the pgvector data volume)
+	docker compose down

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ A hand-rolled RAG study tool for learning AI/ML from papers, books, and document
 
 > **Status:** Early implementation — tracer bullet complete. Five of six packages (`core/`, `retrieval_qa/`, `api/`, `ingestion/`, `scripts/`) have implementation code (~5200 source lines, plus `tests/`). Only `depth_dive/` is still a stub (just `__init__.py` + smoke test). Ingestion pipeline, Harness A query pipeline, three API endpoints (`POST /ingest`, `GET /documents/{id}`, `POST /query`), and the `scripts/` eval & chunk-size-tuning tooling are operational. See [docs/](./docs/) for architecture decisions and plans.
 
+## Local development
+
+The root `Makefile` wraps the local dev container lifecycle defined in `docker-compose.yml` (Postgres + pgvector): `make up` to start the stack in the background, `make logs` to tail service logs (`make logs SERVICE=postgres` scopes to one service), and `make down` to stop and remove containers/network — `down` never deletes the pgvector data volume. Run `make help` to list every target. Docker's daemon must be running; `up`/`logs`/`down` fail fast with a clear message if it isn't. Per-package checks (`ruff`, `mypy`, `pytest`) stay explicit `uv run` invocations.
+
 ## Architecture
 
 Structured monorepo with extractable module boundaries:


### PR DESCRIPTION
Add a root Makefile wrapping the docker-compose.yml lifecycle (Postgres + pgvector) with five targets only: help (default), up, logs, down, and check-docker. It is local-dev-only, never invoked by CI, and not a general task runner or migration runner. README local-dev instructions now reference the Makefile surface. Closes #195