### PR TITLE
ci: make aggregate gate roll up from a single needs list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,10 @@ jobs:
         run: actionlint -color
 
   # 6. AGGREGATE GATE (single predictable check name for ruleset)
+  # The `needs:` list below is the SINGLE source of truth for which jobs gate
+  # a merge. A new gate joins the aggregate simply by being listed here — the
+  # pass/fail check rolls over every dependency via the `needs.*.result`
+  # wildcard, so no separate env mapping or switch list needs to stay in sync.
   ci-passed:
     name: CI passed
     if: always()
@@ -171,15 +175,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check all prerequisites passed
-        env:
-          DETECT: ${{ needs.detect-changes.result }}
-          QUALITY: ${{ needs.quality.result }}
-          BOUNDARIES: ${{ needs.boundaries.result }}
-          COMMITLINT: ${{ needs.commitlint.result }}
-          ACTIONLINT: ${{ needs.actionlint.result }}
-        run: |
-          for result in "$DETECT" "$QUALITY" "$BOUNDARIES" "$COMMITLINT" "$ACTIONLINT"; do
-            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
-              exit 1
-            fi
-          done
+        # Fails the gate if any listed dependency ends in failure or was
+        # cancelled. When every dependency passes, this step is skipped and the
+        # job reports success. `skipped` results (conditional jobs that did not
+        # run) are intentionally NOT treated as failures.
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1


### PR DESCRIPTION
Replace the ci-passed gate's four-way manual wiring (needs list + per-job env mapping + shell switch loop) with a step-level contains(needs.*.result, ...) check, so the needs list is the single source of truth for which jobs gate a merge.

A new gate now joins the aggregate with a single mechanical edit: adding its job id to the needs list. The check still fails the run if any listed dependency ends in failure/cancelled, and 'skipped' conditional gates (quality/boundaries with no package changes, commitlint off-PR) continue to pass, preserving existing semantics.

closes #202