### PR TITLE
feat(depth-dive): add assembly agent corpus grounding (#243)

### DIFF
--- a/api/src/api/routes/dive.py
+++ b/api/src/api/routes/dive.py
@@ -1,8 +1,15 @@
 """Depth Dive route: POST /dive (depth-dive spec §9)."""
 
-from fastapi import APIRouter, HTTPException
+from typing import Annotated
 
+from fastapi import APIRouter, Depends, HTTPException
+
+from api.dependencies import get_embedder
+from core.clients import Embedder
+from core.config.settings import settings
+from core.database.connection import db_session
 from core.types.depth_dive import HarnessBRequest, HarnessBResponse
+from core.types.retrieval_config import RetrievalConfig
 from depth_dive.harness import run_dive
 from depth_dive.transform import PassageTransformError
 
@@ -10,17 +17,33 @@ router = APIRouter(tags=["dive"])
 
 
 @router.post("/dive", response_model=HarnessBResponse)
-def dive(body: HarnessBRequest) -> HarnessBResponse:
+def dive(
+    body: HarnessBRequest,
+    embeddings_client: Annotated[Embedder, Depends(get_embedder)],
+) -> HarnessBResponse:
     """Generate a Depth Dive interactive animation for a Captured Passage.
 
-    Returns 200 with a ``HarnessBResponse`` carrying the hardcoded demo
-    ``interactive_animation`` scene graph. Passages that violate the declared
-    size/bounds or that the tracer bullet does not support are rejected with
-    422 (``PassageTransformError``). Malformed request bodies return 422 via
-    FastAPI defaults.
+    Runs the framing + assembly pipeline (ADR-0020): the assembly agent
+    grounds the passage against the ingested corpus and populates
+    ``grounded``/``cited_passages``. Returns 200 with a ``HarnessBResponse``
+    carrying the ``interactive_animation`` scene graph. Passages that violate
+    the declared size/bounds or that the tracer bullet does not support are
+    rejected with 422 (``PassageTransformError``). Upstream failures map to
+    502 / 503 via the ``RetrievalError`` subclass handlers registered on the
+    app; malformed request bodies return 422 via FastAPI defaults.
     """
     try:
-        return run_dive(body)
+        with db_session() as session:
+            return run_dive(
+                body,
+                session=session,
+                embedder=embeddings_client,
+                config=RetrievalConfig(
+                    model_name=settings.embedding_model,
+                    ef_search=settings.hnsw_ef_search,
+                    top_k=settings.query_top_k,
+                ),
+            )
     except PassageTransformError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 

--- a/api/tests/api/test_dive.py
+++ b/api/tests/api/test_dive.py
@@ -8,10 +8,18 @@ path without a Postgres instance.
 import base64
 import io
 from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
 
 from fastapi.testclient import TestClient
 from PIL import Image
+from sqlalchemy.orm import Session
 
+from api.dependencies import get_embedder
+from api.tests.conftest import set_dependency_override
+from core.database.schema import Chunk
+from core.exceptions import UpstreamBadResponse, UpstreamUnavailable
+from core.types.responses import CitedPassage
 from depth_dive.transform import IMAGE_MAX_BYTES, TABLE_MAX_ROWS, TEXT_PASSAGE_MAX_CHARS
 
 _VALID_BODY = {
@@ -131,8 +139,11 @@ def test_dive_code_passage_returns_422(mock_client: TestClient) -> None:
 # ============================================================
 
 
-def test_dive_returns_interactive_animation_scene_graph(mock_client: TestClient) -> None:
+def test_dive_returns_interactive_animation_scene_graph(
+    mock_client: TestClient, patched_dive_grounding: Any
+) -> None:
     """A valid text passage returns 200 with elements, steps, and initial_state."""
+    patched_dive_grounding()
     response = mock_client.post("/dive", json=_VALID_BODY)
     assert response.status_code == 200
     body = response.json()
@@ -146,8 +157,11 @@ def test_dive_returns_interactive_animation_scene_graph(mock_client: TestClient)
     assert output["viewport"]["height"] > 0
 
 
-def test_dive_response_has_exact_field_set(mock_client: TestClient) -> None:
+def test_dive_response_has_exact_field_set(
+    mock_client: TestClient, patched_dive_grounding: Any
+) -> None:
     """The 200 body exposes exactly the HarnessBResponse spec §9 fields."""
+    patched_dive_grounding()
     response = mock_client.post("/dive", json=_VALID_BODY)
     assert response.status_code == 200
     assert set(response.json().keys()) == {
@@ -163,8 +177,11 @@ def test_dive_response_has_exact_field_set(mock_client: TestClient) -> None:
     }
 
 
-def test_dive_tracer_bullet_is_not_grounded(mock_client: TestClient) -> None:
-    """No retrieval runs in the tracer bullet: grounded=False, search flags off."""
+def test_dive_tracer_bullet_is_not_grounded(
+    mock_client: TestClient, patched_dive_grounding: Any
+) -> None:
+    """An ungrounded assembly result leaves the search flags off and cites nothing."""
+    patched_dive_grounding()
     response = mock_client.post("/dive", json=_VALID_BODY)
     assert response.status_code == 200
     body = response.json()
@@ -175,8 +192,30 @@ def test_dive_tracer_bullet_is_not_grounded(mock_client: TestClient) -> None:
     assert body["cited_passages"] == []
 
 
-def test_dive_applies_worked_example_treatment(mock_client: TestClient) -> None:
+def test_dive_grounded_response_populates_citations(
+    mock_client: TestClient, patched_dive_grounding: Any
+) -> None:
+    """A grounded assembly result populates grounded and cited_passages."""
+    passage_id = uuid4()
+    patched_dive_grounding(
+        grounded=True, cited_passages=[CitedPassage(chunk_id=passage_id, text="corpus chunk")]
+    )
+    response = mock_client.post("/dive", json=_VALID_BODY)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["grounded"] is True
+    assert len(body["cited_passages"]) == 1
+    passage = body["cited_passages"][0]
+    assert set(passage.keys()) == {"chunk_id", "text"}
+    assert passage["chunk_id"] == str(passage_id)
+    assert passage["text"] == "corpus chunk"
+
+
+def test_dive_applies_worked_example_treatment(
+    mock_client: TestClient, patched_dive_grounding: Any
+) -> None:
     """The demo payload recommends and applies the worked_example treatment."""
+    patched_dive_grounding()
     response = mock_client.post("/dive", json=_VALID_BODY)
     assert response.status_code == 200
     body = response.json()
@@ -185,8 +224,11 @@ def test_dive_applies_worked_example_treatment(mock_client: TestClient) -> None:
     assert body["routing_note"] is None
 
 
-def test_dive_steps_reference_declared_elements(mock_client: TestClient) -> None:
+def test_dive_steps_reference_declared_elements(
+    mock_client: TestClient, patched_dive_grounding: Any
+) -> None:
     """Every step's element_states key resolves to a declared scene element."""
+    patched_dive_grounding()
     response = mock_client.post("/dive", json=_VALID_BODY)
     assert response.status_code == 200
     output = response.json()["output"]
@@ -196,8 +238,11 @@ def test_dive_steps_reference_declared_elements(mock_client: TestClient) -> None
             assert element_id in element_ids
 
 
-def test_dive_explicit_request_override_routes_treatment(mock_client: TestClient) -> None:
+def test_dive_explicit_request_override_routes_treatment(
+    mock_client: TestClient, patched_dive_grounding: Any
+) -> None:
     """An explicit requested treatment wins over the recommendation with a note."""
+    patched_dive_grounding()
     body = {**_VALID_BODY, "requested_treatments": ["segmented_carousel"]}
     response = mock_client.post("/dive", json=body)
     assert response.status_code == 200
@@ -207,8 +252,11 @@ def test_dive_explicit_request_override_routes_treatment(mock_client: TestClient
     assert data["routing_note"] is not None
 
 
-def test_dive_deferred_treatment_is_accepted_and_routed_not_422(mock_client: TestClient) -> None:
+def test_dive_deferred_treatment_is_accepted_and_routed_not_422(
+    mock_client: TestClient, patched_dive_grounding: Any
+) -> None:
     """A deferred requested treatment is accepted, dropped, and noted (not a 422)."""
+    patched_dive_grounding()
     body = {**_VALID_BODY, "requested_treatments": ["analogy_mapping"]}
     response = mock_client.post("/dive", json=body)
     assert response.status_code == 200, response.text
@@ -223,15 +271,17 @@ def test_dive_deferred_treatment_is_accepted_and_routed_not_422(mock_client: Tes
 # ============================================================
 
 
-def test_dive_accepts_image_passage(mock_client: TestClient) -> None:
+def test_dive_accepts_image_passage(mock_client: TestClient, patched_dive_grounding: Any) -> None:
     """A valid image passage returns 200 with the interactive animation."""
+    patched_dive_grounding()
     response = mock_client.post("/dive", json=_image_body(png=_png()))
     assert response.status_code == 200, response.text
     assert response.json()["output"]["output_type"] == "interactive_animation"
 
 
-def test_dive_accepts_diagram_passage(mock_client: TestClient) -> None:
+def test_dive_accepts_diagram_passage(mock_client: TestClient, patched_dive_grounding: Any) -> None:
     """A valid diagram passage uses the same carrier and returns 200."""
+    patched_dive_grounding()
     body = {
         "captured_passage": {
             "passage_type": "diagram",
@@ -243,8 +293,9 @@ def test_dive_accepts_diagram_passage(mock_client: TestClient) -> None:
     assert response.status_code == 200
 
 
-def test_dive_accepts_table_passage(mock_client: TestClient) -> None:
+def test_dive_accepts_table_passage(mock_client: TestClient, patched_dive_grounding: Any) -> None:
     """A valid table passage returns 200 with the interactive animation."""
+    patched_dive_grounding()
     response = mock_client.post("/dive", json=_table_body(rows=[["a", "1"], ["b", "2"]]))
     assert response.status_code == 200
     assert response.json()["output"]["output_type"] == "interactive_animation"
@@ -289,3 +340,124 @@ def test_dive_table_over_row_bound_returns_422(mock_client: TestClient) -> None:
     assert response.status_code == 422
     detail = response.json()["detail"]
     assert "row limit" in detail
+
+
+# ============================================================
+# 502 / 503 — upstream error mapping
+# ============================================================
+
+
+def test_dive_embeddings_bad_response_returns_502(mock_client: TestClient) -> None:
+    """A mocked embeddings provider returning a bad response maps to 502."""
+
+    def _bad_embedder() -> Any:
+        embedder = MagicMock()
+        embedder.embed.side_effect = UpstreamBadResponse("bad upstream response")
+        return embedder
+
+    set_dependency_override(mock_client, get_embedder, _bad_embedder)
+    response = mock_client.post("/dive", json=_VALID_BODY)
+
+    assert response.status_code == 502
+    assert "detail" in response.json()
+
+
+def test_dive_embeddings_unavailable_returns_503(mock_client: TestClient) -> None:
+    """A mocked embeddings provider that's unreachable/timeout maps to 503."""
+
+    def _unavailable_embedder() -> Any:
+        embedder = MagicMock()
+        embedder.embed.side_effect = UpstreamUnavailable("timeout")
+        return embedder
+
+    set_dependency_override(mock_client, get_embedder, _unavailable_embedder)
+    response = mock_client.post("/dive", json=_VALID_BODY)
+
+    assert response.status_code == 503
+    assert "detail" in response.json()
+
+
+# ============================================================
+# 200 — end-to-end against a real test DB (skips without Postgres)
+# ============================================================
+
+
+def test_dive_end_to_end_anchored_text_is_grounded(
+    client: TestClient,
+    test_session: Session,
+    ingest_a_paper: Any,
+) -> None:
+    """An anchored text passage against a ready corpus is grounded with citations."""
+    ingest_a_paper("RAG Paper")
+    anchor = test_session.query(Chunk).first()
+    assert anchor is not None
+    parent_id = anchor.parent_chunk_id or anchor.chunk_id
+
+    body = {
+        "captured_passage": {
+            "passage_type": "text",
+            "content": "Attention is all you need.",
+            "chunk_id": str(anchor.chunk_id),
+        }
+    }
+    response = client.post("/dive", json=body)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["grounded"] is True
+    assert len(data["cited_passages"]) >= 1
+    assert data["cited_passages"][0]["chunk_id"] == str(parent_id)
+    assert data["cited_passages"][0]["text"]
+
+
+def test_dive_end_to_end_unanchored_text_is_grounded(
+    client: TestClient,
+    ingest_a_paper: Any,
+) -> None:
+    """An unanchored passage matching a ready corpus passes the similarity gate."""
+    ingest_a_paper("RAG Paper")
+    body = {
+        "captured_passage": {
+            "passage_type": "text",
+            "content": "Attention is all you need.",
+        }
+    }
+    response = client.post("/dive", json=body)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["grounded"] is True
+    assert len(data["cited_passages"]) >= 1
+
+
+def test_dive_end_to_end_empty_corpus_unanchored_is_not_grounded(client: TestClient) -> None:
+    """An unanchored passage against an empty corpus is ungrounded, not an error."""
+    body = {
+        "captured_passage": {
+            "passage_type": "text",
+            "content": "Attention is all you need.",
+        }
+    }
+    response = client.post("/dive", json=body)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["grounded"] is False
+    assert data["cited_passages"] == []
+
+
+def test_dive_end_to_end_empty_corpus_anchored_is_not_grounded(client: TestClient) -> None:
+    """An anchor that no ready corpus can resolve is ungrounded, not an error."""
+    body = {
+        "captured_passage": {
+            "passage_type": "text",
+            "content": "Attention is all you need.",
+            "chunk_id": str(uuid4()),
+        }
+    }
+    response = client.post("/dive", json=body)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["grounded"] is False
+    assert data["cited_passages"] == []

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -17,7 +17,7 @@ from fastapi.testclient import TestClient
 from api.dependencies import get_completion_provider, get_embedder, get_reranker
 from api.server import create_app
 from core.clients import InMemoryEmbedder, MockCompletionProvider, NoopReranker
-from core.types.responses import RetrievalResult, ScoredChunk
+from core.types.responses import CitedPassage, RetrievalResult, ScoredChunk
 
 IngestADocument = Callable[[str], str]
 
@@ -116,12 +116,38 @@ def mock_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.setattr("api.routes.ingest.db_session", _mock_db_session)
     monkeypatch.setattr("api.routes.documents.db_session", _mock_db_session)
     monkeypatch.setattr("api.routes.retrieval_qa.db_session", _mock_db_session)
+    monkeypatch.setattr("api.routes.dive.db_session", _mock_db_session)
 
     app = create_app()
     app.dependency_overrides[get_embedder] = _default_fake_embedder
     app.dependency_overrides[get_completion_provider] = _default_fake_llm_refusal_provider
     app.dependency_overrides[get_reranker] = lambda: NoopReranker()
     return TestClient(app)
+
+
+@pytest.fixture
+def patched_dive_grounding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[bool, Sequence[CitedPassage] | None], None]:
+    """Return a factory that patches ``depth_dive.harness.run_assembly``.
+
+    Sets the assembly grounding outcome the harness should report, so the
+    POST /dive route can be exercised without a database.
+    """
+
+    def _patch(
+        grounded: bool = False, cited_passages: Sequence[CitedPassage] | None = None
+    ) -> None:
+        from depth_dive.assembly.assembly_agent import GroundingResult
+
+        monkeypatch.setattr(
+            "depth_dive.harness.run_assembly",
+            lambda *args, **kwargs: GroundingResult(
+                grounded=grounded, cited_passages=list(cited_passages or [])
+            ),
+        )
+
+    return _patch
 
 
 @pytest.fixture

--- a/depth_dive/src/depth_dive/__init__.py
+++ b/depth_dive/src/depth_dive/__init__.py
@@ -1,9 +1,9 @@
 """Depth Dive package (Harness B).
 
 Owns the passage-transform validation stage, the two-agent harness (framing +
-assembly; stubbed for the MVP tracer bullet), the similarity-gate policy, and
-the generative artifacts. Consumes ``core/retrieval/`` primitives (ADR-0019)
-once retrieval participates, and never imports ``retrieval_qa`` (ADR-0011).
+assembly), the similarity-gate policy, and the generative artifacts. Consumes
+``core/retrieval/`` primitives (ADR-0019) for corpus grounding, and never
+imports ``retrieval_qa`` (ADR-0011).
 """
 
 from depth_dive.harness import run_dive

--- a/depth_dive/src/depth_dive/assembly/__init__.py
+++ b/depth_dive/src/depth_dive/assembly/__init__.py
@@ -1,0 +1,14 @@
+"""Assembly agent: grounds and builds the dive (ADR-0020, ticket #243).
+
+Consumes the :class:`~depth_dive.framing.framing_agent.FramingBrief` and
+grounds the dive against the ingested corpus via the shared ``core/retrieval/``
+primitives (ADR-0019): anchored ``text``/``code`` passages fetch the parent
+chunk plus semantic neighbors, and every other passage runs the
+corpus-similarity gate. The brief's ``search_intent`` drives the web-search
+step once it lands (ticket #244); the artifact payload stays the hardcoded
+demo until LLM generation lands (ticket #245).
+"""
+
+from depth_dive.assembly.assembly_agent import GroundingResult, run_assembly
+
+__all__ = ["GroundingResult", "run_assembly"]

--- a/depth_dive/src/depth_dive/assembly/assembly_agent.py
+++ b/depth_dive/src/depth_dive/assembly/assembly_agent.py
@@ -1,0 +1,201 @@
+"""Assembly agent implementation (ADR-0020, ticket #243).
+
+Consumes the framing brief and grounds the dive against the ingested corpus
+through the shared ``core/retrieval/`` primitives (ADR-0019):
+
+- An anchored ``text``/``code`` passage (``chunk_id``) fetches the enclosing
+  Parent Chunk plus up to K semantic neighbors from the global corpus.
+- Every other passage runs the corpus-similarity gate on the passage's
+  embeddable representation; the gate's threshold and grounded/unverified
+  judgement are Depth Dive harness policy (ADR-0019, ADR-0020).
+
+The brief's ``search_intent`` is consumed by the web-search step once it
+lands (ticket #244); the artifact payload stays the hardcoded demo until LLM
+generation lands (ticket #245).
+"""
+
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.orm import Session
+
+from core.clients import Embedder
+from core.retrieval import fetch_parent_chunk, search_dense_neighbors
+from core.types.captured_passage import (
+    CapturedPassage,
+    CodePassage,
+    DiagramPassage,
+    ImagePassage,
+    TablePassage,
+    TableRow,
+    TextPassage,
+)
+from core.types.responses import CitedPassage
+from core.types.retrieval_config import RetrievalConfig
+from depth_dive.framing.framing_agent import FramingBrief
+
+SIMILARITY_GATE_THRESHOLD: float = 0.5
+"""Cosine-similarity floor for the unanchored-passage corpus gate.
+
+Depth Dive harness policy (ADR-0019, ADR-0020): an unanchored passage counts
+as grounded only when its closest corpus chunk is at least this similar — a
+close paraphrase or the passage itself under different chunk boundaries.
+Below the floor the passage is unverified: the dive still proceeds, but
+``grounded`` stays False. The floor is an MVP starting point, to be tuned by
+retrieval evaluation.
+"""
+
+
+class GroundingResult(BaseModel):
+    """The corpus-grounding outcome of the assembly agent.
+
+    ``grounded`` follows the Harness A semantics (same field on
+    ``HarnessBResponse``): True when the ingested corpus vouches for the
+    dive. ``cited_passages`` is empty whenever ``grounded`` is False.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    grounded: bool
+    cited_passages: list[CitedPassage]
+
+
+def run_assembly(
+    passage: CapturedPassage,
+    brief: FramingBrief,
+    *,
+    session: Session,
+    embedder: Embedder,
+    config: RetrievalConfig,
+) -> GroundingResult:
+    """Ground one captured passage against the ingested corpus.
+
+    Args:
+        passage: The captured passage carried in the request.
+        brief: The framing agent's creative brief for this dive. Its
+            ``search_intent`` drives the web-search step (ticket #244);
+            corpus grounding in this slice is keyed on the passage's anchor.
+        session: SQLAlchemy session bound to the documents database.
+        embedder: Provider used to embed the passage content (1536-dim).
+        config: Retrieval configuration (model name, ef_search, top_k).
+
+    Returns:
+        A ``GroundingResult`` carrying the grounded flag and the cited
+        passages. An unresolvable anchor or a failed similarity gate is a
+        valid ungrounded result, never an exception.
+
+    Raises:
+        UpstreamBadResponse: The embeddings API returned an unexpected
+            response (route maps to 502).
+        UpstreamUnavailable: The embeddings API or the database was
+            unreachable (route maps to 503).
+    """
+    if isinstance(passage, (TextPassage, CodePassage)) and passage.chunk_id is not None:
+        return _ground_anchored(
+            passage, passage.chunk_id, session=session, embedder=embedder, config=config
+        )
+    return _ground_via_gate(passage, session=session, embedder=embedder, config=config)
+
+
+def _ground_anchored(
+    passage: TextPassage | CodePassage,
+    chunk_id: UUID,
+    *,
+    session: Session,
+    embedder: Embedder,
+    config: RetrievalConfig,
+) -> GroundingResult:
+    """Ground an anchored text/code passage: parent chunk + K neighbors.
+
+    The parent chunk leads the citations; neighbors follow in cosine-closeness
+    order. The anchor chunk itself is skipped (its content is inside the
+    parent) and duplicate ids are cited once.
+    """
+    parent = fetch_parent_chunk(session=session, chunk_id=chunk_id)
+    if parent is None:
+        return GroundingResult(grounded=False, cited_passages=[])
+    query_vector = embedder.embed([passage.content])[0]
+    neighbors = search_dense_neighbors(session=session, query_vector=query_vector, config=config)
+    cited = [parent]
+    seen = {parent.chunk_id, chunk_id}
+    for neighbor in neighbors:
+        if neighbor.chunk_id in seen:
+            continue
+        seen.add(neighbor.chunk_id)
+        cited.append(CitedPassage(chunk_id=neighbor.chunk_id, text=neighbor.text))
+    return GroundingResult(grounded=True, cited_passages=cited)
+
+
+def _ground_via_gate(
+    passage: CapturedPassage,
+    *,
+    session: Session,
+    embedder: Embedder,
+    config: RetrievalConfig,
+) -> GroundingResult:
+    """Ground an unanchored passage through the corpus-similarity gate.
+
+    The closest corpus chunk decides the gate: at or above
+    ``SIMILARITY_GATE_THRESHOLD`` the passage is grounded and the passing
+    neighbors are cited; below it (or with nothing to embed, or an empty
+    corpus) the passage is unverified and ungrounded.
+    """
+    embeddable = _embeddable_text(passage)
+    if embeddable is None:
+        return GroundingResult(grounded=False, cited_passages=[])
+    query_vector = embedder.embed([embeddable])[0]
+    neighbors = search_dense_neighbors(session=session, query_vector=query_vector, config=config)
+    if not neighbors or neighbors[0].score < SIMILARITY_GATE_THRESHOLD:
+        return GroundingResult(grounded=False, cited_passages=[])
+    cited = [
+        CitedPassage(chunk_id=n.chunk_id, text=n.text)
+        for n in neighbors
+        if n.score >= SIMILARITY_GATE_THRESHOLD
+    ]
+    return GroundingResult(grounded=True, cited_passages=cited)
+
+
+def _embeddable_text(passage: CapturedPassage) -> str | None:
+    """Derive the passage's embeddable text representation, if it has one.
+
+    Text/code embed their content; image/diagram embed their caption (the
+    corpus-side text-serializable form per the storage contract, depth-dive
+    spec §10); tables embed a deterministic serialization of headers and rows.
+    ``None`` means there is nothing to embed, so the gate cannot verify the
+    passage.
+    """
+    if isinstance(passage, (TextPassage, CodePassage)):
+        return passage.content
+    if isinstance(passage, (ImagePassage, DiagramPassage)):
+        caption = (passage.caption or "").strip()
+        return caption or None
+    if isinstance(passage, TablePassage):
+        return _serialize_table(passage)
+    return None
+
+
+def _serialize_table(passage: TablePassage) -> str | None:
+    """Serialize a table to a deterministic embeddable text form.
+
+    Caption (when present), then headers, then one line per row; cells joined
+    with ``" | "`` and dict rows rendered as ``key: value`` cells. Returns
+    ``None`` when the table carries no caption, headers, or rows.
+    """
+    lines: list[str] = []
+    caption = (passage.caption or "").strip()
+    if caption:
+        lines.append(caption)
+    if passage.headers:
+        lines.append(" | ".join(passage.headers))
+    for row in passage.rows:
+        lines.append(_serialize_row(row))
+    return "\n".join(lines) if lines else None
+
+
+def _serialize_row(row: TableRow) -> str:
+    if isinstance(row, dict):
+        return " | ".join(f"{key}: {value}" for key, value in row.items())
+    return " | ".join(row)
+
+
+__all__ = ["SIMILARITY_GATE_THRESHOLD", "GroundingResult", "run_assembly"]

--- a/depth_dive/src/depth_dive/generation/__init__.py
+++ b/depth_dive/src/depth_dive/generation/__init__.py
@@ -1,9 +1,8 @@
 """Hardcoded demo artifacts for the MVP tracer bullet.
 
-Replaces the assembly agent (ADR-0020) until real generation lands: every
-``POST /dive`` returns the same self-attention ``interactive_animation`` scene
-graph, proving the contract, type wiring, and passage-transform validation
-end-to-end.
+Stands in for the LLM-driven artifact generation inside the assembly agent
+(ticket #245): every ``POST /dive`` returns the same self-attention
+``interactive_animation`` scene graph while corpus grounding is already live.
 """
 
 from depth_dive.generation.demo_animation import build_demo_animation

--- a/depth_dive/src/depth_dive/harness.py
+++ b/depth_dive/src/depth_dive/harness.py
@@ -2,33 +2,55 @@
 
 Runs the Depth Dive pipeline for one ``HarnessBRequest`` and returns a
 ``HarnessBResponse``. The passage is validated by the Passage Transform stage,
-then the framing agent resolves the treatment set and search intent (ADR-0020,
-ticket #242). The assembly agent is still the hardcoded demo; no retrieval or
-web search participates yet, so ``grounded`` is always ``False`` and the search
-flags are off.
+the framing agent resolves the treatment set and search intent (ticket #242),
+and the assembly agent grounds the passage against the ingested corpus via the
+shared ``core/retrieval/`` primitives (ticket #243). Web search does not
+participate yet (ticket #244), so the search flags stay off; the artifact
+payload stays the hardcoded demo until LLM generation lands (ticket #245).
 """
 
+from sqlalchemy.orm import Session
+
+from core.clients import Embedder
 from core.types.depth_dive import HarnessBRequest, HarnessBResponse
+from core.types.retrieval_config import RetrievalConfig
+from depth_dive.assembly.assembly_agent import run_assembly
 from depth_dive.framing.framing_agent import run_framing
 from depth_dive.generation.demo_animation import build_demo_animation
 from depth_dive.transform import transform_passage
 
 
-def run_dive(request: HarnessBRequest) -> HarnessBResponse:
+def run_dive(
+    request: HarnessBRequest,
+    *,
+    session: Session,
+    embedder: Embedder,
+    config: RetrievalConfig,
+) -> HarnessBResponse:
     """Validate a request and return the dive response.
 
     Args:
         request: The ``HarnessBRequest`` carried by ``POST /dive``.
+        session: SQLAlchemy session bound to the documents database, used by
+            the assembly agent's corpus grounding.
+        embedder: Provider used to embed the passage for grounding
+            (1536-dim).
+        config: Retrieval configuration (model name, ef_search, top_k).
 
     Returns:
         A ``HarnessBResponse`` whose ``output`` is the hardcoded demo
-        ``interactive_animation`` scene graph, whose treatment fields come from
-        the framing agent, and whose search flags stay off for the tracer
-        bullet.
+        ``interactive_animation`` scene graph, whose treatment fields come
+        from the framing agent, and whose ``grounded``/``cited_passages``
+        come from the assembly agent's corpus grounding. The search flags
+        stay off until the web-search step lands (ticket #244).
 
     Raises:
         PassageTransformError: The passage violates the declared size/bounds
             or is a type this harness does not yet support.
+        UpstreamBadResponse: The embeddings API returned an unexpected
+            response during grounding (route maps to 502).
+        UpstreamUnavailable: The embeddings API or the database was
+            unreachable during grounding (route maps to 503).
     """
     transform_passage(request.captured_passage)
     brief = run_framing(
@@ -36,15 +58,22 @@ def run_dive(request: HarnessBRequest) -> HarnessBResponse:
         requested_treatments=request.requested_treatments,
         preferred_treatments=request.preferred_treatments,
     )
+    grounding = run_assembly(
+        request.captured_passage,
+        brief,
+        session=session,
+        embedder=embedder,
+        config=config,
+    )
     return HarnessBResponse(
         output=build_demo_animation(),
         recommended_treatments=brief.recommended_treatments,
         applied_treatments=brief.applied_treatments,
         routing_note=brief.routing_note,
-        grounded=False,
+        grounded=grounding.grounded,
         external_search_attempted=False,
         external_search_failed=False,
-        cited_passages=[],
+        cited_passages=grounding.cited_passages,
     )
 
 

--- a/depth_dive/tests/depth_dive/assembly/test_assembly_agent.py
+++ b/depth_dive/tests/depth_dive/assembly/test_assembly_agent.py
@@ -1,0 +1,394 @@
+"""Tests for the Depth Dive assembly agent (ADR-0020, ticket #243).
+
+The ``core/retrieval/`` primitives are mocked at the assembly module boundary
+(their database behaviour is covered by ``core``'s own retrieval tests) and the
+embedder is a stub, per coding-standards.md: hosted API calls stay out of unit
+tests.
+"""
+
+from collections.abc import Sequence
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from core.clients import Embedder
+from core.exceptions import UpstreamUnavailable
+from core.types.captured_passage import (
+    CapturedPassage,
+    CodePassage,
+    ImagePassage,
+    TablePassage,
+    TextPassage,
+)
+from core.types.responses import CitedPassage, ScoredChunk
+from core.types.retrieval_config import RetrievalConfig
+from depth_dive.assembly import assembly_agent
+from depth_dive.assembly.assembly_agent import (
+    SIMILARITY_GATE_THRESHOLD,
+    GroundingResult,
+    run_assembly,
+)
+from depth_dive.framing.framing_agent import run_framing
+
+_CONFIG = RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5)
+
+
+class _StubEmbedder:
+    """A stub embedder that returns one fixed vector and records its inputs."""
+
+    def __init__(self, vector: list[float] | None = None) -> None:
+        self.vector = vector if vector is not None else [0.5] * 1536
+        self.embedded: list[str] = []
+
+    def embed(self, texts: Sequence[str]) -> list[list[float]]:
+        self.embedded.extend(texts)
+        return [list(self.vector) for _ in texts]
+
+
+def _neighbor(chunk_id: UUID, text: str, score: float) -> ScoredChunk:
+    return ScoredChunk(chunk_id=chunk_id, text=text, score=score)
+
+
+def _run(passage: CapturedPassage, *, session: Session, embedder: Embedder) -> GroundingResult:
+    return run_assembly(
+        passage,
+        run_framing(passage),
+        session=session,
+        embedder=embedder,
+        config=_CONFIG,
+    )
+
+
+def test_anchored_text_grounds_with_parent_and_neighbors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An anchored text passage grounds with the parent chunk plus neighbors."""
+    anchor_id = uuid4()
+    parent_id = uuid4()
+    neighbor_id = uuid4()
+    fetch_parent = MagicMock(
+        return_value=CitedPassage(chunk_id=parent_id, text="the enclosing parent chunk")
+    )
+    search_neighbors = MagicMock(return_value=[_neighbor(neighbor_id, "a semantic neighbor", 0.9)])
+    monkeypatch.setattr(assembly_agent, "fetch_parent_chunk", fetch_parent)
+    monkeypatch.setattr(assembly_agent, "search_dense_neighbors", search_neighbors)
+
+    passage = TextPassage(content="Attention is all you need.", chunk_id=anchor_id)
+    session = MagicMock()
+    result = _run(passage, session=session, embedder=_StubEmbedder())
+
+    assert result.grounded is True
+    assert [p.chunk_id for p in result.cited_passages] == [parent_id, neighbor_id]
+    assert result.cited_passages[0].text == "the enclosing parent chunk"
+    fetch_parent.assert_called_once_with(session=session, chunk_id=anchor_id)
+
+
+def test_anchored_code_grounds_with_parent_and_neighbors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An anchored code passage uses the same parent + neighbors grounding."""
+    anchor_id = uuid4()
+    parent_id = uuid4()
+    monkeypatch.setattr(
+        assembly_agent,
+        "fetch_parent_chunk",
+        MagicMock(return_value=CitedPassage(chunk_id=parent_id, text="parent")),
+    )
+    monkeypatch.setattr(assembly_agent, "search_dense_neighbors", MagicMock(return_value=[]))
+
+    passage = CodePassage(content="def f():\n    return 1", language="python", chunk_id=anchor_id)
+    result = _run(passage, session=MagicMock(), embedder=_StubEmbedder())
+
+    assert result.grounded is True
+    assert [p.chunk_id for p in result.cited_passages] == [parent_id]
+
+
+def test_anchored_passage_with_unresolvable_anchor_is_not_grounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An anchor the corpus cannot resolve grounds nothing, without embedding."""
+    monkeypatch.setattr(assembly_agent, "fetch_parent_chunk", MagicMock(return_value=None))
+    search_neighbors = MagicMock()
+    monkeypatch.setattr(assembly_agent, "search_dense_neighbors", search_neighbors)
+
+    passage = TextPassage(content="Attention is all you need.", chunk_id=uuid4())
+    embedder = _StubEmbedder()
+    result = _run(passage, session=MagicMock(), embedder=embedder)
+
+    assert result.grounded is False
+    assert result.cited_passages == []
+    search_neighbors.assert_not_called()
+    assert embedder.embedded == []
+
+
+# ============================================================
+# Unanchored passages: the corpus-similarity gate
+# ============================================================
+
+
+def test_unanchored_text_passes_gate_when_corpus_is_similar(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A top neighbor at/above the gate threshold grounds the passage."""
+    close_id = uuid4()
+    monkeypatch.setattr(assembly_agent, "fetch_parent_chunk", MagicMock())
+    monkeypatch.setattr(
+        assembly_agent,
+        "search_dense_neighbors",
+        MagicMock(return_value=[_neighbor(close_id, "a near-duplicate chunk", 0.9)]),
+    )
+
+    passage = TextPassage(content="Attention is all you need.")
+    result = _run(passage, session=MagicMock(), embedder=_StubEmbedder())
+
+    assert result.grounded is True
+    assert [p.chunk_id for p in result.cited_passages] == [close_id]
+    assert result.cited_passages[0].text == "a near-duplicate chunk"
+
+
+def test_unanchored_text_fails_gate_when_corpus_is_dissimilar(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A top neighbor below the gate threshold leaves the passage ungrounded."""
+    monkeypatch.setattr(assembly_agent, "fetch_parent_chunk", MagicMock())
+    monkeypatch.setattr(
+        assembly_agent,
+        "search_dense_neighbors",
+        MagicMock(
+            return_value=[
+                _neighbor(uuid4(), "unrelated chunk", SIMILARITY_GATE_THRESHOLD - 0.01),
+            ]
+        ),
+    )
+
+    passage = TextPassage(content="Attention is all you need.")
+    result = _run(passage, session=MagicMock(), embedder=_StubEmbedder())
+
+    assert result.grounded is False
+    assert result.cited_passages == []
+
+
+def test_unanchored_gate_boundary_score_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A top neighbor exactly at the threshold counts as grounded."""
+    monkeypatch.setattr(assembly_agent, "fetch_parent_chunk", MagicMock())
+    monkeypatch.setattr(
+        assembly_agent,
+        "search_dense_neighbors",
+        MagicMock(return_value=[_neighbor(uuid4(), "boundary chunk", SIMILARITY_GATE_THRESHOLD)]),
+    )
+
+    passage = TextPassage(content="Attention is all you need.")
+    result = _run(passage, session=MagicMock(), embedder=_StubEmbedder())
+
+    assert result.grounded is True
+
+
+def test_unanchored_gate_cites_only_neighbors_above_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gate-passing citations keep only the neighbors that clear the threshold."""
+    close_id = uuid4()
+    monkeypatch.setattr(assembly_agent, "fetch_parent_chunk", MagicMock())
+    monkeypatch.setattr(
+        assembly_agent,
+        "search_dense_neighbors",
+        MagicMock(
+            return_value=[
+                _neighbor(close_id, "close chunk", 0.9),
+                _neighbor(uuid4(), "weak chunk", SIMILARITY_GATE_THRESHOLD - 0.01),
+            ]
+        ),
+    )
+
+    passage = TextPassage(content="Attention is all you need.")
+    result = _run(passage, session=MagicMock(), embedder=_StubEmbedder())
+
+    assert result.grounded is True
+    assert [p.chunk_id for p in result.cited_passages] == [close_id]
+
+
+def test_unanchored_empty_corpus_fails_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No neighbors at all (empty corpus) is a failed gate, not an error."""
+    monkeypatch.setattr(assembly_agent, "fetch_parent_chunk", MagicMock())
+    search_neighbors = MagicMock(return_value=[])
+    monkeypatch.setattr(assembly_agent, "search_dense_neighbors", search_neighbors)
+
+    passage = TextPassage(content="Attention is all you need.")
+    embedder = _StubEmbedder()
+    result = _run(passage, session=MagicMock(), embedder=embedder)
+
+    assert result.grounded is False
+    assert result.cited_passages == []
+    assert embedder.embedded == ["Attention is all you need."]
+    search_neighbors.assert_called_once()
+    assert search_neighbors.call_args.kwargs["query_vector"] == embedder.vector
+
+
+# ============================================================
+# Non-text passages: embeddable representation for the gate
+# ============================================================
+
+
+def test_unanchored_image_gates_on_caption(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unanchored image embeds its caption for the similarity gate."""
+    close_id = uuid4()
+    monkeypatch.setattr(assembly_agent, "fetch_parent_chunk", MagicMock())
+    monkeypatch.setattr(
+        assembly_agent,
+        "search_dense_neighbors",
+        MagicMock(return_value=[_neighbor(close_id, "caption-matching chunk", 0.9)]),
+    )
+
+    passage = ImagePassage(content=b"\x00", media_type="image/png", caption="An attention plot")
+    embedder = _StubEmbedder()
+    result = _run(passage, session=MagicMock(), embedder=embedder)
+
+    assert result.grounded is True
+    assert embedder.embedded == ["An attention plot"]
+
+
+def test_unanchored_image_without_caption_cannot_be_grounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No caption means nothing embeddable: ungrounded without any call."""
+    search_neighbors = MagicMock()
+    monkeypatch.setattr(assembly_agent, "fetch_parent_chunk", MagicMock())
+    monkeypatch.setattr(assembly_agent, "search_dense_neighbors", search_neighbors)
+
+    passage = ImagePassage(content=b"\x00", media_type="image/png")
+    embedder = _StubEmbedder()
+    result = _run(passage, session=MagicMock(), embedder=embedder)
+
+    assert result.grounded is False
+    assert result.cited_passages == []
+    assert embedder.embedded == []
+    search_neighbors.assert_not_called()
+
+
+def test_unanchored_table_gates_on_serialized_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unanchored table embeds a deterministic serialization of its rows."""
+    monkeypatch.setattr(assembly_agent, "fetch_parent_chunk", MagicMock())
+    monkeypatch.setattr(
+        assembly_agent,
+        "search_dense_neighbors",
+        MagicMock(return_value=[_neighbor(uuid4(), "table chunk", 0.9)]),
+    )
+
+    passage = TablePassage(rows=[["a", "1"], ["b", "2"]], headers=["l", "v"], caption="Scores")
+    embedder = _StubEmbedder()
+    result = _run(passage, session=MagicMock(), embedder=embedder)
+
+    assert result.grounded is True
+    assert embedder.embedded == ["Scores\nl | v\na | 1\nb | 2"]
+
+
+def test_unanchored_dict_table_rows_serialize_keyed_cells(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Header-keyed dict rows serialize as ``key: value`` cells."""
+    monkeypatch.setattr(assembly_agent, "fetch_parent_chunk", MagicMock())
+    monkeypatch.setattr(
+        assembly_agent,
+        "search_dense_neighbors",
+        MagicMock(return_value=[_neighbor(uuid4(), "table chunk", 0.9)]),
+    )
+
+    passage = TablePassage(rows=[{"l": "a", "v": "1"}])
+    embedder = _StubEmbedder()
+    _run(passage, session=MagicMock(), embedder=embedder)
+
+    assert embedder.embedded == ["l: a | v: 1"]
+
+
+def test_anchored_image_falls_back_to_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A document_id anchor cannot resolve yet (ADR-0019), so the gate runs."""
+    close_id = uuid4()
+    fetch_parent = MagicMock()
+    monkeypatch.setattr(assembly_agent, "fetch_parent_chunk", fetch_parent)
+    monkeypatch.setattr(
+        assembly_agent,
+        "search_dense_neighbors",
+        MagicMock(return_value=[_neighbor(close_id, "caption-matching chunk", 0.9)]),
+    )
+
+    passage = ImagePassage(
+        content=b"\x00",
+        media_type="image/png",
+        caption="An attention plot",
+        document_id=uuid4(),
+        ordinal="Figure 3",
+    )
+    result = _run(passage, session=MagicMock(), embedder=_StubEmbedder())
+
+    assert result.grounded is True
+    assert [p.chunk_id for p in result.cited_passages] == [close_id]
+    fetch_parent.assert_not_called()
+
+
+# ============================================================
+# Anchored citation hygiene and upstream failures
+# ============================================================
+
+
+def test_anchored_citations_skip_anchor_chunk_and_duplicates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The anchor chunk itself and duplicate ids never appear in citations."""
+    anchor_id = uuid4()
+    parent_id = uuid4()
+    neighbor_id = uuid4()
+    monkeypatch.setattr(
+        assembly_agent,
+        "fetch_parent_chunk",
+        MagicMock(return_value=CitedPassage(chunk_id=parent_id, text="parent")),
+    )
+    monkeypatch.setattr(
+        assembly_agent,
+        "search_dense_neighbors",
+        MagicMock(
+            return_value=[
+                _neighbor(anchor_id, "the anchor chunk itself", 0.99),
+                _neighbor(neighbor_id, "a semantic neighbor", 0.9),
+                _neighbor(parent_id, "the parent again", 0.8),
+                _neighbor(neighbor_id, "the neighbor again", 0.7),
+            ]
+        ),
+    )
+
+    passage = TextPassage(content="Attention is all you need.", chunk_id=anchor_id)
+    result = _run(passage, session=MagicMock(), embedder=_StubEmbedder())
+
+    assert result.grounded is True
+    assert [p.chunk_id for p in result.cited_passages] == [parent_id, neighbor_id]
+
+
+def test_assembly_propagates_embeddings_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unreachable embeddings API surfaces as UpstreamUnavailable (503)."""
+    monkeypatch.setattr(
+        assembly_agent,
+        "fetch_parent_chunk",
+        MagicMock(return_value=CitedPassage(chunk_id=uuid4(), text="parent")),
+    )
+
+    class _FailingEmbedder:
+        def embed(self, texts: Sequence[str]) -> list[list[float]]:
+            raise UpstreamUnavailable("embeddings API unreachable")
+
+    passage = TextPassage(content="Attention is all you need.", chunk_id=uuid4())
+    with pytest.raises(UpstreamUnavailable):
+        _run(passage, session=MagicMock(), embedder=_FailingEmbedder())
+
+
+def test_assembly_propagates_database_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unreachable database surfaces as UpstreamUnavailable (503)."""
+    monkeypatch.setattr(
+        assembly_agent,
+        "fetch_parent_chunk",
+        MagicMock(side_effect=UpstreamUnavailable("database unreachable")),
+    )
+
+    passage = TextPassage(content="Attention is all you need.", chunk_id=uuid4())
+    with pytest.raises(UpstreamUnavailable):
+        _run(passage, session=MagicMock(), embedder=_StubEmbedder())

--- a/depth_dive/tests/depth_dive/test_harness.py
+++ b/depth_dive/tests/depth_dive/test_harness.py
@@ -1,11 +1,19 @@
-"""Tests for the Depth Dive harness entrypoint (ADR-0020)."""
+"""Tests for the Depth Dive harness entrypoint (ADR-0020).
+
+The assembly agent is mocked at the harness boundary (its own suite covers
+grounding policy) so these tests exercise orchestration only: transform ->
+framing -> assembly -> response assembly.
+"""
 
 import io
+from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
 from PIL import Image
 from pydantic import TypeAdapter
 
+from core.clients import InMemoryEmbedder
 from core.types.captured_passage import (
     CapturedPassage,
     ImagePassage,
@@ -18,16 +26,35 @@ from core.types.depth_dive import (
     InteractiveAnimation,
     Treatment,
 )
+from core.types.responses import CitedPassage
+from core.types.retrieval_config import RetrievalConfig
+from depth_dive import harness
+from depth_dive.assembly.assembly_agent import GroundingResult
+from depth_dive.framing.framing_agent import FramingBrief
 from depth_dive.harness import run_dive
 from depth_dive.transform import PassageTransformError
 
 _VALID_TEXT = TextPassage(content="Attention is all you need.")
 _captured_passage_adapter: TypeAdapter[CapturedPassage] = TypeAdapter(CapturedPassage)
 
+_CONFIG = RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5)
 
-def _request(passage: CapturedPassage) -> HarnessBRequest:
-    """Wrap a passage in a request with no treatment hints."""
-    return HarnessBRequest(captured_passage=passage)
+
+@pytest.fixture
+def patched_assembly(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Patch ``run_assembly`` to return an ungrounded result by default."""
+    assembly = MagicMock(return_value=GroundingResult(grounded=False, cited_passages=[]))
+    monkeypatch.setattr(harness, "run_assembly", assembly)
+    return assembly
+
+
+def _dive(passage: CapturedPassage) -> HarnessBResponse:
+    return run_dive(
+        HarnessBRequest(captured_passage=passage),
+        session=MagicMock(),
+        embedder=InMemoryEmbedder(),
+        config=_CONFIG,
+    )
 
 
 def _png_bytes() -> bytes:
@@ -45,9 +72,9 @@ def _valid_table() -> TablePassage:
     return TablePassage(rows=[["a", "1"], ["b", "2"]], headers=["l", "v"])
 
 
-def test_run_dive_returns_hardcoded_animation() -> None:
+def test_run_dive_returns_hardcoded_animation(patched_assembly: MagicMock) -> None:
     """A valid text passage yields a HarnessBResponse with the demo animation."""
-    response = run_dive(_request(_VALID_TEXT))
+    response = _dive(_VALID_TEXT)
     assert isinstance(response, HarnessBResponse)
     assert isinstance(response.output, InteractiveAnimation)
     assert response.output.output_type == "interactive_animation"
@@ -56,61 +83,106 @@ def test_run_dive_returns_hardcoded_animation() -> None:
     assert response.output.initial_state
 
 
-def test_run_dive_response_is_not_grounded_without_retrieval() -> None:
-    """No retrieval/search runs in the tracer bullet: grounded=False, search off."""
-    response = run_dive(_request(_VALID_TEXT))
+def test_run_dive_mirrors_ungrounded_assembly_result(patched_assembly: MagicMock) -> None:
+    """An ungrounded assembly result leaves the search flags off and cites nothing."""
+    response = _dive(_VALID_TEXT)
     assert response.grounded is False
+    assert response.cited_passages == []
     assert response.external_search_attempted is False
     assert response.external_search_failed is False
     assert response.external_search_note is None
-    assert response.cited_passages == []
 
 
-def test_run_dive_recommends_and_applies_worked_example() -> None:
+def test_run_dive_mirrors_grounded_assembly_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A grounded assembly result populates grounded and cited_passages."""
+    passage_id = uuid4()
+    assembly = MagicMock(
+        return_value=GroundingResult(
+            grounded=True,
+            cited_passages=[CitedPassage(chunk_id=passage_id, text="cited corpus chunk")],
+        )
+    )
+    monkeypatch.setattr(harness, "run_assembly", assembly)
+
+    response = _dive(_VALID_TEXT)
+
+    assert response.grounded is True
+    assert len(response.cited_passages) == 1
+    assert response.cited_passages[0].chunk_id == passage_id
+    assert response.cited_passages[0].text == "cited corpus chunk"
+
+
+def test_run_dive_passes_passage_and_brief_to_assembly(
+    patched_assembly: MagicMock,
+) -> None:
+    """Assembly consumes the captured passage and the framing brief."""
+    session = MagicMock()
+    embedder = InMemoryEmbedder()
+    run_dive(
+        HarnessBRequest(captured_passage=_VALID_TEXT),
+        session=session,
+        embedder=embedder,
+        config=_CONFIG,
+    )
+
+    patched_assembly.assert_called_once()
+    call = patched_assembly.call_args
+    assert call.args[0] == _VALID_TEXT
+    assert isinstance(call.args[1], FramingBrief)
+    assert call.kwargs["session"] is session
+    assert call.kwargs["embedder"] is embedder
+    assert call.kwargs["config"] is _CONFIG
+
+
+def test_run_dive_recommends_and_applies_worked_example(patched_assembly: MagicMock) -> None:
     """The demo treats the passage as a worked_example; no routing overrides."""
-    response = run_dive(_request(_VALID_TEXT))
+    response = _dive(_VALID_TEXT)
     assert response.recommended_treatments == [Treatment.WORKED_EXAMPLE]
     assert response.applied_treatments == [Treatment.WORKED_EXAMPLE]
     assert response.routing_note is None
 
 
-def test_run_dive_output_is_static_across_passages() -> None:
+def test_run_dive_output_is_static_across_passages(patched_assembly: MagicMock) -> None:
     """The tracer bullet returns the identical hardcoded payload for any text."""
-    first = run_dive(_request(_VALID_TEXT))
-    second = run_dive(_request(TextPassage(content="A completely different passage.")))
-    assert first.model_dump() == second.model_dump()
+    first = _dive(_VALID_TEXT)
+    second = _dive(TextPassage(content="A completely different passage."))
+    assert first.output.model_dump() == second.output.model_dump()
 
 
-def test_run_dive_validates_before_building() -> None:
+def test_run_dive_validates_before_building(patched_assembly: MagicMock) -> None:
     """A passage violating text bounds is rejected, not silently built."""
     with pytest.raises(PassageTransformError):
-        run_dive(_request(TextPassage(content="")))
+        _dive(TextPassage(content=""))
+    patched_assembly.assert_not_called()
 
 
-def test_run_dive_accepts_image_passage() -> None:
+def test_run_dive_accepts_image_passage(patched_assembly: MagicMock) -> None:
     """A valid image passage returns a valid HarnessBResponse."""
-    response = run_dive(_request(_valid_image()))
+    response = _dive(_valid_image())
     assert isinstance(response, HarnessBResponse)
     assert response.output.output_type == "interactive_animation"
 
 
-def test_run_dive_accepts_table_passage() -> None:
+def test_run_dive_accepts_table_passage(patched_assembly: MagicMock) -> None:
     """A valid table passage returns a valid HarnessBResponse."""
-    response = run_dive(_request(_valid_table()))
+    response = _dive(_valid_table())
     assert isinstance(response, HarnessBResponse)
     assert response.output.output_type == "interactive_animation"
 
 
-def test_run_dive_rejects_invalid_image() -> None:
+def test_run_dive_rejects_invalid_image(patched_assembly: MagicMock) -> None:
     """An image that fails transform validation is rejected, not silently built."""
     with pytest.raises(PassageTransformError):
-        run_dive(_request(ImagePassage(content=b"not an image", media_type="image/png")))
+        _dive(ImagePassage(content=b"not an image", media_type="image/png"))
+    patched_assembly.assert_not_called()
 
 
-def test_run_dive_accepts_type_checked_union_payload() -> None:
+def test_run_dive_accepts_type_checked_union_payload(patched_assembly: MagicMock) -> None:
     """The union type parses request-shaped payloads before the harness runs."""
     passage = _captured_passage_adapter.validate_python(
         {"passage_type": "text", "content": "Typed union payload", "chunk_id": None}
     )
-    response = run_dive(_request(passage))
+    response = _dive(passage)
     assert response.output.output_type == "interactive_animation"


### PR DESCRIPTION
Wire the assembly agent into POST /dive so it grounds a Captured Passage against the ingested corpus through core/retrieval primitives (ADR-0019):

- Anchored text/code passages fetch the parent chunk plus semantic neighbors; the parent is cited first and the anchor chunk and duplicate ids are skipped.
- Every other passage runs the corpus-similarity gate, whose threshold (SIMILARITY_GATE_THRESHOLD) is Depth Dive policy; failing or empty-corpus cases are a valid ungrounded result, not an exception.
- The response's grounded/cited_passages now come from the grounding result. Web search stays no-op (ticket #244) and the artifact payload is still the hardcoded demo (ticket #245).

run_dive now takes the DB session, embedder, and RetrievalConfig so the route can open a session and pass configured dependencies, mirroring the POST /query pattern.