### PR TITLE
ci: add pre-merge docker build gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,31 @@ jobs:
       - name: Lint workflow files
         run: actionlint -color
 
-  # 6. AGGREGATE GATE (single predictable check name for ruleset)
+  # 6. DOCKER BUILD GATE (build-only, never pushes)
+  # Catches Dockerfile breakage pre-merge instead of on `main` or at release
+  # time. Runs unconditionally, like the workflow-validation gate. Uses the same
+  # bare GHA cache backend (default repo-wide scope) as the release workflow so
+  # PR builds and release builds read and write one shared cache, and PR builds
+  # warm the exact cache the release pipeline later consumes. No registry
+  # login, no push capability, no secrets.
+  docker-build:
+    name: Docker image build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build image (push disabled)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # 7. AGGREGATE GATE (single predictable check name for ruleset)
   # The `needs:` list below is the SINGLE source of truth for which jobs gate
   # a merge. A new gate joins the aggregate simply by being listed here — the
   # pass/fail check rolls over every dependency via the `needs.*.result`
@@ -171,7 +195,7 @@ jobs:
   ci-passed:
     name: CI passed
     if: always()
-    needs: [detect-changes, quality, boundaries, commitlint, actionlint]
+    needs: [detect-changes, quality, boundaries, commitlint, actionlint, docker-build]
     runs-on: ubuntu-latest
     steps:
       - name: Check all prerequisites passed


### PR DESCRIPTION
Dockerfile breakage currently surfaces only on main or at release time. Add a build-only job to the PR pipeline that runs unconditionally, builds with push disabled, and needs no registry login or secrets. It uses the same bare GHA cache backend as the release workflow so PR builds warm the cache the release pipeline consumes. The job joins the aggregate gate via the single documented append to its needs list.

Refs #207