### PR TITLE
feat(depth-dive): add POST /dive tracer bullet with hardcoded animati…

### DIFF
--- a/api/src/api/routes/dive.py
+++ b/api/src/api/routes/dive.py
@@ -1,0 +1,28 @@
+"""Depth Dive route: POST /dive (depth-dive spec §9)."""
+
+from fastapi import APIRouter, HTTPException
+
+from core.types.depth_dive import HarnessBRequest, HarnessBResponse
+from depth_dive.harness import run_dive
+from depth_dive.transform import PassageTransformError
+
+router = APIRouter(tags=["dive"])
+
+
+@router.post("/dive", response_model=HarnessBResponse)
+def dive(body: HarnessBRequest) -> HarnessBResponse:
+    """Generate a Depth Dive interactive animation for a Captured Passage.
+
+    Returns 200 with a ``HarnessBResponse`` carrying the hardcoded demo
+    ``interactive_animation`` scene graph. Passages that violate the declared
+    size/bounds or that the tracer bullet does not support are rejected with
+    422 (``PassageTransformError``). Malformed request bodies return 422 via
+    FastAPI defaults.
+    """
+    try:
+        return run_dive(body.captured_passage)
+    except PassageTransformError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+__all__ = ["router"]

--- a/api/src/api/server.py
+++ b/api/src/api/server.py
@@ -3,6 +3,7 @@
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from api.routes.dive import router as dive_router
 from api.routes.documents import router as documents_router
 from api.routes.health import router as health_router
 from api.routes.ingest import router as ingest_router
@@ -27,6 +28,7 @@ def create_app() -> FastAPI:
     app.include_router(ingest_router)
     app.include_router(documents_router)
     app.include_router(query_router)
+    app.include_router(dive_router)
 
     app.add_exception_handler(
         UpstreamBadResponse,

--- a/api/tests/api/test_dive.py
+++ b/api/tests/api/test_dive.py
@@ -1,0 +1,164 @@
+"""Tests for the POST /dive route (depth-dive spec §9).
+
+The route needs no database session, so the ``mock_client`` fixture (real app,
+mocked upstream providers) exercises the full request -> transform -> response
+path without a Postgres instance.
+"""
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from depth_dive.transform import TEXT_PASSAGE_MAX_CHARS
+
+_VALID_BODY = {
+    "captured_passage": {
+        "passage_type": "text",
+        "content": "Attention is all you need.",
+    }
+}
+
+
+def _faulty_body(*, content: str) -> dict[str, Any]:
+    return {"captured_passage": {"passage_type": "text", "content": content}}
+
+
+# ============================================================
+# 422 — request validation (FastAPI / Pydantic defaults)
+# ============================================================
+
+
+def test_dive_missing_body_returns_422(mock_client: TestClient) -> None:
+    """POST /dive without a body returns 422 by FastAPI default."""
+    response = mock_client.post("/dive")
+    assert response.status_code == 422
+
+
+def test_dive_missing_captured_passage_returns_422(mock_client: TestClient) -> None:
+    """A body without captured_passage returns 422."""
+    response = mock_client.post("/dive", json={})
+    assert response.status_code == 422
+
+
+def test_dive_unknown_passage_type_returns_422(mock_client: TestClient) -> None:
+    """An unrecognized passage_type fails union validation with 422."""
+    response = mock_client.post("/dive", json={"captured_passage": {"passage_type": "audio"}})
+    assert response.status_code == 422
+
+
+def test_dive_invalid_chunk_id_returns_422(mock_client: TestClient) -> None:
+    """A malformed chunk_id anchor is rejected with 422."""
+    body = {
+        "captured_passage": {
+            "passage_type": "text",
+            "content": "text",
+            "chunk_id": "not-a-uuid",
+        }
+    }
+    response = mock_client.post("/dive", json=body)
+    assert response.status_code == 422
+
+
+# ============================================================
+# 422 — passage transform validation (size/bounds)
+# ============================================================
+
+
+def test_dive_empty_text_returns_422(mock_client: TestClient) -> None:
+    """Empty text content violates the transform bounds and returns 422."""
+    response = mock_client.post("/dive", json=_faulty_body(content=""))
+    assert response.status_code == 422
+    assert "detail" in response.json()
+
+
+def test_dive_oversized_text_returns_422(mock_client: TestClient) -> None:
+    """Text exceeding the declared size bound is rejected with 422, not cropped."""
+    response = mock_client.post(
+        "/dive", json=_faulty_body(content="x" * (TEXT_PASSAGE_MAX_CHARS + 1))
+    )
+    assert response.status_code == 422
+    assert "detail" in response.json()
+
+
+def test_dive_non_text_passage_returns_422(mock_client: TestClient) -> None:
+    """A non-text passage is unsupported by the MVP tracer bullet and returns 422."""
+    body = {
+        "captured_passage": {
+            "passage_type": "code",
+            "content": "def f():\n    return 1",
+            "language": "python",
+        }
+    }
+    response = mock_client.post("/dive", json=body)
+    assert response.status_code == 422
+    assert "detail" in response.json()
+
+
+# ============================================================
+# 200 — valid text passage returns the hardcoded animation
+# ============================================================
+
+
+def test_dive_returns_interactive_animation_scene_graph(mock_client: TestClient) -> None:
+    """A valid text passage returns 200 with elements, steps, and initial_state."""
+    response = mock_client.post("/dive", json=_VALID_BODY)
+    assert response.status_code == 200
+    body = response.json()
+    output = body["output"]
+    assert output["output_type"] == "interactive_animation"
+    assert output["elements"]
+    assert output["steps"]
+    assert output["initial_state"]
+    assert isinstance(output["title"], str)
+    assert output["viewport"]["width"] > 0
+    assert output["viewport"]["height"] > 0
+
+
+def test_dive_response_has_exact_field_set(mock_client: TestClient) -> None:
+    """The 200 body exposes exactly the HarnessBResponse spec §9 fields."""
+    response = mock_client.post("/dive", json=_VALID_BODY)
+    assert response.status_code == 200
+    assert set(response.json().keys()) == {
+        "output",
+        "recommended_treatments",
+        "applied_treatments",
+        "routing_note",
+        "grounded",
+        "external_search_attempted",
+        "external_search_failed",
+        "external_search_note",
+        "cited_passages",
+    }
+
+
+def test_dive_tracer_bullet_is_not_grounded(mock_client: TestClient) -> None:
+    """No retrieval runs in the tracer bullet: grounded=False, search flags off."""
+    response = mock_client.post("/dive", json=_VALID_BODY)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["grounded"] is False
+    assert body["external_search_attempted"] is False
+    assert body["external_search_failed"] is False
+    assert body["external_search_note"] is None
+    assert body["cited_passages"] == []
+
+
+def test_dive_applies_worked_example_treatment(mock_client: TestClient) -> None:
+    """The demo payload recommends and applies the worked_example treatment."""
+    response = mock_client.post("/dive", json=_VALID_BODY)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["recommended_treatments"] == ["worked_example"]
+    assert body["applied_treatments"] == ["worked_example"]
+    assert body["routing_note"] is None
+
+
+def test_dive_steps_reference_declared_elements(mock_client: TestClient) -> None:
+    """Every step's element_states key resolves to a declared scene element."""
+    response = mock_client.post("/dive", json=_VALID_BODY)
+    assert response.status_code == 200
+    output = response.json()["output"]
+    element_ids = {element["id"] for element in output["elements"]}
+    for step in output["steps"]:
+        for element_id in step["element_states"]:
+            assert element_id in element_ids

--- a/conftest.py
+++ b/conftest.py
@@ -26,6 +26,9 @@ from sqlalchemy.orm import Session, sessionmaker
 import api.controllers.qa_controller
 import api.server  # noqa: F401
 import core.retrieval.query  # noqa: F401
+import depth_dive.generation.demo_animation
+import depth_dive.harness
+import depth_dive.transform  # noqa: F401
 import ingestion.tasks  # noqa: F401
 import retrieval_qa.chunking.book_chunker
 import retrieval_qa.chunking.documentation_chunker

--- a/core/src/core/types/__init__.py
+++ b/core/src/core/types/__init__.py
@@ -1,11 +1,31 @@
 """Shared Pydantic boundary types."""
 
+from core.types.captured_passage import (
+    CapturedPassage,
+    CodePassage,
+    DiagramPassage,
+    ImagePassage,
+    TablePassage,
+    TextPassage,
+)
 from core.types.chat import ChatMessage
 from core.types.chunk import (
     BookChunkMetadata,
     Chunk,
     DocumentationChunkMetadata,
     PaperChunkMetadata,
+)
+from core.types.depth_dive import (
+    AnimationStep,
+    ElementState,
+    ElementStyle,
+    HarnessBRequest,
+    HarnessBResponse,
+    InteractionHints,
+    InteractiveAnimation,
+    SceneElement,
+    Treatment,
+    Viewport,
 )
 from core.types.document import (
     DocumentStatus,
@@ -22,18 +42,34 @@ from core.types.responses import (
 from core.types.retrieval_config import RetrievalConfig
 
 __all__ = [
+    "AnimationStep",
     "BookChunkMetadata",
+    "CapturedPassage",
     "ChatMessage",
     "Chunk",
     "CitedPassage",
+    "CodePassage",
+    "DiagramPassage",
     "DocumentStatus",
     "DocumentStatusResponse",
     "DocumentType",
     "DocumentationChunkMetadata",
+    "ElementState",
+    "ElementStyle",
     "HarnessARequest",
     "HarnessAResponse",
+    "HarnessBRequest",
+    "HarnessBResponse",
+    "ImagePassage",
+    "InteractionHints",
+    "InteractiveAnimation",
     "PaperChunkMetadata",
     "RetrievalConfig",
     "RetrievalResult",
+    "SceneElement",
     "ScoredChunk",
+    "TablePassage",
+    "TextPassage",
+    "Treatment",
+    "Viewport",
 ]

--- a/core/src/core/types/captured_passage.py
+++ b/core/src/core/types/captured_passage.py
@@ -1,0 +1,116 @@
+"""Captured Passage domain model (ADR-0021).
+
+A Captured Passage is the specific content a user selects or pastes to anchor a
+Depth Dive request. One of five passage types — text, image, diagram, table, or
+code snippet — modeled as a discriminated union keyed on ``passage_type``.
+
+The content is always carried in the request; the store is never the content
+source. Anchors are optional provenance/retrieval context: ``text`` and ``code``
+may anchor via ``chunk_id`` (ADR-0014); ``image``, ``diagram``, and ``table``
+anchor via ``document_id`` + document-relative ``ordinal``. Unanchored passages
+may carry an optional ``source`` URL as provenance only.
+"""
+
+from typing import Annotated, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+TableRow = list[str] | dict[str, str]
+"""Canonical structured table row: column cells or a header-keyed dict."""
+
+
+class _PassageBase(BaseModel):
+    """Shared ``source`` provenance field for every passage variant."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: str | None = None
+
+
+class TextPassage(_PassageBase):
+    """A captured text excerpt.
+
+    ``chunk_id`` optionally anchors the passage to an ingested chunk
+    (ADR-0014). Content is always carried in the request.
+    """
+
+    passage_type: Literal["text"] = "text"
+    content: str
+    chunk_id: UUID | None = None
+
+
+class CodePassage(_PassageBase):
+    """A captured code snippet.
+
+    ``language`` is a hint only — unvalidated free text. ``chunk_id``
+    optionally anchors the snippet to an ingested chunk (ADR-0014).
+    """
+
+    passage_type: Literal["code"] = "code"
+    content: str
+    language: str | None = None
+    chunk_id: UUID | None = None
+
+
+class _BinaryPassageBase(_PassageBase):
+    """Carrier shared by the image and diagram variants."""
+
+    content: bytes
+    media_type: Literal["image/png", "image/jpeg", "image/webp", "image/gif"]
+    caption: str | None = None
+    document_id: UUID | None = None
+    ordinal: str | None = None
+
+
+class ImagePassage(_BinaryPassageBase):
+    """A captured image.
+
+    ``document_id`` + ``ordinal`` form the optional parallel anchor,
+    distinct from the ``chunk_id`` anchor used by text/code.
+    """
+
+    passage_type: Literal["image"] = "image"
+
+
+class DiagramPassage(_BinaryPassageBase):
+    """A captured diagram.
+
+    Same carrier as ``ImagePassage`` but semantically distinct: diagrams may
+    feed an internal graph IR for harness routing/assembly. That IR is never
+    sent to the model as a graph.
+    """
+
+    passage_type: Literal["diagram"] = "diagram"
+
+
+class TablePassage(_PassageBase):
+    """A captured structured table.
+
+    ``rows`` carry the canonical structured form; ``headers`` is optional
+    header metadata. ``document_id`` + ``ordinal`` form the optional parallel
+    anchor.
+    """
+
+    passage_type: Literal["table"] = "table"
+    rows: list[TableRow]
+    headers: list[str] | None = None
+    caption: str | None = None
+    document_id: UUID | None = None
+    ordinal: str | None = None
+
+
+CapturedPassage = Annotated[
+    TextPassage | CodePassage | ImagePassage | DiagramPassage | TablePassage,
+    Field(discriminator="passage_type"),
+]
+"""Discriminated union keyed on ``passage_type`` (ADR-0021)."""
+
+__all__ = [
+    "CapturedPassage",
+    "CodePassage",
+    "DiagramPassage",
+    "ImagePassage",
+    "TablePassage",
+    "TextPassage",
+]

--- a/core/src/core/types/depth_dive.py
+++ b/core/src/core/types/depth_dive.py
@@ -1,0 +1,173 @@
+"""Harness B request/response and interactive-animation models (depth-dive spec §7-§9).
+
+``HarnessBRequest`` and ``HarnessBResponse`` are the ``POST /dive`` contract.
+``InteractiveAnimation`` is the MVP output: a declarative, stateless scene graph
+the client renders without further server calls (dual coding).
+"""
+
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from core.types.captured_passage import CapturedPassage
+from core.types.responses import CitedPassage
+
+
+class Treatment(StrEnum):
+    """Pedagogical patterns layered onto an interactive animation (spec §3).
+
+    Only the three MVP treatments are modeled; the deferred treatments
+    (``analogy_mapping``, ``elaborative_prompt``, ``interactive_concept_map``)
+    are eval-gated and out of the MVP type set.
+    """
+
+    WORKED_EXAMPLE = "worked_example"
+    PREDICTION_REVEAL = "prediction_reveal"
+    SEGMENTED_CAROUSEL = "segmented_carousel"
+
+
+class Viewport(BaseModel):
+    """Nominal scene dimensions.
+
+    Screen-size independence is the client's job; ``width``/``height`` are the
+    design-time coordinate space (prototype: 800 x 520).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    width: int = Field(gt=0)
+    height: int = Field(gt=0)
+
+
+class ElementStyle(BaseModel):
+    """Optional presentation hints for a scene element."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    fontSize: float | None = None
+    fontWeight: str | None = None
+    textAnchor: str | None = None
+    fill: str | None = None
+
+
+class SceneElement(BaseModel):
+    """A persistent scene primitive with a stable ID.
+
+    Type-specific payload lives in the optional fields (``text`` for
+    ``text``/``token``, ``label`` + ``color`` for ``vector``, ``value`` for
+    ``score``, ``style`` for text rendering). The exact primitive set is
+    finalized during implementation (spec §7).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    type: Literal["text", "token", "vector", "score", "arrow", "group"]
+    x: float
+    y: float
+    text: str | None = None
+    label: str | None = None
+    color: str | None = None
+    value: float | None = None
+    highlight: bool = False
+    style: ElementStyle | None = None
+
+
+class ElementState(BaseModel):
+    """A sparse per-element mutation applied by a step.
+
+    Fields are all optional so a step may update only what changes
+    (opacity, highlight, value, text).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    opacity: float | None = None
+    highlight: bool | None = None
+    value: float | None = None
+    text: str | None = None
+
+
+class AnimationStep(BaseModel):
+    """One ordered state in the animation, mutating ``element_states`` by ID."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    label: str
+    duration_ms: int | None = Field(default=None, gt=0)
+    segment: int | None = None
+    element_states: dict[str, ElementState]
+
+
+class InteractionHints(BaseModel):
+    """Optional interaction affordances the client may expose."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    click_to_advance: bool = True
+    reveal_on_last_step: list[str] = Field(default_factory=list)
+    segments: list[str] = Field(default_factory=list)
+
+
+class InteractiveAnimation(BaseModel):
+    """The ``interactive_animation`` output contract (spec §7).
+
+    A declarative, stateless scene graph: persistent ``elements`` plus ordered
+    ``steps`` that mutate ``element_states`` by element ID, seeded from
+    ``initial_state``. The entire artifact ships in the response.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    output_type: Literal["interactive_animation"] = "interactive_animation"
+    title: str
+    concept: str
+    viewport: Viewport
+    elements: list[SceneElement] = Field(min_length=1)
+    steps: list[AnimationStep] = Field(min_length=1)
+    initial_state: dict[str, ElementState]
+    interactions: InteractionHints = InteractionHints()
+
+
+class HarnessBRequest(BaseModel):
+    """Request body for ``POST /dive`` (spec §9)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    captured_passage: CapturedPassage
+    requested_output_type: Literal["interactive_animation"] | None = None
+    requested_treatments: list[Treatment] | None = None
+    preferred_treatments: list[Treatment] | None = None
+    client_passage_id: str | None = None
+
+
+class HarnessBResponse(BaseModel):
+    """Response body for ``POST /dive`` (spec §9)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    output: InteractiveAnimation
+    recommended_treatments: list[Treatment]
+    applied_treatments: list[Treatment]
+    routing_note: str | None = None
+    grounded: bool
+    external_search_attempted: bool
+    external_search_failed: bool
+    external_search_note: str | None = None
+    cited_passages: list[CitedPassage]
+
+
+__all__ = [
+    "AnimationStep",
+    "ElementState",
+    "ElementStyle",
+    "HarnessBRequest",
+    "HarnessBResponse",
+    "InteractionHints",
+    "InteractiveAnimation",
+    "SceneElement",
+    "Treatment",
+    "Viewport",
+]

--- a/core/tests/core/types/test_captured_passage.py
+++ b/core/tests/core/types/test_captured_passage.py
@@ -1,0 +1,139 @@
+"""Tests for the Captured Passage discriminated union (ADR-0021)."""
+
+from uuid import uuid4
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from core.types.captured_passage import (
+    CapturedPassage,
+    CodePassage,
+    DiagramPassage,
+    ImagePassage,
+    TablePassage,
+    TextPassage,
+)
+
+_PNG = b"\x89PNG\r\n\x1a\n"
+
+# ``CapturedPassage`` is an ``Annotated`` union alias; a ``TypeAdapter`` is the
+# runtime handle for validating payloads against it at module level.
+_captured_passage_adapter: TypeAdapter[CapturedPassage] = TypeAdapter(CapturedPassage)
+
+
+def test_text_passage_parses_discriminated_union() -> None:
+    """A text passage resolves to TextPassage with carried content."""
+    chunk_id = uuid4()
+    parsed = _captured_passage_adapter.validate_python(
+        {"passage_type": "text", "content": "Attention is all you need.", "chunk_id": str(chunk_id)}
+    )
+    assert isinstance(parsed, TextPassage)
+    assert parsed.content == "Attention is all you need."
+    assert parsed.chunk_id == chunk_id
+    assert parsed.source is None
+
+
+def test_text_passage_defaults_unanchored() -> None:
+    """A text passage without chunk_id or source parses as unanchored."""
+    parsed = _captured_passage_adapter.validate_python({"passage_type": "text", "content": "Hello"})
+    assert isinstance(parsed, TextPassage)
+    assert parsed.chunk_id is None
+    assert parsed.source is None
+
+
+def test_code_passage_parses_discriminated_union() -> None:
+    """A code passage carries content, language, and optional chunk anchor."""
+    parsed = _captured_passage_adapter.validate_python(
+        {
+            "passage_type": "code",
+            "content": "def f():\n    return 1",
+            "language": "python",
+            "source": "https://example.com/snippet",
+        }
+    )
+    assert isinstance(parsed, CodePassage)
+    assert parsed.language == "python"
+    assert parsed.source == "https://example.com/snippet"
+
+
+def test_image_passage_parses_bytes_and_media_type() -> None:
+    """An image passage carries raw bytes and a validated media type."""
+    document_id = uuid4()
+    parsed = _captured_passage_adapter.validate_python(
+        {
+            "passage_type": "image",
+            "content": _PNG,
+            "media_type": "image/png",
+            "caption": "Figure 1",
+            "document_id": str(document_id),
+            "ordinal": "Figure 1",
+        }
+    )
+    assert isinstance(parsed, ImagePassage)
+    assert parsed.content == _PNG
+    assert parsed.document_id == document_id
+    assert parsed.ordinal == "Figure 1"
+
+
+def test_image_passage_rejects_unsupported_media_type() -> None:
+    """An image passage rejects a media type outside the allowed set."""
+    with pytest.raises(ValidationError):
+        _captured_passage_adapter.validate_python(
+            {"passage_type": "image", "content": _PNG, "media_type": "image/svg+xml"}
+        )
+
+
+def test_diagram_passage_is_distinct_variant() -> None:
+    """A diagram passage parses to DiagramPassage with the same carrier shape."""
+    parsed = _captured_passage_adapter.validate_python(
+        {"passage_type": "diagram", "content": _PNG, "media_type": "image/jpeg"}
+    )
+    assert isinstance(parsed, DiagramPassage)
+
+
+def test_table_passage_parses_rows_and_headers() -> None:
+    """A table passage carries structured rows plus optional headers."""
+    parsed = _captured_passage_adapter.validate_python(
+        {
+            "passage_type": "table",
+            "rows": [["a", "1"], ["b", "2"]],
+            "headers": ["letter", "number"],
+            "caption": "Table 1",
+        }
+    )
+    assert isinstance(parsed, TablePassage)
+    assert parsed.rows == [["a", "1"], ["b", "2"]]
+    assert parsed.headers == ["letter", "number"]
+
+
+def test_table_passage_accepts_header_keyed_row_dicts() -> None:
+    """A table passage accepts dict rows keyed by header."""
+    parsed = _captured_passage_adapter.validate_python(
+        {"passage_type": "table", "rows": [{"letter": "a", "number": "1"}]}
+    )
+    assert isinstance(parsed, TablePassage)
+    assert parsed.rows == [{"letter": "a", "number": "1"}]
+
+
+def test_missing_discriminator_rejects() -> None:
+    """A passage without passage_type fails union validation."""
+    with pytest.raises(ValidationError):
+        _captured_passage_adapter.validate_python({"content": "no type"})
+
+
+def test_unknown_discriminator_rejects() -> None:
+    """An unknown passage_type fails union validation."""
+    with pytest.raises(ValidationError):
+        _captured_passage_adapter.validate_python({"passage_type": "audio", "content": "x"})
+
+
+def test_variant_rejects_extra_fields() -> None:
+    """Passage variants forbid undeclared fields (boundary hygiene)."""
+    with pytest.raises(ValidationError):
+        TextPassage(content="x", surprise=True)  # type: ignore[call-arg]
+
+
+def test_content_always_carried_not_lazy() -> None:
+    """Content is a required field; a passage without it fails validation."""
+    with pytest.raises(ValidationError):
+        _captured_passage_adapter.validate_python({"passage_type": "text"})

--- a/core/tests/core/types/test_depth_dive.py
+++ b/core/tests/core/types/test_depth_dive.py
@@ -1,0 +1,166 @@
+"""Tests for the Depth Dive (Harness B) request/response and scene-graph models."""
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from core.types.captured_passage import TextPassage
+from core.types.depth_dive import (
+    AnimationStep,
+    ElementState,
+    HarnessBRequest,
+    HarnessBResponse,
+    InteractionHints,
+    InteractiveAnimation,
+    SceneElement,
+    Treatment,
+    Viewport,
+)
+from core.types.responses import CitedPassage
+
+
+def _animation() -> InteractiveAnimation:
+    """A minimal valid scene graph for request/response tests."""
+    return InteractiveAnimation(
+        output_type="interactive_animation",
+        title="Self-attention",
+        concept="attention",
+        viewport=Viewport(width=800, height=520),
+        elements=[SceneElement(id="title", type="text", x=400, y=36, text="Self-attention")],
+        steps=[
+            AnimationStep(
+                id="setup",
+                label="Show the title.",
+                duration_ms=1500,
+                element_states={"title": ElementState(opacity=1)},
+            )
+        ],
+        initial_state={"title": ElementState(opacity=1)},
+        interactions=InteractionHints(click_to_advance=True),
+    )
+
+
+def test_harness_b_request_accepts_text_passage() -> None:
+    """HarnessBRequest parses a text Captured Passage and optional hints."""
+    body = HarnessBRequest(
+        captured_passage=TextPassage(content="Attention is all you need."),
+        requested_treatments=[Treatment.WORKED_EXAMPLE],
+        client_passage_id="ui-123",
+    )
+    assert isinstance(body.captured_passage, TextPassage)
+    assert body.requested_treatments == [Treatment.WORKED_EXAMPLE]
+    assert body.client_passage_id == "ui-123"
+    assert body.requested_output_type is None
+
+
+def test_harness_b_request_rejects_missing_passage() -> None:
+    """HarnessBRequest requires a captured passage."""
+    with pytest.raises(ValidationError):
+        HarnessBRequest()  # type: ignore[call-arg]
+
+
+def test_harness_b_request_rejects_unknown_output_type() -> None:
+    """HarnessBRequest restricts requested_output_type to interactive_animation."""
+    with pytest.raises(ValidationError):
+        HarnessBRequest(
+            captured_passage=TextPassage(content="x"),
+            requested_output_type="carousel",  # type: ignore[arg-type]
+        )
+
+
+def test_harness_b_response_serializes_scene_graph() -> None:
+    """A grounded HarnessBResponse round-trips output, treatments, and citations."""
+    chunk_id = uuid4()
+    response = HarnessBResponse(
+        output=_animation(),
+        recommended_treatments=[Treatment.WORKED_EXAMPLE],
+        applied_treatments=[Treatment.WORKED_EXAMPLE],
+        grounded=True,
+        external_search_attempted=False,
+        external_search_failed=False,
+        cited_passages=[CitedPassage(chunk_id=chunk_id, text="full chunk")],
+    )
+    dumped = response.model_dump(mode="json")
+    assert dumped["output"]["output_type"] == "interactive_animation"
+    assert dumped["output"]["elements"][0]["id"] == "title"
+    assert dumped["applied_treatments"] == ["worked_example"]
+    assert dumped["cited_passages"][0]["chunk_id"] == str(chunk_id)
+    assert dumped["grounded"] is True
+
+
+def test_harness_b_response_rejects_unknown_treatment() -> None:
+    """applied_treatments only accepts the three MVP treatments."""
+    with pytest.raises(ValidationError):
+        HarnessBResponse(
+            output=_animation(),
+            recommended_treatments=[Treatment.WORKED_EXAMPLE],
+            applied_treatments=["voodoo"],  # type: ignore[list-item]
+            grounded=False,
+            external_search_attempted=False,
+            external_search_failed=False,
+            cited_passages=[],
+        )
+
+
+def test_harness_b_response_has_exact_field_set() -> None:
+    """HarnessBResponse exposes exactly the spec §9 fields."""
+    fields = set(HarnessBResponse.model_fields)
+    assert fields == {
+        "output",
+        "recommended_treatments",
+        "applied_treatments",
+        "routing_note",
+        "grounded",
+        "external_search_attempted",
+        "external_search_failed",
+        "external_search_note",
+        "cited_passages",
+    }
+
+
+def test_interactive_animation_requires_elements_steps_initial_state() -> None:
+    """The scene graph requires non-empty elements/steps and an initial_state."""
+    with pytest.raises(ValidationError):
+        InteractiveAnimation(
+            output_type="interactive_animation",
+            title="T",
+            concept="c",
+            viewport=Viewport(width=800, height=520),
+            elements=[],
+            steps=[],
+            initial_state={},
+        )
+
+
+def test_interactive_animation_forbids_extra_fields() -> None:
+    """Undeclared scene-graph fields are rejected at the boundary."""
+    with pytest.raises(ValidationError):
+        InteractiveAnimation(
+            output_type="interactive_animation",
+            title="T",
+            concept="c",
+            viewport=Viewport(width=800, height=520),
+            elements=[SceneElement(id="t", type="text", x=0, y=0)],
+            steps=[AnimationStep(id="s", label="l", element_states={})],
+            initial_state={},
+            unexpected=True,  # type: ignore[call-arg]
+        )
+
+
+def test_element_state_is_sparse() -> None:
+    """ElementState accepts only the four mutable fields."""
+    state = ElementState(opacity=0.5, value=0.15)
+    assert state.opacity == 0.5
+    assert state.value == 0.15
+    assert state.highlight is None
+    assert state.text is None
+
+
+def test_treatment_enum_has_three_mvp_values() -> None:
+    """Treatment exposes exactly the three MVP treatments as str values."""
+    assert [t.value for t in Treatment] == [
+        "worked_example",
+        "prediction_reveal",
+        "segmented_carousel",
+    ]

--- a/depth_dive/src/depth_dive/__init__.py
+++ b/depth_dive/src/depth_dive/__init__.py
@@ -1,3 +1,11 @@
-"""Depth Dive package (Harness B)."""
+"""Depth Dive package (Harness B).
 
-__all__: list[str] = []
+Owns the passage-transform validation stage, the two-agent harness (framing +
+assembly; stubbed for the MVP tracer bullet), the similarity-gate policy, and
+the generative artifacts. Consumes ``core/retrieval/`` primitives (ADR-0019)
+once retrieval participates, and never imports ``retrieval_qa`` (ADR-0011).
+"""
+
+from depth_dive.harness import run_dive
+
+__all__ = ["run_dive"]

--- a/depth_dive/src/depth_dive/generation/__init__.py
+++ b/depth_dive/src/depth_dive/generation/__init__.py
@@ -1,0 +1,11 @@
+"""Hardcoded demo artifacts for the MVP tracer bullet.
+
+Replaces the assembly agent (ADR-0020) until real generation lands: every
+``POST /dive`` returns the same self-attention ``interactive_animation`` scene
+graph, proving the contract, type wiring, and passage-transform validation
+end-to-end.
+"""
+
+from depth_dive.generation.demo_animation import build_demo_animation
+
+__all__ = ["build_demo_animation"]

--- a/depth_dive/src/depth_dive/generation/demo_animation.py
+++ b/depth_dive/src/depth_dive/generation/demo_animation.py
@@ -1,0 +1,154 @@
+"""Builder for the hardcoded self-attention demo animation.
+
+The scene graph mirrors the ``prototype/interactive-animation-contract``
+worked example (`[river, bank, money]`): a persistent element set plus four
+ordered steps that mutate ``element_states`` per element ID, seeded from
+``initial_state``. Static by design — the tracer bullet returns this payload
+for every valid text passage.
+"""
+
+from core.types.depth_dive import (
+    AnimationStep,
+    ElementState,
+    ElementStyle,
+    InteractionHints,
+    InteractiveAnimation,
+    SceneElement,
+    Viewport,
+)
+
+_DEFAULT_VIEWPORT = Viewport(width=800, height=520)
+_TEXT_STYLE = ElementStyle(fontSize=13, textAnchor="middle", fill="var(--muted)")
+
+_ACCENT = "var(--accent)"
+_ACCENT_2 = "var(--accent-2)"
+_OK = "var(--ok)"
+_WARN = "var(--warn)"
+
+
+# Match the prototype's defaults for every element the renderer interpolates.
+def build_demo_animation() -> InteractiveAnimation:
+    """Return the hardcoded self-attention ``interactive_animation`` payload."""
+    elements = [
+        SceneElement(
+            id="title",
+            type="text",
+            x=400,
+            y=36,
+            text="Self-attention: bank",
+            style=ElementStyle(fontSize=20, fontWeight="bold", textAnchor="middle"),
+        ),
+        SceneElement(id="tok-river", type="token", x=160, y=100, text="river"),
+        SceneElement(id="tok-bank", type="token", x=400, y=100, text="bank"),
+        SceneElement(id="tok-money", type="token", x=640, y=100, text="money"),
+        SceneElement(id="q-label", type="text", x=160, y=200, text="Query (Q)", style=_TEXT_STYLE),
+        SceneElement(id="k-label", type="text", x=400, y=200, text="Key (K)", style=_TEXT_STYLE),
+        SceneElement(id="v-label", type="text", x=640, y=200, text="Value (V)", style=_TEXT_STYLE),
+        SceneElement(id="q-bank", type="vector", x=160, y=240, label="Q_bank", color=_ACCENT),
+        SceneElement(id="k-river", type="vector", x=400, y=240, label="K_river", color=_ACCENT_2),
+        SceneElement(id="k-bank", type="vector", x=400, y=300, label="K_bank", color=_ACCENT_2),
+        SceneElement(id="k-money", type="vector", x=400, y=360, label="K_money", color=_ACCENT_2),
+        SceneElement(id="v-river", type="vector", x=640, y=240, label="V_river", color=_OK),
+        SceneElement(id="v-bank", type="vector", x=640, y=300, label="V_bank", color=_OK),
+        SceneElement(id="v-money", type="vector", x=640, y=360, label="V_money", color=_OK),
+        SceneElement(id="score-river", type="score", x=280, y=260, value=0.15),
+        SceneElement(id="score-bank", type="score", x=280, y=300, value=0.35),
+        SceneElement(id="score-money", type="score", x=280, y=340, value=0.50),
+        SceneElement(
+            id="out-bank",
+            type="vector",
+            x=400,
+            y=470,
+            label="context(bank)",
+            color=_WARN,
+        ),
+        SceneElement(id="caption", type="text", x=400, y=510, text="", style=_TEXT_STYLE),
+    ]
+
+    setup = AnimationStep(
+        id="setup",
+        label="Three input words. We want a context-aware meaning for 'bank'.",
+        duration_ms=1500,
+        element_states={
+            "title": ElementState(opacity=1),
+            "tok-river": ElementState(opacity=1),
+            "tok-bank": ElementState(opacity=1, highlight=True),
+            "tok-money": ElementState(opacity=1),
+            "q-label": ElementState(opacity=0),
+            "k-label": ElementState(opacity=0),
+            "v-label": ElementState(opacity=0),
+            "q-bank": ElementState(opacity=0),
+            "k-river": ElementState(opacity=0),
+            "k-bank": ElementState(opacity=0),
+            "k-money": ElementState(opacity=0),
+            "v-river": ElementState(opacity=0),
+            "v-bank": ElementState(opacity=0),
+            "v-money": ElementState(opacity=0),
+            "score-river": ElementState(opacity=0),
+            "score-bank": ElementState(opacity=0),
+            "score-money": ElementState(opacity=0),
+            "out-bank": ElementState(opacity=0),
+            "caption": ElementState(opacity=1, text="Input: [river, bank, money]"),
+        },
+    )
+
+    steps = [
+        setup,
+        AnimationStep(
+            id="qkv",
+            label="For every word, the model builds a Query, Key, and Value vector.",
+            duration_ms=2000,
+            element_states={
+                "q-label": ElementState(opacity=1),
+                "k-label": ElementState(opacity=1),
+                "v-label": ElementState(opacity=1),
+                "q-bank": ElementState(opacity=1),
+                "k-river": ElementState(opacity=1),
+                "k-bank": ElementState(opacity=1),
+                "k-money": ElementState(opacity=1),
+                "v-river": ElementState(opacity=1),
+                "v-bank": ElementState(opacity=1),
+                "v-money": ElementState(opacity=1),
+                "caption": ElementState(text="Q, K, V are learned projections of each token."),
+            },
+        ),
+        AnimationStep(
+            id="scores",
+            label="Query bank is compared to every Key to produce attention scores.",
+            duration_ms=2500,
+            element_states={
+                "score-river": ElementState(opacity=1, value=0.15),
+                "score-bank": ElementState(opacity=1, value=0.35),
+                "score-money": ElementState(opacity=1, value=0.50),
+                "caption": ElementState(text="Higher score = more relevant context for 'bank'."),
+            },
+        ),
+        AnimationStep(
+            id="weighted",
+            label="Scores become weights; Values sum into the new 'bank' representation.",
+            duration_ms=2500,
+            element_states={
+                "out-bank": ElementState(opacity=1),
+                "score-river": ElementState(value=0.15),
+                "score-bank": ElementState(value=0.35),
+                "score-money": ElementState(value=0.50),
+                "caption": ElementState(
+                    text="context(bank) = 0.15*V_river + 0.35*V_bank + 0.50*V_money"
+                ),
+            },
+        ),
+    ]
+
+    return InteractiveAnimation(
+        output_type="interactive_animation",
+        title="Self-attention: how a word sees its neighbors",
+        concept="attention",
+        viewport=_DEFAULT_VIEWPORT,
+        elements=elements,
+        steps=steps,
+        initial_state=dict(setup.element_states.items()),
+        interactions=InteractionHints(click_to_advance=True),
+    )
+
+
+__all__ = ["build_demo_animation"]

--- a/depth_dive/src/depth_dive/harness.py
+++ b/depth_dive/src/depth_dive/harness.py
@@ -1,0 +1,43 @@
+"""Harness B entrypoint (ADR-0020).
+
+Runs the Depth Dive pipeline for one Captured Passage and returns a
+``HarnessBResponse``. The full two-agent pipeline (framing then assembly) is
+deferred; the MVP tracer bullet validates the passage via the Passage Transform
+stage and returns the hardcoded demo ``interactive_animation``. No retrieval,
+web search, or per-learner state participates yet, so ``grounded`` is always
+``False`` and the search flags are off.
+"""
+
+from core.types.captured_passage import CapturedPassage
+from core.types.depth_dive import HarnessBResponse, Treatment
+from depth_dive.generation.demo_animation import build_demo_animation
+from depth_dive.transform import transform_passage
+
+
+def run_dive(passage: CapturedPassage) -> HarnessBResponse:
+    """Validate a Captured Passage and return the tracer-bullet dive response.
+
+    Args:
+        passage: The captured passage carried in the ``HarnessBRequest``.
+
+    Returns:
+        A ``HarnessBResponse`` whose ``output`` is the hardcoded demo
+        ``interactive_animation`` scene graph.
+
+    Raises:
+        PassageTransformError: The passage violates the declared size/bounds
+            or is a type this harness does not yet support.
+    """
+    transform_passage(passage)
+    return HarnessBResponse(
+        output=build_demo_animation(),
+        recommended_treatments=[Treatment.WORKED_EXAMPLE],
+        applied_treatments=[Treatment.WORKED_EXAMPLE],
+        grounded=False,
+        external_search_attempted=False,
+        external_search_failed=False,
+        cited_passages=[],
+    )
+
+
+__all__ = ["run_dive"]

--- a/depth_dive/src/depth_dive/transform.py
+++ b/depth_dive/src/depth_dive/transform.py
@@ -1,0 +1,69 @@
+"""Passage Transform stage (depth-dive spec §5).
+
+Runs before the framing agent: validates the carried content against the
+declared ``passage_type``, normalizes, and emits model-ready content blocks.
+For the MVP tracer bullet only ``text`` passes are transformable; other
+passage types raise ``PassageTransformError`` until their transforms land.
+
+Requests exceeding declared bounds are rejected (422 via the route), never
+silently cropped.
+"""
+
+from core.types.captured_passage import CapturedPassage, TextPassage
+
+TEXT_PASSAGE_MAX_CHARS = 100_000
+"""MVP size bound for text passages (spec §5: bounded by model token budget)."""
+
+
+class PassageTransformError(Exception):
+    """A captured passage violated transform validation or is unsupported.
+
+    Raised for size-bound violations and for passage types the transform
+    cannot yet process. The route layer maps this to a 422 response.
+    """
+
+
+def transform_passage(passage: CapturedPassage) -> str:
+    """Validate a captured passage and return the model-ready text block.
+
+    Args:
+        passage: The captured passage carried in the request.
+
+    Returns:
+        The normalized (stripped) text content for ``text`` passages.
+
+    Raises:
+        PassageTransformError: The passage content violates the declared
+            bounds, or the passage type is not supported by this transform.
+    """
+    if isinstance(passage, TextPassage):
+        return _transform_text(passage.content)
+    raise PassageTransformError(
+        f"passage_type {passage.passage_type!r} is not supported by the MVP tracer bullet"
+    )
+
+
+def _transform_text(content: str) -> str:
+    """Validate and normalize a text passage.
+
+    Args:
+        content: The raw captured text content.
+
+    Returns:
+        The stripped text content.
+
+    Raises:
+        PassageTransformError: The content is empty/whitespace-only or
+            exceeds ``TEXT_PASSAGE_MAX_CHARS`` characters.
+    """
+    stripped = content.strip()
+    if not stripped:
+        raise PassageTransformError("text passage content must be non-empty")
+    if len(stripped) > TEXT_PASSAGE_MAX_CHARS:
+        raise PassageTransformError(
+            f"text passage content exceeds the {TEXT_PASSAGE_MAX_CHARS} character limit"
+        )
+    return stripped
+
+
+__all__ = ["TEXT_PASSAGE_MAX_CHARS", "PassageTransformError", "transform_passage"]

--- a/depth_dive/tests/depth_dive/generation/test_demo_animation.py
+++ b/depth_dive/tests/depth_dive/generation/test_demo_animation.py
@@ -1,0 +1,53 @@
+"""Tests for the hardcoded demo animation builder."""
+
+from depth_dive.generation.demo_animation import build_demo_animation
+
+
+def test_demo_animation_is_interactive_animation() -> None:
+    """The demo payload declares the interactive_animation output type."""
+    animation = build_demo_animation()
+    assert animation.output_type == "interactive_animation"
+
+
+def test_demo_animation_has_persistent_elements() -> None:
+    """The scene graph ships a non-empty element set with stable IDs."""
+    animation = build_demo_animation()
+    assert len(animation.elements) > 0
+    ids = {element.id for element in animation.elements}
+    assert len(ids) == len(animation.elements)  # no duplicate element IDs
+
+
+def test_demo_animation_has_ordered_steps() -> None:
+    """The scene graph ships a non-empty, labeled step sequence."""
+    animation = build_demo_animation()
+    assert len(animation.steps) > 0
+    for step in animation.steps:
+        assert step.id
+        assert step.label
+        assert step.duration_ms is not None
+        assert step.duration_ms > 0
+
+
+def test_demo_animation_has_initial_state() -> None:
+    """initial_state seeds every element with a state."""
+    animation = build_demo_animation()
+    assert animation.initial_state
+    for element in animation.elements:
+        assert element.id in animation.initial_state
+
+
+def test_demo_animation_steps_mutate_element_ids() -> None:
+    """Every state key in a step references a declared element ID."""
+    animation = build_demo_animation()
+    declared_ids = {element.id for element in animation.elements}
+    for step in animation.steps:
+        for element_id in step.element_states:
+            assert element_id in declared_ids
+
+
+def test_demo_animation_has_viewport_and_treatment_agnostic_hints() -> None:
+    """The payload carries a viewport and click-to-advance interaction."""
+    animation = build_demo_animation()
+    assert animation.viewport.width > 0
+    assert animation.viewport.height > 0
+    assert animation.interactions.click_to_advance is True

--- a/depth_dive/tests/depth_dive/test_harness.py
+++ b/depth_dive/tests/depth_dive/test_harness.py
@@ -1,0 +1,63 @@
+"""Tests for the Depth Dive harness entrypoint (ADR-0020)."""
+
+import pytest
+from pydantic import TypeAdapter
+
+from core.types.captured_passage import CapturedPassage, TextPassage
+from core.types.depth_dive import HarnessBResponse, InteractiveAnimation, Treatment
+from depth_dive.harness import run_dive
+from depth_dive.transform import PassageTransformError
+
+_VALID_TEXT = TextPassage(content="Attention is all you need.")
+_captured_passage_adapter: TypeAdapter[CapturedPassage] = TypeAdapter(CapturedPassage)
+
+
+def test_run_dive_returns_hardcoded_animation() -> None:
+    """A valid text passage yields a HarnessBResponse with the demo animation."""
+    response = run_dive(_VALID_TEXT)
+    assert isinstance(response, HarnessBResponse)
+    assert isinstance(response.output, InteractiveAnimation)
+    assert response.output.output_type == "interactive_animation"
+    assert len(response.output.elements) > 0
+    assert len(response.output.steps) > 0
+    assert response.output.initial_state
+
+
+def test_run_dive_response_is_not_grounded_without_retrieval() -> None:
+    """No retrieval/search runs in the tracer bullet: grounded=False, search off."""
+    response = run_dive(_VALID_TEXT)
+    assert response.grounded is False
+    assert response.external_search_attempted is False
+    assert response.external_search_failed is False
+    assert response.external_search_note is None
+    assert response.cited_passages == []
+
+
+def test_run_dive_recommends_and_applies_worked_example() -> None:
+    """The demo treats the passage as a worked_example; no routing overrides."""
+    response = run_dive(_VALID_TEXT)
+    assert response.recommended_treatments == [Treatment.WORKED_EXAMPLE]
+    assert response.applied_treatments == [Treatment.WORKED_EXAMPLE]
+    assert response.routing_note is None
+
+
+def test_run_dive_output_is_static_across_passages() -> None:
+    """The tracer bullet returns the identical hardcoded payload for any text."""
+    first = run_dive(_VALID_TEXT)
+    second = run_dive(TextPassage(content="A completely different passage."))
+    assert first.model_dump() == second.model_dump()
+
+
+def test_run_dive_validates_before_building() -> None:
+    """A passage violating text bounds is rejected, not silently built."""
+    with pytest.raises(PassageTransformError):
+        run_dive(TextPassage(content=""))
+
+
+def test_run_dive_accepts_type_checked_union_payload() -> None:
+    """The union type parses request-shaped payloads before the harness runs."""
+    passage = _captured_passage_adapter.validate_python(
+        {"passage_type": "text", "content": "Typed union payload", "chunk_id": None}
+    )
+    response = run_dive(passage)
+    assert response.output.output_type == "interactive_animation"

--- a/depth_dive/tests/depth_dive/test_transform.py
+++ b/depth_dive/tests/depth_dive/test_transform.py
@@ -1,0 +1,61 @@
+"""Tests for the Passage Transform stage (depth-dive spec §5)."""
+
+import pytest
+
+from core.types.captured_passage import CodePassage, ImagePassage, TextPassage
+from depth_dive.transform import (
+    TEXT_PASSAGE_MAX_CHARS,
+    PassageTransformError,
+    transform_passage,
+)
+
+
+def test_text_passage_returns_stripped_content() -> None:
+    """A valid text passage normalizes to its stripped content."""
+    result = transform_passage(TextPassage(content="  Attention is all you need.  "))
+    assert result == "Attention is all you need."
+
+
+def test_text_passage_with_anchor_transforms() -> None:
+    """An anchored text passage still transforms; the anchor is ignored here."""
+    result = transform_passage(TextPassage(content="Hello world"))
+    assert result == "Hello world"
+
+
+def test_empty_text_content_is_rejected() -> None:
+    """Empty text content fails transform validation."""
+    with pytest.raises(PassageTransformError):
+        transform_passage(TextPassage(content=""))
+
+
+def test_whitespace_only_text_content_is_rejected() -> None:
+    """Whitespace-only text content fails transform validation."""
+    with pytest.raises(PassageTransformError):
+        transform_passage(TextPassage(content="   \n\t  "))
+
+
+def test_oversized_text_content_is_rejected() -> None:
+    """Text exceeding the declared character bound fails transform validation."""
+    with pytest.raises(PassageTransformError):
+        transform_passage(TextPassage(content="x" * (TEXT_PASSAGE_MAX_CHARS + 1)))
+
+
+def test_boundary_text_content_is_accepted() -> None:
+    """Text exactly at the declared bound is accepted."""
+    result = transform_passage(TextPassage(content="x" * TEXT_PASSAGE_MAX_CHARS))
+    assert len(result) == TEXT_PASSAGE_MAX_CHARS
+
+
+def test_bound_measures_normalized_not_raw_content() -> None:
+    """The bound applies to the stripped content, matching the returned value."""
+    content = "x" * TEXT_PASSAGE_MAX_CHARS
+    result = transform_passage(TextPassage(content=f"  {content}  "))
+    assert len(result) == TEXT_PASSAGE_MAX_CHARS
+
+
+def test_non_text_types_are_rejected_for_tracer_bullet() -> None:
+    """Non-text passage types are unsupported by the MVP tracer bullet."""
+    with pytest.raises(PassageTransformError):
+        transform_passage(CodePassage(content="def f():\n    pass"))
+    with pytest.raises(PassageTransformError):
+        transform_passage(ImagePassage(content=b"\x89PNG", media_type="image/png"))


### PR DESCRIPTION
…on

Add the Harness B tracer bullet: a text Captured Passage carried in a HarnessBRequest validates through the Passage Transform stage and returns the hardcoded self-attention interactive_animation scene graph.

- core/types: CapturedPassage union (five variants, ADR-0021) and depth_dive models (HarnessBRequest/Response, InteractiveAnimation scene graph, Treatment)
- depth_dive: transform stage with text size bounds (422 on violation), harness entrypoint, and demo animation builder (stubbed assembly agent)
- api: POST /dive route mapping PassageTransformError to 422

Retrieval, web search, and the similarity gate are out of tracer-bullet scope; grounded is always False and search flags are off (ADR-0020).