### PR TITLE
feat(depth-dive): add framing agent with treatment routing and search…

### DIFF
--- a/api/src/api/routes/dive.py
+++ b/api/src/api/routes/dive.py
@@ -20,7 +20,7 @@ def dive(body: HarnessBRequest) -> HarnessBResponse:
     FastAPI defaults.
     """
     try:
-        return run_dive(body.captured_passage)
+        return run_dive(body)
     except PassageTransformError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 

--- a/api/tests/api/test_dive.py
+++ b/api/tests/api/test_dive.py
@@ -196,6 +196,28 @@ def test_dive_steps_reference_declared_elements(mock_client: TestClient) -> None
             assert element_id in element_ids
 
 
+def test_dive_explicit_request_override_routes_treatment(mock_client: TestClient) -> None:
+    """An explicit requested treatment wins over the recommendation with a note."""
+    body = {**_VALID_BODY, "requested_treatments": ["segmented_carousel"]}
+    response = mock_client.post("/dive", json=body)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["recommended_treatments"] == ["worked_example"]
+    assert data["applied_treatments"] == ["segmented_carousel"]
+    assert data["routing_note"] is not None
+
+
+def test_dive_deferred_treatment_is_accepted_and_routed_not_422(mock_client: TestClient) -> None:
+    """A deferred requested treatment is accepted, dropped, and noted (not a 422)."""
+    body = {**_VALID_BODY, "requested_treatments": ["analogy_mapping"]}
+    response = mock_client.post("/dive", json=body)
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["applied_treatments"] == ["worked_example"]
+    assert data["routing_note"] is not None
+    assert "analogy_mapping" in data["routing_note"]
+
+
 # ============================================================
 # 200 + 422 — image, diagram, and table passages
 # ============================================================

--- a/core/src/core/types/depth_dive.py
+++ b/core/src/core/types/depth_dive.py
@@ -15,16 +15,33 @@ from core.types.responses import CitedPassage
 
 
 class Treatment(StrEnum):
-    """Pedagogical patterns layered onto an interactive animation (spec §3).
+    """MVP pedagogical patterns layered onto an interactive animation (spec §3).
 
-    Only the three MVP treatments are modeled; the deferred treatments
-    (``analogy_mapping``, ``elaborative_prompt``, ``interactive_concept_map``)
-    are eval-gated and out of the MVP type set.
+    These are the treatments the harness can actually produce. The deferred
+    treatments live in :class:`DeferredTreatment` so a request can name them
+    and be routed (with a ``routing_note``) rather than rejected.
     """
 
     WORKED_EXAMPLE = "worked_example"
     PREDICTION_REVEAL = "prediction_reveal"
     SEGMENTED_CAROUSEL = "segmented_carousel"
+
+
+class DeferredTreatment(StrEnum):
+    """Eval-gated treatments that are deferred from the MVP type set (spec §3).
+
+    Modeled separately from :class:`Treatment` so clients can still name them
+    in a request hint; the framing agent drops them with a ``routing_note`` and
+    they never appear in the applied/recommended response fields.
+    """
+
+    ANALOGY_MAPPING = "analogy_mapping"
+    ELABORATIVE_PROMPT = "elaborative_prompt"
+    INTERACTIVE_CONCEPT_MAP = "interactive_concept_map"
+
+
+TreatmentHint = Treatment | DeferredTreatment
+"""Any treatment name a request may carry, MVP supported or deferred."""
 
 
 class Viewport(BaseModel):
@@ -138,8 +155,8 @@ class HarnessBRequest(BaseModel):
 
     captured_passage: CapturedPassage
     requested_output_type: Literal["interactive_animation"] | None = None
-    requested_treatments: list[Treatment] | None = None
-    preferred_treatments: list[Treatment] | None = None
+    requested_treatments: list[TreatmentHint] | None = None
+    preferred_treatments: list[TreatmentHint] | None = None
     client_passage_id: str | None = None
 
 
@@ -161,6 +178,7 @@ class HarnessBResponse(BaseModel):
 
 __all__ = [
     "AnimationStep",
+    "DeferredTreatment",
     "ElementState",
     "ElementStyle",
     "HarnessBRequest",
@@ -169,5 +187,6 @@ __all__ = [
     "InteractiveAnimation",
     "SceneElement",
     "Treatment",
+    "TreatmentHint",
     "Viewport",
 ]

--- a/depth_dive/src/depth_dive/framing/__init__.py
+++ b/depth_dive/src/depth_dive/framing/__init__.py
@@ -1,0 +1,12 @@
+"""Framing agent: emits the internal creative brief (ADR-0020, ticket #242).
+
+The framing agent consumes a ``CapturedPassage`` plus optional request hints,
+decides whether external grounding (web search) would help this specific dive
+(ADR-0012), and resolves the final treatment set through the precedence rules
+(explicit ask > preferred > harness recommendation). The brief it emits stays
+internal and is not exposed in ``HarnessBResponse``.
+"""
+
+from depth_dive.framing.framing_agent import FramingBrief, run_framing
+
+__all__ = ["FramingBrief", "run_framing"]

--- a/depth_dive/src/depth_dive/framing/framing_agent.py
+++ b/depth_dive/src/depth_dive/framing/framing_agent.py
@@ -1,0 +1,206 @@
+"""Framing agent implementation (ADR-0020, ticket #242).
+
+Makes the "what to make" decision visible before generation starts: it picks
+the recommended treatments, resolves the applied set through the precedence
+rules from the depth-dive spec §6, decides whether web search would help this
+specific dive (ADR-0012), and emits a :class:`FramingBrief`.
+
+The MVP tracer bullet performs no content analysis — the recommendation and
+search-intent decision are deterministic stands-in for the eventual LLM framing
+turn (ADR-0012), keyed on the passage's type, its content, and its anchoring so
+they stay per-request rather than following a fixed schedule by output type or
+keyword.
+"""
+
+import re
+from collections.abc import Sequence
+
+from pydantic import BaseModel, ConfigDict
+
+from core.types.captured_passage import (
+    CapturedPassage,
+    CodePassage,
+    DiagramPassage,
+    ImagePassage,
+    TablePassage,
+    TextPassage,
+)
+from core.types.depth_dive import DeferredTreatment, Treatment, TreatmentHint
+
+_SEARCH_INTENT_MAX_CHARS = 200
+"""Cap on the length of a derived web-search intent."""
+
+_CONCEPT_MAX_CHARS = 120
+"""Cap on the length of the brief's concept summary."""
+
+
+class FramingBrief(BaseModel):
+    """Internal creative brief emitted by the framing agent (ADR-0020).
+
+    Not exposed on ``HarnessBResponse``; the assembly agent consumes it. The
+    creative fields beyond treatment routing (key takeaways, visual metaphors,
+    required corpus context) are populated by the LLM-driven framing turn and
+    are out of scope for the routing-and-search tracer bullet.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    concept: str
+    recommended_treatments: list[Treatment]
+    applied_treatments: list[Treatment]
+    routing_note: str | None = None
+    search_intent: str | None = None
+
+
+def run_framing(
+    passage: CapturedPassage,
+    *,
+    requested_treatments: Sequence[TreatmentHint] | None = None,
+    preferred_treatments: Sequence[TreatmentHint] | None = None,
+) -> FramingBrief:
+    """Produce the framing brief for one captured passage and request hints.
+
+    Args:
+        passage: The captured passage carried in the request.
+        requested_treatments: Explicit, user-typed treatment ask (MVP or
+            deferred/still-deferred names).
+        preferred_treatments: UI-supplied, request-time-only treatment
+            preferences.
+
+    Returns:
+        A ``FramingBrief`` carrying the recommended and applied treatments,
+        a routing note when an override or fallback occurred, and the
+        per-request web-search intent.
+    """
+    recommended = _recommend_treatments(passage)
+    applied, notes = _resolve_treatments(requested_treatments, preferred_treatments, recommended)
+    return FramingBrief(
+        concept=_concept(passage),
+        recommended_treatments=recommended,
+        applied_treatments=applied,
+        routing_note=_join_notes(notes),
+        search_intent=_decide_search_intent(passage),
+    )
+
+
+def _recommend_treatments(passage: CapturedPassage) -> list[Treatment]:
+    """Return the harness's blind recommendation for a passage.
+
+    Keyed on passage type (spec §6 maps coding examples to ``worked_example``);
+    a general explanatory walkthrough suits text, an image is best revealed
+    through prediction, and a table spreads naturally onto swipeable slides.
+    """
+    if isinstance(passage, (CodePassage, TextPassage)):
+        return [Treatment.WORKED_EXAMPLE]
+    if isinstance(passage, (ImagePassage, DiagramPassage)):
+        return [Treatment.PREDICTION_REVEAL]
+    if isinstance(passage, TablePassage):
+        return [Treatment.SEGMENTED_CAROUSEL]
+    return [Treatment.WORKED_EXAMPLE]
+
+
+def _resolve_treatments(
+    requested: Sequence[TreatmentHint] | None,
+    preferred: Sequence[TreatmentHint] | None,
+    recommendation: list[Treatment],
+) -> tuple[list[Treatment], list[str]]:
+    """Apply the §6 precedence rules and collect a routing note.
+
+    Explicit `requested` beats `preferred` beats the harness recommendation. An
+    empty or absent hints list contributes nothing, so precedence falls through
+    to the next level. Treatments the MVP set supports are kept; deferred
+    treatments are dropped and reported so the caller can flag the fallback.
+    Precedence overrides of the recommendation are also reported.
+    """
+    for hints, override_note in (
+        (requested, "explicit request overrides the harness recommendation"),
+        (preferred, "preferred treatments override the harness recommendation"),
+    ):
+        if hints:
+            applied, notes = _filter_supported(hints)
+            if not applied:
+                applied = list(recommendation)
+            elif applied != recommendation:
+                notes.append(override_note)
+            return applied, notes
+    return list(recommendation), []
+
+
+def _filter_supported(hints: Sequence[TreatmentHint]) -> tuple[list[Treatment], list[str]]:
+    """Split hints into supported treatments and dropped deferred names.
+
+    Returns the supported treatments plus a note describing any deferred
+    treatments that were dropped.
+    """
+    supported: list[Treatment] = []
+    dropped: list[str] = []
+    for hint in hints:
+        if isinstance(hint, Treatment):
+            supported.append(hint)
+        elif isinstance(hint, DeferredTreatment):
+            dropped.append(hint.value)
+    notes: list[str] = []
+    if dropped:
+        names = ", ".join(dropped)
+        notes.append(f"deferred and unavailable, dropped: {names}")
+    return supported, notes
+
+
+def _join_notes(notes: Sequence[str]) -> str | None:
+    """Join zero or more routing notes into one note, or ``None``."""
+    return "; ".join(notes) if notes else None
+
+
+def _decide_search_intent(passage: CapturedPassage) -> str | None:
+    """Decide, per-request, whether external grounding would help.
+
+    This is the tracer-bullet stand-in for the framing LLM's per-request
+    judgment that ADR-0012 calls for — the real content assessment lands with
+    the LLM framing turn. Until then it substitutes a deterministic rule keyed
+    on the request's own properties (anchoring and content), not on output type
+    or keyword: a passage anchored to the corpus is grounded by retrieval, so no
+    external search is warranted; an unanchored passage has no corpus grounding,
+    so a web-search intent is derived from whatever is searchable — text/code
+    content or a non-text caption. No caption means nothing to search for.
+    """
+    if _is_anchored(passage):
+        return None
+    if isinstance(passage, (TextPassage, CodePassage)):
+        return _snippet(passage.content)
+    if isinstance(passage, (ImagePassage, DiagramPassage, TablePassage)):
+        return _snippet(passage.caption or "")
+    return None
+
+
+def _is_anchored(passage: CapturedPassage) -> bool:
+    """Return whether the passage carries a corpus anchor."""
+    if isinstance(passage, (TextPassage, CodePassage)):
+        return passage.chunk_id is not None
+    return passage.document_id is not None
+
+
+def _snippet(text: str, limit: int = _SEARCH_INTENT_MAX_CHARS) -> str | None:
+    """Trim text to a single-line searchable snippet, or ``None`` if empty."""
+    collapsed = re.sub(r"\s+", " ", text).strip()
+    if not collapsed:
+        return None
+    return collapsed[:limit]
+
+
+def _concept(passage: CapturedPassage) -> str:
+    """Derive a short concept label for the brief from the passage."""
+    if isinstance(passage, (TextPassage, CodePassage)):
+        return _brief_snippet(passage.content) or "the captured passage"
+    caption = _brief_snippet(passage.caption or "")
+    if caption:
+        return caption
+    kind = "diagram" if isinstance(passage, DiagramPassage) else passage.passage_type
+    return f"the captured {kind}"
+
+
+def _brief_snippet(text: str) -> str | None:
+    """Collapse and cap text for the brief's concept field."""
+    return _snippet(text, limit=_CONCEPT_MAX_CHARS)
+
+
+__all__ = ["FramingBrief", "run_framing"]

--- a/depth_dive/src/depth_dive/harness.py
+++ b/depth_dive/src/depth_dive/harness.py
@@ -1,38 +1,46 @@
 """Harness B entrypoint (ADR-0020).
 
-Runs the Depth Dive pipeline for one Captured Passage and returns a
-``HarnessBResponse``. The full two-agent pipeline (framing then assembly) is
-deferred; the MVP tracer bullet validates the passage via the Passage Transform
-stage and returns the hardcoded demo ``interactive_animation``. No retrieval,
-web search, or per-learner state participates yet, so ``grounded`` is always
-``False`` and the search flags are off.
+Runs the Depth Dive pipeline for one ``HarnessBRequest`` and returns a
+``HarnessBResponse``. The passage is validated by the Passage Transform stage,
+then the framing agent resolves the treatment set and search intent (ADR-0020,
+ticket #242). The assembly agent is still the hardcoded demo; no retrieval or
+web search participates yet, so ``grounded`` is always ``False`` and the search
+flags are off.
 """
 
-from core.types.captured_passage import CapturedPassage
-from core.types.depth_dive import HarnessBResponse, Treatment
+from core.types.depth_dive import HarnessBRequest, HarnessBResponse
+from depth_dive.framing.framing_agent import run_framing
 from depth_dive.generation.demo_animation import build_demo_animation
 from depth_dive.transform import transform_passage
 
 
-def run_dive(passage: CapturedPassage) -> HarnessBResponse:
-    """Validate a Captured Passage and return the tracer-bullet dive response.
+def run_dive(request: HarnessBRequest) -> HarnessBResponse:
+    """Validate a request and return the dive response.
 
     Args:
-        passage: The captured passage carried in the ``HarnessBRequest``.
+        request: The ``HarnessBRequest`` carried by ``POST /dive``.
 
     Returns:
         A ``HarnessBResponse`` whose ``output`` is the hardcoded demo
-        ``interactive_animation`` scene graph.
+        ``interactive_animation`` scene graph, whose treatment fields come from
+        the framing agent, and whose search flags stay off for the tracer
+        bullet.
 
     Raises:
         PassageTransformError: The passage violates the declared size/bounds
             or is a type this harness does not yet support.
     """
-    transform_passage(passage)
+    transform_passage(request.captured_passage)
+    brief = run_framing(
+        request.captured_passage,
+        requested_treatments=request.requested_treatments,
+        preferred_treatments=request.preferred_treatments,
+    )
     return HarnessBResponse(
         output=build_demo_animation(),
-        recommended_treatments=[Treatment.WORKED_EXAMPLE],
-        applied_treatments=[Treatment.WORKED_EXAMPLE],
+        recommended_treatments=brief.recommended_treatments,
+        applied_treatments=brief.applied_treatments,
+        routing_note=brief.routing_note,
         grounded=False,
         external_search_attempted=False,
         external_search_failed=False,

--- a/depth_dive/tests/depth_dive/framing/test_framing_agent.py
+++ b/depth_dive/tests/depth_dive/framing/test_framing_agent.py
@@ -1,0 +1,200 @@
+"""Tests for the Depth Dive framing agent (ADR-0020, ticket #242).
+
+Covers treatment routing precedence (explicit ask > preferred > harness
+recommendation), deferred/unsupported treatment fallback with a ``routing_note``,
+and the per-request web-search-intent decision.
+"""
+
+from uuid import uuid4
+
+from core.types.captured_passage import (
+    CodePassage,
+    ImagePassage,
+    TablePassage,
+    TextPassage,
+)
+from core.types.depth_dive import DeferredTreatment, Treatment
+from depth_dive.framing.framing_agent import run_framing
+
+_VALID_TEXT = TextPassage(content="Attention is all you need.")
+_VALID_CODE = CodePassage(content="def f():\n    return 1", language="python")
+_VALID_IMAGE = ImagePassage(content=b"\x00", media_type="image/png", caption="An attention plot")
+_VALID_TABLE = TablePassage(rows=[["a", "1"], ["b", "2"]], headers=["l", "v"], caption="Scores")
+
+
+def test_framing_recommends_worked_example_for_text() -> None:
+    """The harness recommends worked_example for a text passage."""
+    brief = run_framing(_VALID_TEXT)
+    assert brief.recommended_treatments == [Treatment.WORKED_EXAMPLE]
+
+
+def test_framing_recommends_worked_example_for_code() -> None:
+    """The harness recommends worked_example for a code passage (spec §6)."""
+    brief = run_framing(_VALID_CODE)
+    assert brief.recommended_treatments == [Treatment.WORKED_EXAMPLE]
+
+
+def test_framing_recommends_prediction_reveal_for_image() -> None:
+    """The harness recommends prediction_reveal for an image passage."""
+    brief = run_framing(_VALID_IMAGE)
+    assert brief.recommended_treatments == [Treatment.PREDICTION_REVEAL]
+
+
+def test_framing_recommends_segmented_carousel_for_table() -> None:
+    """The harness recommends segmented_carousel for a table passage."""
+    brief = run_framing(_VALID_TABLE)
+    assert brief.recommended_treatments == [Treatment.SEGMENTED_CAROUSEL]
+
+
+# ------------------------------------------------------------
+# Routing precedence
+# ------------------------------------------------------------
+
+
+def test_framing_uses_recommendation_when_no_hints() -> None:
+    """With no request hints, applied equals the harness recommendation."""
+    brief = run_framing(_VALID_TEXT)
+    assert brief.applied_treatments == brief.recommended_treatments
+    assert brief.routing_note is None
+
+
+def test_explicit_request_beats_harness_recommendation() -> None:
+    """An explicit requested treatment wins over the recommendation with a note."""
+    brief = run_framing(_VALID_TEXT, requested_treatments=[Treatment.SEGMENTED_CAROUSEL])
+    assert brief.applied_treatments == [Treatment.SEGMENTED_CAROUSEL]
+    assert brief.recommended_treatments == [Treatment.WORKED_EXAMPLE]
+    assert brief.routing_note is not None
+    assert "request" in brief.routing_note
+
+
+def test_preferred_beats_recommendation_when_no_explicit_ask() -> None:
+    """A UI-supplied preferred treatment wins over the recommendation."""
+    brief = run_framing(_VALID_TEXT, preferred_treatments=[Treatment.PREDICTION_REVEAL])
+    assert brief.applied_treatments == [Treatment.PREDICTION_REVEAL]
+    assert brief.routing_note is not None
+
+
+def test_explicit_request_beats_preferred() -> None:
+    """When both are supplied, the explicit ask wins over the preferred set."""
+    brief = run_framing(
+        _VALID_TEXT,
+        requested_treatments=[Treatment.SEGMENTED_CAROUSEL],
+        preferred_treatments=[Treatment.PREDICTION_REVEAL],
+    )
+    assert brief.applied_treatments == [Treatment.SEGMENTED_CAROUSEL]
+    assert Treatment.PREDICTION_REVEAL not in brief.applied_treatments
+
+
+def test_empty_request_falls_through_to_preferred() -> None:
+    """An empty explicit-request list is not an ask, so preferred still applies."""
+    brief = run_framing(
+        _VALID_TEXT,
+        requested_treatments=[],
+        preferred_treatments=[Treatment.SEGMENTED_CAROUSEL],
+    )
+    assert brief.applied_treatments == [Treatment.SEGMENTED_CAROUSEL]
+
+
+def test_matching_explicit_request_produces_no_note() -> None:
+    """A request that matches the recommendation needs no routing note."""
+    brief = run_framing(_VALID_TEXT, requested_treatments=[Treatment.WORKED_EXAMPLE])
+    assert brief.applied_treatments == [Treatment.WORKED_EXAMPLE]
+    assert brief.routing_note is None
+
+
+# ------------------------------------------------------------
+# Deferred / unsupported treatment fallback
+# ------------------------------------------------------------
+
+
+def test_deferred_treatment_falls_back_with_note() -> None:
+    """A requested deferred treatment is dropped and reported in the note."""
+    brief = run_framing(
+        _VALID_TEXT,
+        requested_treatments=[DeferredTreatment.ANALOGY_MAPPING],
+    )
+    assert brief.applied_treatments == [Treatment.WORKED_EXAMPLE]
+    assert brief.routing_note is not None
+    assert DeferredTreatment.ANALOGY_MAPPING.value in brief.routing_note
+
+
+def test_mixed_request_keeps_supported_and_drops_deferred() -> None:
+    """A request mixing supported and deferred treatments keeps the supported ones."""
+    brief = run_framing(
+        _VALID_TEXT,
+        requested_treatments=[
+            Treatment.SEGMENTED_CAROUSEL,
+            DeferredTreatment.ELABORATIVE_PROMPT,
+        ],
+    )
+    assert brief.applied_treatments == [Treatment.SEGMENTED_CAROUSEL]
+    assert brief.routing_note is not None
+    assert DeferredTreatment.ELABORATIVE_PROMPT.value in brief.routing_note
+
+
+def test_deferred_preferred_treatment_falls_back_with_note() -> None:
+    """A deferred preferred treatment is dropped and reported."""
+    brief = run_framing(
+        _VALID_TEXT,
+        preferred_treatments=[DeferredTreatment.INTERACTIVE_CONCEPT_MAP],
+    )
+    assert brief.applied_treatments == [Treatment.WORKED_EXAMPLE]
+    assert brief.routing_note is not None
+    assert DeferredTreatment.INTERACTIVE_CONCEPT_MAP.value in brief.routing_note
+
+
+# ------------------------------------------------------------
+# Web-search intent decision
+# ------------------------------------------------------------
+
+
+def test_anchored_text_gets_no_search_intent() -> None:
+    """An anchored text passage relies on corpus retrieval, so no web intent."""
+    passage = TextPassage(content="Attention is all you need.", chunk_id=uuid4())
+    brief = run_framing(passage)
+    assert brief.search_intent is None
+
+
+def test_unanchored_text_gets_search_intent() -> None:
+    """An unanchored text passage produces a search intent from its content."""
+    brief = run_framing(_VALID_TEXT)
+    assert brief.search_intent is not None
+    assert brief.search_intent == "Attention is all you need."
+
+
+def test_unanchored_code_gets_search_intent() -> None:
+    """An unanchored code passage produces a search intent from its content."""
+    brief = run_framing(_VALID_CODE)
+    assert brief.search_intent is not None
+    assert "def f" in brief.search_intent
+
+
+def test_anchored_image_gets_no_search_intent() -> None:
+    """An anchored image passage relies on corpus retrieval, so no web intent."""
+    passage = ImagePassage(
+        content=b"\x00",
+        media_type="image/png",
+        caption="An attention plot",
+        document_id=uuid4(),
+    )
+    brief = run_framing(passage)
+    assert brief.search_intent is None
+
+
+def test_unanchored_image_uses_caption_as_search_intent() -> None:
+    """An unanchored image passage with a caption uses that as the web intent."""
+    brief = run_framing(_VALID_IMAGE)
+    assert brief.search_intent == "An attention plot"
+
+
+def test_unanchored_image_without_caption_gets_no_search_intent() -> None:
+    """Without a caption an unanchored image has no derivable web intent."""
+    passage = ImagePassage(content=b"\x00", media_type="image/png")
+    brief = run_framing(passage)
+    assert brief.search_intent is None
+
+
+def test_unanchored_whitespace_text_gets_no_search_intent() -> None:
+    """Whitespace-only unanchored text has nothing to search for."""
+    brief = run_framing(TextPassage(content="   \n  "))
+    assert brief.search_intent is None

--- a/depth_dive/tests/depth_dive/test_harness.py
+++ b/depth_dive/tests/depth_dive/test_harness.py
@@ -12,12 +12,22 @@ from core.types.captured_passage import (
     TablePassage,
     TextPassage,
 )
-from core.types.depth_dive import HarnessBResponse, InteractiveAnimation, Treatment
+from core.types.depth_dive import (
+    HarnessBRequest,
+    HarnessBResponse,
+    InteractiveAnimation,
+    Treatment,
+)
 from depth_dive.harness import run_dive
 from depth_dive.transform import PassageTransformError
 
 _VALID_TEXT = TextPassage(content="Attention is all you need.")
 _captured_passage_adapter: TypeAdapter[CapturedPassage] = TypeAdapter(CapturedPassage)
+
+
+def _request(passage: CapturedPassage) -> HarnessBRequest:
+    """Wrap a passage in a request with no treatment hints."""
+    return HarnessBRequest(captured_passage=passage)
 
 
 def _png_bytes() -> bytes:
@@ -37,7 +47,7 @@ def _valid_table() -> TablePassage:
 
 def test_run_dive_returns_hardcoded_animation() -> None:
     """A valid text passage yields a HarnessBResponse with the demo animation."""
-    response = run_dive(_VALID_TEXT)
+    response = run_dive(_request(_VALID_TEXT))
     assert isinstance(response, HarnessBResponse)
     assert isinstance(response.output, InteractiveAnimation)
     assert response.output.output_type == "interactive_animation"
@@ -48,7 +58,7 @@ def test_run_dive_returns_hardcoded_animation() -> None:
 
 def test_run_dive_response_is_not_grounded_without_retrieval() -> None:
     """No retrieval/search runs in the tracer bullet: grounded=False, search off."""
-    response = run_dive(_VALID_TEXT)
+    response = run_dive(_request(_VALID_TEXT))
     assert response.grounded is False
     assert response.external_search_attempted is False
     assert response.external_search_failed is False
@@ -58,7 +68,7 @@ def test_run_dive_response_is_not_grounded_without_retrieval() -> None:
 
 def test_run_dive_recommends_and_applies_worked_example() -> None:
     """The demo treats the passage as a worked_example; no routing overrides."""
-    response = run_dive(_VALID_TEXT)
+    response = run_dive(_request(_VALID_TEXT))
     assert response.recommended_treatments == [Treatment.WORKED_EXAMPLE]
     assert response.applied_treatments == [Treatment.WORKED_EXAMPLE]
     assert response.routing_note is None
@@ -66,27 +76,27 @@ def test_run_dive_recommends_and_applies_worked_example() -> None:
 
 def test_run_dive_output_is_static_across_passages() -> None:
     """The tracer bullet returns the identical hardcoded payload for any text."""
-    first = run_dive(_VALID_TEXT)
-    second = run_dive(TextPassage(content="A completely different passage."))
+    first = run_dive(_request(_VALID_TEXT))
+    second = run_dive(_request(TextPassage(content="A completely different passage.")))
     assert first.model_dump() == second.model_dump()
 
 
 def test_run_dive_validates_before_building() -> None:
     """A passage violating text bounds is rejected, not silently built."""
     with pytest.raises(PassageTransformError):
-        run_dive(TextPassage(content=""))
+        run_dive(_request(TextPassage(content="")))
 
 
 def test_run_dive_accepts_image_passage() -> None:
     """A valid image passage returns a valid HarnessBResponse."""
-    response = run_dive(_valid_image())
+    response = run_dive(_request(_valid_image()))
     assert isinstance(response, HarnessBResponse)
     assert response.output.output_type == "interactive_animation"
 
 
 def test_run_dive_accepts_table_passage() -> None:
     """A valid table passage returns a valid HarnessBResponse."""
-    response = run_dive(_valid_table())
+    response = run_dive(_request(_valid_table()))
     assert isinstance(response, HarnessBResponse)
     assert response.output.output_type == "interactive_animation"
 
@@ -94,7 +104,7 @@ def test_run_dive_accepts_table_passage() -> None:
 def test_run_dive_rejects_invalid_image() -> None:
     """An image that fails transform validation is rejected, not silently built."""
     with pytest.raises(PassageTransformError):
-        run_dive(ImagePassage(content=b"not an image", media_type="image/png"))
+        run_dive(_request(ImagePassage(content=b"not an image", media_type="image/png")))
 
 
 def test_run_dive_accepts_type_checked_union_payload() -> None:
@@ -102,5 +112,5 @@ def test_run_dive_accepts_type_checked_union_payload() -> None:
     passage = _captured_passage_adapter.validate_python(
         {"passage_type": "text", "content": "Typed union payload", "chunk_id": None}
     )
-    response = run_dive(passage)
+    response = run_dive(_request(passage))
     assert response.output.output_type == "interactive_animation"


### PR DESCRIPTION
… intent

Adds the first Depth Dive agent (ADR-0020): a framing agent that consumes a CapturedPassage plus request hints and emits an internal creative brief resolving the treatment set and a per-request web-search intent.

Treatment routing follows spec §6 precedence (explicit ask > preferred > harness recommendation). Deferred treatments are modeled separately (DeferredTreatment) so a request can name one and be routed with a routing_note rather than rejected; the harness recommendation is determined by passage type. The search-intent decision is a per-request stand-in for the framing LLM turn (ADR-0012), keyed on anchoring and content, not output type.

POST /dive now returns recommended/applied treatments and the routing note from the brief. run_dive accepts HarnessBRequest instead of a bare passage.

Closes #242