### PR TITLE
feat(depth-dive): add web-search wrapper with retry-once and fallback…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,5 +25,8 @@ QUERY_TOP_K=5
 # Active inference model for generation.
 INFERENCE_MODEL=gpt-4o-mini
 
+# Model used by the Depth Dive web-search client (Responses API web_search tool).
+WEB_SEARCH_MODEL=gpt-4o-mini
+
 # Active reranker model.
 RERANKER_MODEL=rerank-v3.5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,10 +114,10 @@ Rules:
 
 ## What does not exist yet
 
-- **Depth Dive implementation** — `depth_dive/src/depth_dive/` is a stub; `generation/` and `web_search/` subdirectories don't exist yet.
+- **LLM-driven Depth Dive generation** — `depth_dive/src/depth_dive/generation/` only ships the hardcoded demo animation (`demo_animation.py`); the LLM assembly turn that builds a per-request `interactive_animation` from the framing brief, corpus grounding, and web-search results is ticket #245.
 - **`api/routes/__init__.py`** — route modules are imported directly in `server.py`; no package init file exists.
 
-Bootstrap order is complete for the first four packages (`core/` (shared retrieval layer included) → `retrieval_qa/` → `api/` → `ingestion/`), plus the `scripts/` eval & tuning tooling over the `eval_corpus/` tuning set. `depth_dive/` is the remaining package to implement.
+Bootstrap order is complete for all six packages (`core/` (shared retrieval layer included) → `retrieval_qa/` → `depth_dive/` → `api/` → `ingestion/`, plus the `scripts/` eval & tuning tooling over the `eval_corpus/` tuning set). `depth_dive/` now runs the full harness: transform → framing → assembly (corpus grounding + retry-once web search) → demo artifact.
 
 ## Agent skills
 

--- a/api/src/api/dependencies.py
+++ b/api/src/api/dependencies.py
@@ -1,8 +1,8 @@
 """FastAPI dependency providers.
 
 Factories here let route handlers depend on protocols (``Embedder``,
-``CompletionProvider``, ``Reranker``) rather than concrete clients, following
-the dependency inversion principle (ADR-0011, SOLID review).
+``CompletionProvider``, ``Reranker``, ``WebSearchClient``) rather than concrete
+clients, following the dependency inversion principle (ADR-0011, SOLID review).
 """
 
 from core.clients import (
@@ -15,6 +15,7 @@ from core.clients import (
     Reranker,
 )
 from core.config.settings import settings
+from depth_dive.web_search.client import OpenAIWebSearchClient, WebSearchClient
 
 
 def get_embedder() -> Embedder:
@@ -44,4 +45,14 @@ def get_reranker() -> Reranker:
     return NoopReranker()
 
 
-__all__ = ["get_completion_provider", "get_embedder", "get_reranker"]
+def get_web_search_client() -> WebSearchClient:
+    """Return the configured web-search provider for Depth Dive."""
+    return OpenAIWebSearchClient(api_key=settings.openai_api_key)
+
+
+__all__ = [
+    "get_completion_provider",
+    "get_embedder",
+    "get_reranker",
+    "get_web_search_client",
+]

--- a/api/src/api/routes/dive.py
+++ b/api/src/api/routes/dive.py
@@ -4,7 +4,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from api.dependencies import get_embedder
+from api.dependencies import get_embedder, get_web_search_client
 from core.clients import Embedder
 from core.config.settings import settings
 from core.database.connection import db_session
@@ -12,6 +12,7 @@ from core.types.depth_dive import HarnessBRequest, HarnessBResponse
 from core.types.retrieval_config import RetrievalConfig
 from depth_dive.harness import run_dive
 from depth_dive.transform import PassageTransformError
+from depth_dive.web_search.client import WebSearchClient
 
 router = APIRouter(tags=["dive"])
 
@@ -20,17 +21,21 @@ router = APIRouter(tags=["dive"])
 def dive(
     body: HarnessBRequest,
     embeddings_client: Annotated[Embedder, Depends(get_embedder)],
+    web_search: Annotated[WebSearchClient, Depends(get_web_search_client)],
 ) -> HarnessBResponse:
     """Generate a Depth Dive interactive animation for a Captured Passage.
 
     Runs the framing + assembly pipeline (ADR-0020): the assembly agent
-    grounds the passage against the ingested corpus and populates
-    ``grounded``/``cited_passages``. Returns 200 with a ``HarnessBResponse``
+    grounds the passage against the ingested corpus, populates
+    ``grounded``/``cited_passages``, and runs the retry-once web-search step
+    when the brief carries a ``search_intent`` (ADR-0013) — surfacing the
+    outcome on ``external_search_*``. Returns 200 with a ``HarnessBResponse``
     carrying the ``interactive_animation`` scene graph. Passages that violate
     the declared size/bounds or that the tracer bullet does not support are
     rejected with 422 (``PassageTransformError``). Upstream failures map to
     502 / 503 via the ``RetrievalError`` subclass handlers registered on the
-    app; malformed request bodies return 422 via FastAPI defaults.
+    app; malformed request bodies return 422 via FastAPI defaults. A failed
+    web search is a valid degraded response (note + flags), never an error.
     """
     try:
         with db_session() as session:
@@ -43,6 +48,7 @@ def dive(
                     ef_search=settings.hnsw_ef_search,
                     top_k=settings.query_top_k,
                 ),
+                web_search=web_search,
             )
     except PassageTransformError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc

--- a/api/tests/api/test_dive.py
+++ b/api/tests/api/test_dive.py
@@ -211,6 +211,43 @@ def test_dive_grounded_response_populates_citations(
     assert passage["text"] == "corpus chunk"
 
 
+# ============================================================
+# 200 — external_search_* flag wiring (web-search step, ticket #244)
+# ============================================================
+
+
+def test_dive_successful_search_reports_attempted_only(
+    mock_client: TestClient, patched_dive_grounding: Any
+) -> None:
+    """A successful web search leaves attempted=True with no failure or note."""
+    patched_dive_grounding(external_search_attempted=True)
+    response = mock_client.post("/dive", json=_VALID_BODY)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["external_search_attempted"] is True
+    assert body["external_search_failed"] is False
+    assert body["external_search_note"] is None
+
+
+def test_dive_failed_search_surfaces_flag_and_note(
+    mock_client: TestClient, patched_dive_grounding: Any
+) -> None:
+    """A double-failed search surfaces the failed flag and the user-facing note."""
+    patched_dive_grounding(
+        external_search_attempted=True,
+        external_search_failed=True,
+        external_search_note="External grounding was sought but could not be "
+        "retrieved; this dive reflects the ingested corpus only.",
+    )
+    response = mock_client.post("/dive", json=_VALID_BODY)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["external_search_attempted"] is True
+    assert body["external_search_failed"] is True
+    assert body["external_search_note"] is not None
+    assert "external" in body["external_search_note"].lower()
+
+
 def test_dive_applies_worked_example_treatment(
     mock_client: TestClient, patched_dive_grounding: Any
 ) -> None:

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -14,10 +14,16 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from api.dependencies import get_completion_provider, get_embedder, get_reranker
+from api.dependencies import (
+    get_completion_provider,
+    get_embedder,
+    get_reranker,
+    get_web_search_client,
+)
 from api.server import create_app
 from core.clients import InMemoryEmbedder, MockCompletionProvider, NoopReranker
 from core.types.responses import CitedPassage, RetrievalResult, ScoredChunk
+from depth_dive.web_search.client import StubWebSearchClient
 
 IngestADocument = Callable[[str], str]
 
@@ -88,6 +94,7 @@ def client(override_route_db_session: object) -> TestClient:
     app.dependency_overrides[get_embedder] = _default_fake_embedder
     app.dependency_overrides[get_completion_provider] = _default_fake_llm_refusal_provider
     app.dependency_overrides[get_reranker] = lambda: NoopReranker()
+    app.dependency_overrides[get_web_search_client] = lambda: StubWebSearchClient()
     return TestClient(app)
 
 
@@ -122,28 +129,39 @@ def mock_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     app.dependency_overrides[get_embedder] = _default_fake_embedder
     app.dependency_overrides[get_completion_provider] = _default_fake_llm_refusal_provider
     app.dependency_overrides[get_reranker] = lambda: NoopReranker()
+    app.dependency_overrides[get_web_search_client] = lambda: StubWebSearchClient()
     return TestClient(app)
 
 
 @pytest.fixture
 def patched_dive_grounding(
     monkeypatch: pytest.MonkeyPatch,
-) -> Callable[[bool, Sequence[CitedPassage] | None], None]:
+) -> Callable[..., None]:
     """Return a factory that patches ``depth_dive.harness.run_assembly``.
 
-    Sets the assembly grounding outcome the harness should report, so the
-    POST /dive route can be exercised without a database.
+    Sets the assembly outcome (grounding plus the ``external_search_*``
+    flags) the harness should report, so the POST /dive route can be
+    exercised without a database.
     """
 
     def _patch(
-        grounded: bool = False, cited_passages: Sequence[CitedPassage] | None = None
+        grounded: bool = False,
+        cited_passages: Sequence[CitedPassage] | None = None,
+        *,
+        external_search_attempted: bool = False,
+        external_search_failed: bool = False,
+        external_search_note: str | None = None,
     ) -> None:
-        from depth_dive.assembly.assembly_agent import GroundingResult
+        from depth_dive.assembly.assembly_agent import AssemblyResult
 
         monkeypatch.setattr(
             "depth_dive.harness.run_assembly",
-            lambda *args, **kwargs: GroundingResult(
-                grounded=grounded, cited_passages=list(cited_passages or [])
+            lambda *args, **kwargs: AssemblyResult(
+                grounded=grounded,
+                cited_passages=list(cited_passages or []),
+                external_search_attempted=external_search_attempted,
+                external_search_failed=external_search_failed,
+                external_search_note=external_search_note,
             ),
         )
 

--- a/conftest.py
+++ b/conftest.py
@@ -28,7 +28,9 @@ import api.server  # noqa: F401
 import core.retrieval.query  # noqa: F401
 import depth_dive.generation.demo_animation
 import depth_dive.harness
-import depth_dive.transform  # noqa: F401
+import depth_dive.transform
+import depth_dive.web_search.client
+import depth_dive.web_search.wrapper  # noqa: F401
 import ingestion.tasks  # noqa: F401
 import retrieval_qa.chunking.book_chunker
 import retrieval_qa.chunking.documentation_chunker

--- a/core/src/core/config/settings.py
+++ b/core/src/core/config/settings.py
@@ -20,6 +20,8 @@ class Settings(BaseSettings):
         query_top_k: Number of chunks the retrieval step fetches per query
             (server-side infra knob, not client-controlled per ADR-0014).
         inference_model: Active chat-completion model ID for generation.
+        web_search_model: Model used by the Depth Dive web-search client
+            (OpenAI Responses API ``web_search`` tool).
         max_upload_bytes: Maximum accepted upload size in bytes.
         allowed_file_extensions: Lower-case file extensions accepted for upload.
     """
@@ -38,6 +40,7 @@ class Settings(BaseSettings):
     hnsw_ef_search: int = 40
     query_top_k: int = 5
     inference_model: str = "gpt-4o-mini"
+    web_search_model: str = "gpt-4o-mini"
     max_upload_bytes: int = 100 * 1024 * 1024  # 100 MB placeholder
     allowed_file_extensions: set[str] = {"pdf", "epub", "md", "html"}
     cohere_api_key: str | None = None

--- a/depth_dive/pyproject.toml
+++ b/depth_dive/pyproject.toml
@@ -7,7 +7,11 @@ name = "depth-dive"
 version = "0.1.0"
 requires-python = ">=3.12"
 license = "MIT"
-dependencies = ["core", "Pillow>=12.0"]
+dependencies = [
+    "core",
+    "Pillow>=12.0",
+    "openai>=2.51.0",
+]
 
 [tool.uv.sources]
 core = { workspace = true }

--- a/depth_dive/src/depth_dive/assembly/__init__.py
+++ b/depth_dive/src/depth_dive/assembly/__init__.py
@@ -1,14 +1,14 @@
-"""Assembly agent: grounds and builds the dive (ADR-0020, ticket #243).
+"""Assembly agent: grounds and builds the dive (ADR-0020, tickets #243, #244).
 
 Consumes the :class:`~depth_dive.framing.framing_agent.FramingBrief` and
 grounds the dive against the ingested corpus via the shared ``core/retrieval/``
 primitives (ADR-0019): anchored ``text``/``code`` passages fetch the parent
 chunk plus semantic neighbors, and every other passage runs the
-corpus-similarity gate. The brief's ``search_intent`` drives the web-search
-step once it lands (ticket #244); the artifact payload stays the hardcoded
-demo until LLM generation lands (ticket #245).
+corpus-similarity gate. The brief's ``search_intent`` drives the retry-once
+web-search step (ADR-0013, ticket #244); the artifact payload stays the
+hardcoded demo until LLM generation lands (ticket #245).
 """
 
-from depth_dive.assembly.assembly_agent import GroundingResult, run_assembly
+from depth_dive.assembly.assembly_agent import AssemblyResult, run_assembly
 
-__all__ = ["GroundingResult", "run_assembly"]
+__all__ = ["AssemblyResult", "run_assembly"]

--- a/depth_dive/src/depth_dive/assembly/assembly_agent.py
+++ b/depth_dive/src/depth_dive/assembly/assembly_agent.py
@@ -1,4 +1,4 @@
-"""Assembly agent implementation (ADR-0020, ticket #243).
+"""Assembly agent implementation (ADR-0020, tickets #243, #244).
 
 Consumes the framing brief and grounds the dive against the ingested corpus
 through the shared ``core/retrieval/`` primitives (ADR-0019):
@@ -9,14 +9,16 @@ through the shared ``core/retrieval/`` primitives (ADR-0019):
   embeddable representation; the gate's threshold and grounded/unverified
   judgement are Depth Dive harness policy (ADR-0019, ADR-0020).
 
-The brief's ``search_intent`` is consumed by the web-search step once it
-lands (ticket #244); the artifact payload stays the hardcoded demo until LLM
-generation lands (ticket #245).
+The brief's ``search_intent`` drives the web-search step (ticket #244): when
+the framing agent judged external grounding would help (ADR-0012), the
+assembly agent calls the retry-once web-search wrapper (ADR-0013) and surfaces
+the outcome on :class:`AssemblyResult`. The artifact payload stays the
+hardcoded demo until LLM generation lands (ticket #245).
 """
 
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
 
 from core.clients import Embedder
@@ -33,6 +35,8 @@ from core.types.captured_passage import (
 from core.types.responses import CitedPassage
 from core.types.retrieval_config import RetrievalConfig
 from depth_dive.framing.framing_agent import FramingBrief
+from depth_dive.web_search.client import WebSearchClient, WebSearchResult
+from depth_dive.web_search.wrapper import SearchOutcome, run_web_search
 
 SIMILARITY_GATE_THRESHOLD: float = 0.5
 """Cosine-similarity floor for the unanchored-passage corpus gate.
@@ -47,17 +51,41 @@ retrieval evaluation.
 
 
 class GroundingResult(BaseModel):
-    """The corpus-grounding outcome of the assembly agent.
+    """The corpus-grounding outcome for one dive.
 
     ``grounded`` follows the Harness A semantics (same field on
-    ``HarnessBResponse``): True when the ingested corpus vouches for the
-    dive. ``cited_passages`` is empty whenever ``grounded`` is False.
+    ``HarnessBResponse``): True when the ingested corpus vouches for the dive.
+    ``cited_passages`` is empty whenever ``grounded`` is False. Internal to
+    the assembly agent — :class:`AssemblyResult` composes it with the
+    web-search outcome.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     grounded: bool
     cited_passages: list[CitedPassage]
+
+
+class AssemblyResult(BaseModel):
+    """The assembly agent's outcome for one dive.
+
+    ``grounded`` and ``cited_passages`` follow the Harness A semantics (same
+    fields on ``HarnessBResponse``): True when the ingested corpus vouches for
+    the dive, and ``cited_passages`` empty whenever ``grounded`` is False.
+    ``external_search_*`` carry the web-search outcome (ADR-0013), and
+    ``external_search_results`` the surfaced external material for the
+    generation step (ticket #245); the internal results are not exposed on the
+    response.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    grounded: bool
+    cited_passages: list[CitedPassage]
+    external_search_attempted: bool = False
+    external_search_failed: bool = False
+    external_search_note: str | None = None
+    external_search_results: list[WebSearchResult] = Field(default_factory=list)
 
 
 def run_assembly(
@@ -67,22 +95,26 @@ def run_assembly(
     session: Session,
     embedder: Embedder,
     config: RetrievalConfig,
-) -> GroundingResult:
-    """Ground one captured passage against the ingested corpus.
+    web_search: WebSearchClient,
+) -> AssemblyResult:
+    """Ground one captured passage and run the web-search step.
 
     Args:
         passage: The captured passage carried in the request.
         brief: The framing agent's creative brief for this dive. Its
-            ``search_intent`` drives the web-search step (ticket #244);
-            corpus grounding in this slice is keyed on the passage's anchor.
+            ``search_intent`` drives the web-search step (ADR-0012, ADR-0013);
+            corpus grounding is keyed on the passage's anchor.
         session: SQLAlchemy session bound to the documents database.
         embedder: Provider used to embed the passage content (1536-dim).
         config: Retrieval configuration (model name, ef_search, top_k).
+        web_search: Provider for the web-search step; called only when the
+            brief carries a ``search_intent``.
 
     Returns:
-        A ``GroundingResult`` carrying the grounded flag and the cited
-        passages. An unresolvable anchor or a failed similarity gate is a
-        valid ungrounded result, never an exception.
+        An ``AssemblyResult`` carrying the grounded flag, the cited passages,
+        and the web-search outcome. An unresolvable anchor or a failed
+        similarity gate is a valid ungrounded result, and a failed search is a
+        valid degraded outcome (with a note) — never exceptions.
 
     Raises:
         UpstreamBadResponse: The embeddings API returned an unexpected
@@ -91,10 +123,32 @@ def run_assembly(
             unreachable (route maps to 503).
     """
     if isinstance(passage, (TextPassage, CodePassage)) and passage.chunk_id is not None:
-        return _ground_anchored(
+        grounding = _ground_anchored(
             passage, passage.chunk_id, session=session, embedder=embedder, config=config
         )
-    return _ground_via_gate(passage, session=session, embedder=embedder, config=config)
+    else:
+        grounding = _ground_via_gate(passage, session=session, embedder=embedder, config=config)
+    outcome = _search_outcome(brief, web_search)
+    return AssemblyResult(
+        grounded=grounding.grounded,
+        cited_passages=grounding.cited_passages,
+        external_search_attempted=outcome.attempted,
+        external_search_failed=outcome.failed,
+        external_search_note=outcome.note,
+        external_search_results=outcome.results,
+    )
+
+
+def _search_outcome(brief: FramingBrief, web_search: WebSearchClient) -> SearchOutcome:
+    """Run the web-search step when the brief carries a search intent.
+
+    Called only when the framing agent judged external grounding would help
+    (ADR-0012) — the brief's ``search_intent`` is present. Otherwise the step
+    is a no-op and no search call is made.
+    """
+    if not brief.search_intent:
+        return SearchOutcome(attempted=False)
+    return run_web_search(brief.search_intent, web_search)
 
 
 def _ground_anchored(
@@ -198,4 +252,4 @@ def _serialize_row(row: TableRow) -> str:
     return " | ".join(row)
 
 
-__all__ = ["SIMILARITY_GATE_THRESHOLD", "GroundingResult", "run_assembly"]
+__all__ = ["SIMILARITY_GATE_THRESHOLD", "AssemblyResult", "run_assembly"]

--- a/depth_dive/src/depth_dive/harness.py
+++ b/depth_dive/src/depth_dive/harness.py
@@ -4,9 +4,10 @@ Runs the Depth Dive pipeline for one ``HarnessBRequest`` and returns a
 ``HarnessBResponse``. The passage is validated by the Passage Transform stage,
 the framing agent resolves the treatment set and search intent (ticket #242),
 and the assembly agent grounds the passage against the ingested corpus via the
-shared ``core/retrieval/`` primitives (ticket #243). Web search does not
-participate yet (ticket #244), so the search flags stay off; the artifact
-payload stays the hardcoded demo until LLM generation lands (ticket #245).
+shared ``core/retrieval/`` primitives (ticket #243) and runs the retry-once
+web-search step when the brief carries a ``search_intent`` (ticket #244). The
+artifact payload stays the hardcoded demo until LLM generation lands (ticket
+#245).
 """
 
 from sqlalchemy.orm import Session
@@ -18,6 +19,7 @@ from depth_dive.assembly.assembly_agent import run_assembly
 from depth_dive.framing.framing_agent import run_framing
 from depth_dive.generation.demo_animation import build_demo_animation
 from depth_dive.transform import transform_passage
+from depth_dive.web_search.client import WebSearchClient
 
 
 def run_dive(
@@ -26,6 +28,7 @@ def run_dive(
     session: Session,
     embedder: Embedder,
     config: RetrievalConfig,
+    web_search: WebSearchClient,
 ) -> HarnessBResponse:
     """Validate a request and return the dive response.
 
@@ -36,13 +39,15 @@ def run_dive(
         embedder: Provider used to embed the passage for grounding
             (1536-dim).
         config: Retrieval configuration (model name, ef_search, top_k).
+        web_search: Web-search provider used by the assembly agent when the
+            framing brief carries a ``search_intent`` (ADR-0012, ADR-0013).
 
     Returns:
         A ``HarnessBResponse`` whose ``output`` is the hardcoded demo
         ``interactive_animation`` scene graph, whose treatment fields come
-        from the framing agent, and whose ``grounded``/``cited_passages``
-        come from the assembly agent's corpus grounding. The search flags
-        stay off until the web-search step lands (ticket #244).
+        from the framing agent, whose ``grounded``/``cited_passages`` come
+        from the assembly agent's corpus grounding, and whose
+        ``external_search_*`` fields come from the web-search step.
 
     Raises:
         PassageTransformError: The passage violates the declared size/bounds
@@ -58,22 +63,24 @@ def run_dive(
         requested_treatments=request.requested_treatments,
         preferred_treatments=request.preferred_treatments,
     )
-    grounding = run_assembly(
+    assembly = run_assembly(
         request.captured_passage,
         brief,
         session=session,
         embedder=embedder,
         config=config,
+        web_search=web_search,
     )
     return HarnessBResponse(
         output=build_demo_animation(),
         recommended_treatments=brief.recommended_treatments,
         applied_treatments=brief.applied_treatments,
         routing_note=brief.routing_note,
-        grounded=grounding.grounded,
-        external_search_attempted=False,
-        external_search_failed=False,
-        cited_passages=grounding.cited_passages,
+        grounded=assembly.grounded,
+        external_search_attempted=assembly.external_search_attempted,
+        external_search_failed=assembly.external_search_failed,
+        external_search_note=assembly.external_search_note,
+        cited_passages=assembly.cited_passages,
     )
 
 

--- a/depth_dive/src/depth_dive/web_search/__init__.py
+++ b/depth_dive/src/depth_dive/web_search/__init__.py
@@ -1,0 +1,28 @@
+"""Web-search tool wrapper for Depth Dive (ADR-0012, ADR-0013).
+
+The framing agent decides per-request whether external grounding would help
+(``search_intent``); the assembly agent calls this wrapper only when the brief
+carries one. The wrapper retries once on failure and falls back with a
+user-facing note if the retry also fails (ADR-0013). Lives inside Depth Dive,
+not a generic tool (ai-system-tree.md).
+"""
+
+from depth_dive.web_search.client import (
+    OpenAIWebSearchClient,
+    StubWebSearchClient,
+    WebSearchClient,
+    WebSearchError,
+    WebSearchResult,
+)
+from depth_dive.web_search.wrapper import FALLBACK_NOTE, SearchOutcome, run_web_search
+
+__all__ = [
+    "FALLBACK_NOTE",
+    "OpenAIWebSearchClient",
+    "SearchOutcome",
+    "StubWebSearchClient",
+    "WebSearchClient",
+    "WebSearchError",
+    "WebSearchResult",
+    "run_web_search",
+]

--- a/depth_dive/src/depth_dive/web_search/client.py
+++ b/depth_dive/src/depth_dive/web_search/client.py
@@ -1,0 +1,221 @@
+"""Web-search provider clients for Depth Dive (ADR-0012, ADR-0013).
+
+Depth Dive is permitted to extend beyond the ingested corpus via web search.
+The framing agent judges per-request whether external grounding would help
+(ADR-0012); this module owns the provider call. A failed search is a *valid,
+degraded* outcome — the retry-once wrapper converts ``WebSearchError`` into a
+fallback with a user-facing note (ADR-0013), so web-search failures never map
+to the route's 502/503 upstream errors.
+"""
+
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+from openai import OpenAI, OpenAIError
+from openai.types.responses import (
+    Response,
+    ResponseFunctionWebSearch,
+    ResponseOutputMessage,
+    ResponseOutputText,
+)
+from openai.types.responses.response_output_text import AnnotationURLCitation
+from pydantic import BaseModel, ConfigDict
+
+from core.config.settings import settings
+
+
+class WebSearchError(Exception):
+    """A web-search provider call failed.
+
+    Depth Dive's own failure type (ADR-0013). ``WebSearchError`` is *not* a
+    ``RetrievalError`` subclass on purpose: a failed search is a graceful
+    fallback for the dive, not an upstream error the route should map to
+    502/503.
+    """
+
+
+class WebSearchResult(BaseModel):
+    """One external-material item surfaced by web search (ADR-0012).
+
+    ``snippet`` is the short, quote-safe span actually cited by the search,
+    and ``url`` is its source — short quotes only, always paired with a
+    source citation (ADR-0012).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: str
+    url: str
+    snippet: str
+
+
+@runtime_checkable
+class WebSearchClient(Protocol):
+    """Protocol for synchronous web-search providers.
+
+    Consumers depend on this protocol rather than a concrete client so that
+    hosted API clients, in-memory test doubles, and future providers are
+    interchangeable.
+    """
+
+    def search(self, query: str) -> list[WebSearchResult]:
+        """Search the web for external grounding material.
+
+        Args:
+            query: The search intent from the framing brief.
+
+        Returns:
+            One ``WebSearchResult`` per surfaced source; ``[]`` when no useful
+            results were found.
+
+        Raises:
+            WebSearchError: The provider call failed (timeout, API error,
+                failed search).
+        """
+        ...
+
+
+class OpenAIWebSearchClient:
+    """Web-search provider backed by OpenAI's Responses API ``web_search`` tool.
+
+    Each ``search()`` call issues one response with the ``web_search`` tool
+    enabled and surfaces the model's ``url_citation`` annotations as
+    ``WebSearchResult`` items — the snippet is the exact cited span of the
+    answer text, which keeps external material quote-safe (ADR-0012).
+    """
+
+    def __init__(self, api_key: str | None = None, model: str | None = None) -> None:
+        """Initialize the client.
+
+        Args:
+            api_key: OpenAI API key. Defaults to ``settings.openai_api_key``.
+            model: Model used for the search response. Defaults to
+                ``settings.web_search_model``.
+        """
+        self._model = model or settings.web_search_model
+        self._api_key = api_key or settings.openai_api_key
+        self._client: OpenAI | None = None
+
+    def _get_client(self) -> OpenAI:
+        if self._client is None:
+            self._client = OpenAI(api_key=self._api_key, timeout=30.0, max_retries=0)
+        return self._client
+
+    def search(self, query: str) -> list[WebSearchResult]:
+        """Search the web and return the cited external material.
+
+        Args:
+            query: The search intent from the framing brief.
+
+        Returns:
+            One ``WebSearchResult`` per ``url_citation`` annotation on the
+            answer text.
+
+        Raises:
+            WebSearchError: The client could not be constructed (missing API
+                key), the API was unreachable, returned a bad status, or the
+                ``web_search_call`` itself failed.
+        """
+        try:
+            response = self._get_client().responses.create(
+                model=self._model,
+                tools=[{"type": "web_search"}],
+                input=query,
+            )
+        except OpenAIError as exc:
+            # ``OpenAIError`` is the SDK's base failure type: it covers
+            # construction-time errors (e.g. a missing API key), connection
+            # failures, and bad API statuses alike. Everything converts to
+            # ``WebSearchError`` so the retry wrapper can fall back gracefully
+            # (ADR-0013) instead of leaking a 5xx to the route.
+            raise WebSearchError(f"Web search API failed: {exc}") from exc
+        return self._parse_response(response)
+
+    @staticmethod
+    def _parse_response(response: Response) -> list[WebSearchResult]:
+        """Extract cited web sources from a Responses API output.
+
+        A ``web_search_call`` item whose status is ``failed`` means the search
+        itself failed even though the HTTP call succeeded. Otherwise the cited
+        sources live in ``url_citation`` annotations on the answer text, with
+        the snippet being the exact cited span.
+
+        Args:
+            response: The raw ``Response`` from the OpenAI SDK.
+
+        Returns:
+            One ``WebSearchResult`` per cited URL.
+
+        Raises:
+            WebSearchError: The search tool reported a failed search.
+        """
+        if any(
+            isinstance(item, ResponseFunctionWebSearch) and item.status == "failed"
+            for item in response.output
+        ):
+            raise WebSearchError("Web search tool reported a failed search")
+        results: list[WebSearchResult] = []
+        for item in response.output:
+            if not isinstance(item, ResponseOutputMessage):
+                continue
+            for part in item.content:
+                if not isinstance(part, ResponseOutputText):
+                    continue
+                for annotation in part.annotations:
+                    if not isinstance(annotation, AnnotationURLCitation):
+                        continue
+                    if not (0 <= annotation.start_index <= annotation.end_index <= len(part.text)):
+                        continue
+                    snippet = part.text[annotation.start_index : annotation.end_index]
+                    results.append(
+                        WebSearchResult(
+                            title=annotation.title,
+                            url=annotation.url,
+                            snippet=snippet,
+                        )
+                    )
+        return results
+
+
+class StubWebSearchClient:
+    """Deterministic, in-memory web-search client for tests and local dev.
+
+    Implements ``WebSearchClient`` without calling a hosted API: returns its
+    configured results for every query, or raises ``WebSearchError`` for a
+    configured number of calls before succeeding — letting the retry wrapper
+    be exercised without any network access.
+    """
+
+    def __init__(
+        self,
+        *,
+        results: Sequence[WebSearchResult] | None = None,
+        failures: int = 0,
+    ) -> None:
+        """Initialize the stub.
+
+        Args:
+            results: Results to return for every query. Defaults to ``[]``.
+            failures: Number of consecutive ``WebSearchError`` failures to
+                raise before returning results.
+        """
+        self._results = list(results or [])
+        self._failures = failures
+        self.calls: list[str] = []
+
+    def search(self, query: str) -> list[WebSearchResult]:
+        """Return the configured results, raising while failures remain."""
+        self.calls.append(query)
+        if self._failures > 0:
+            self._failures -= 1
+            raise WebSearchError("stub search failure")
+        return list(self._results)
+
+
+__all__ = [
+    "OpenAIWebSearchClient",
+    "StubWebSearchClient",
+    "WebSearchClient",
+    "WebSearchError",
+    "WebSearchResult",
+]

--- a/depth_dive/src/depth_dive/web_search/wrapper.py
+++ b/depth_dive/src/depth_dive/web_search/wrapper.py
@@ -1,0 +1,75 @@
+"""Retry-once web-search wrapper with fallback (ADR-0013, ticket #244).
+
+The assembly agent calls :func:`run_web_search` when the framing brief carries
+a ``search_intent``. The wrapper bounds the failure path: one retry for a
+failed or result-less search, then a graceful fallback that flags the missing
+external grounding with a user-facing note instead of silently degrading.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from depth_dive.web_search.client import WebSearchClient, WebSearchError, WebSearchResult
+
+FALLBACK_NOTE = (
+    "External grounding was sought but could not be retrieved; "
+    "this dive reflects the ingested corpus only."
+)
+"""User-facing note attached to a dive whose web search failed twice (ADR-0013)."""
+
+
+class SearchOutcome(BaseModel):
+    """The outcome of the web-search step for one dive (ADR-0013).
+
+    ``attempted`` is True whenever the wrapper issued at least one search;
+    ``failed`` is True when the retry also failed or returned nothing useful,
+    in which case ``note`` carries the user-facing fallback message and
+    ``results`` is empty. A successful outcome carries the external material
+    for the generation step (ticket #245).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    attempted: bool
+    failed: bool = False
+    note: str | None = None
+    results: list[WebSearchResult] = Field(default_factory=list)
+
+
+def run_web_search(query: str, client: WebSearchClient) -> SearchOutcome:
+    """Run one web search with retry-once and fallback (ADR-0013).
+
+    Args:
+        query: The framing brief's ``search_intent`` for this dive.
+        client: The web-search provider.
+
+    Returns:
+        A ``SearchOutcome``. An empty or whitespace-only query is not a search
+        (``attempted=False``). A failed or result-less attempt is retried
+        exactly once; a second failure yields ``failed=True`` with a
+        user-facing ``note`` and no results. Failures never propagate — the
+        dive still renders, just without external material.
+    """
+    if not query.strip():
+        return SearchOutcome(attempted=False)
+    first = _attempt(query, client)
+    if first is not None and first:
+        return SearchOutcome(attempted=True, results=first)
+    second = _attempt(query, client)
+    if second is not None and second:
+        return SearchOutcome(attempted=True, results=second)
+    return SearchOutcome(attempted=True, failed=True, note=FALLBACK_NOTE)
+
+
+def _attempt(query: str, client: WebSearchClient) -> list[WebSearchResult] | None:
+    """Run one search attempt; ``None`` means the provider call failed.
+
+    An empty result list is a valid return but counts as "no useful results"
+    (ADR-0013), so the wrapper treats it like a failure and retries.
+    """
+    try:
+        return client.search(query)
+    except WebSearchError:
+        return None
+
+
+__all__ = ["FALLBACK_NOTE", "SearchOutcome", "run_web_search"]

--- a/depth_dive/tests/depth_dive/assembly/test_assembly_agent.py
+++ b/depth_dive/tests/depth_dive/assembly/test_assembly_agent.py
@@ -1,9 +1,10 @@
-"""Tests for the Depth Dive assembly agent (ADR-0020, ticket #243).
+"""Tests for the Depth Dive assembly agent (ADR-0020, ticket #243, #244).
 
 The ``core/retrieval/`` primitives are mocked at the assembly module boundary
 (their database behaviour is covered by ``core``'s own retrieval tests) and the
-embedder is a stub, per coding-standards.md: hosted API calls stay out of unit
-tests.
+embedder is a stub; the web-search provider is the deterministic
+``StubWebSearchClient``. Hosted API calls stay out of unit tests per
+coding-standards.md.
 """
 
 from collections.abc import Sequence
@@ -27,10 +28,12 @@ from core.types.retrieval_config import RetrievalConfig
 from depth_dive.assembly import assembly_agent
 from depth_dive.assembly.assembly_agent import (
     SIMILARITY_GATE_THRESHOLD,
-    GroundingResult,
+    AssemblyResult,
     run_assembly,
 )
 from depth_dive.framing.framing_agent import run_framing
+from depth_dive.web_search.client import StubWebSearchClient, WebSearchResult
+from depth_dive.web_search.wrapper import FALLBACK_NOTE
 
 _CONFIG = RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=5)
 
@@ -51,13 +54,22 @@ def _neighbor(chunk_id: UUID, text: str, score: float) -> ScoredChunk:
     return ScoredChunk(chunk_id=chunk_id, text=text, score=score)
 
 
-def _run(passage: CapturedPassage, *, session: Session, embedder: Embedder) -> GroundingResult:
+def _run(
+    passage: CapturedPassage,
+    *,
+    session: Session,
+    embedder: Embedder,
+    web_search: StubWebSearchClient | None = None,
+) -> AssemblyResult:
+    if web_search is None:
+        web_search = StubWebSearchClient()
     return run_assembly(
         passage,
         run_framing(passage),
         session=session,
         embedder=embedder,
         config=_CONFIG,
+        web_search=web_search,
     )
 
 
@@ -325,6 +337,118 @@ def test_anchored_image_falls_back_to_gate(monkeypatch: pytest.MonkeyPatch) -> N
     assert result.grounded is True
     assert [p.chunk_id for p in result.cited_passages] == [close_id]
     fetch_parent.assert_not_called()
+
+
+# ============================================================
+# Web search: triggered by the brief's search_intent (ticket #244)
+# ============================================================
+
+
+def _passing_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch retrieval so an unanchored text passage clears the similarity gate."""
+    monkeypatch.setattr(assembly_agent, "fetch_parent_chunk", MagicMock())
+    monkeypatch.setattr(
+        assembly_agent,
+        "search_dense_neighbors",
+        MagicMock(return_value=[_neighbor(uuid4(), "similar chunk", 0.9)]),
+    )
+
+
+def test_assembly_runs_web_search_when_brief_carries_search_intent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unanchored passage with a search intent triggers the web-search step."""
+    _passing_gate(monkeypatch)
+    results = [
+        WebSearchResult(title="Paper", url="https://example.com/paper", snippet="short quote")
+    ]
+    client = StubWebSearchClient(results=results)
+
+    passage = TextPassage(content="Attention is all you need.")
+    result = _run(passage, session=MagicMock(), embedder=_StubEmbedder(), web_search=client)
+
+    assert result.external_search_attempted is True
+    assert result.external_search_failed is False
+    assert result.external_search_note is None
+    assert result.external_search_results == results
+    assert client.calls == ["Attention is all you need."]
+
+
+def test_assembly_skips_web_search_without_search_intent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An anchored passage has no search intent, so the search client is never called."""
+    monkeypatch.setattr(
+        assembly_agent,
+        "fetch_parent_chunk",
+        MagicMock(return_value=CitedPassage(chunk_id=uuid4(), text="parent")),
+    )
+    monkeypatch.setattr(assembly_agent, "search_dense_neighbors", MagicMock(return_value=[]))
+    client = StubWebSearchClient()
+
+    passage = TextPassage(content="Attention is all you need.", chunk_id=uuid4())
+    result = _run(passage, session=MagicMock(), embedder=_StubEmbedder(), web_search=client)
+
+    assert result.external_search_attempted is False
+    assert result.external_search_failed is False
+    assert result.external_search_note is None
+    assert result.external_search_results == []
+    assert client.calls == []
+
+
+def test_assembly_search_double_failure_sets_failed_and_note(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two failed attempts set the failed flag and carry the user-facing note."""
+    _passing_gate(monkeypatch)
+    client = StubWebSearchClient(results=[], failures=2)
+
+    passage = TextPassage(content="Attention is all you need.")
+    result = _run(passage, session=MagicMock(), embedder=_StubEmbedder(), web_search=client)
+
+    assert result.external_search_attempted is True
+    assert result.external_search_failed is True
+    assert result.external_search_note == FALLBACK_NOTE
+    assert result.external_search_results == []
+    assert len(client.calls) == 2
+
+
+def test_assembly_search_recovers_on_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A transient failure is retried exactly once and the search succeeds."""
+    _passing_gate(monkeypatch)
+    results = [
+        WebSearchResult(title="Recovered", url="https://example.com/recovered", snippet="span")
+    ]
+    client = StubWebSearchClient(results=results, failures=1)
+
+    passage = TextPassage(content="Attention is all you need.")
+    result = _run(passage, session=MagicMock(), embedder=_StubEmbedder(), web_search=client)
+
+    assert result.external_search_attempted is True
+    assert result.external_search_failed is False
+    assert result.external_search_results == results
+    assert len(client.calls) == 2
+
+
+def test_assembly_search_failure_still_reports_grounding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed search does not degrade the corpus-grounding outcome."""
+    _passing_gate(monkeypatch)
+    close_id = uuid4()
+    monkeypatch.setattr(
+        assembly_agent,
+        "search_dense_neighbors",
+        MagicMock(return_value=[_neighbor(close_id, "similar chunk", 0.9)]),
+    )
+    client = StubWebSearchClient(results=[], failures=2)
+
+    passage = TextPassage(content="Attention is all you need.")
+    result = _run(passage, session=MagicMock(), embedder=_StubEmbedder(), web_search=client)
+
+    assert result.grounded is True
+    assert [p.chunk_id for p in result.cited_passages] == [close_id]
+    assert result.external_search_failed is True
 
 
 # ============================================================

--- a/depth_dive/tests/depth_dive/test_harness.py
+++ b/depth_dive/tests/depth_dive/test_harness.py
@@ -1,8 +1,9 @@
 """Tests for the Depth Dive harness entrypoint (ADR-0020).
 
 The assembly agent is mocked at the harness boundary (its own suite covers
-grounding policy) so these tests exercise orchestration only: transform ->
-framing -> assembly -> response assembly.
+grounding and search policy) so these tests exercise orchestration only:
+transform -> framing -> assembly -> response assembly. The web-search provider
+is the deterministic ``StubWebSearchClient``.
 """
 
 import io
@@ -29,10 +30,12 @@ from core.types.depth_dive import (
 from core.types.responses import CitedPassage
 from core.types.retrieval_config import RetrievalConfig
 from depth_dive import harness
-from depth_dive.assembly.assembly_agent import GroundingResult
+from depth_dive.assembly.assembly_agent import AssemblyResult
 from depth_dive.framing.framing_agent import FramingBrief
 from depth_dive.harness import run_dive
 from depth_dive.transform import PassageTransformError
+from depth_dive.web_search.client import StubWebSearchClient, WebSearchResult
+from depth_dive.web_search.wrapper import FALLBACK_NOTE
 
 _VALID_TEXT = TextPassage(content="Attention is all you need.")
 _captured_passage_adapter: TypeAdapter[CapturedPassage] = TypeAdapter(CapturedPassage)
@@ -43,17 +46,22 @@ _CONFIG = RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top
 @pytest.fixture
 def patched_assembly(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     """Patch ``run_assembly`` to return an ungrounded result by default."""
-    assembly = MagicMock(return_value=GroundingResult(grounded=False, cited_passages=[]))
+    assembly = MagicMock(return_value=AssemblyResult(grounded=False, cited_passages=[]))
     monkeypatch.setattr(harness, "run_assembly", assembly)
     return assembly
 
 
-def _dive(passage: CapturedPassage) -> HarnessBResponse:
+def _dive(
+    passage: CapturedPassage,
+    *,
+    web_search: StubWebSearchClient | None = None,
+) -> HarnessBResponse:
     return run_dive(
         HarnessBRequest(captured_passage=passage),
         session=MagicMock(),
         embedder=InMemoryEmbedder(),
         config=_CONFIG,
+        web_search=web_search or StubWebSearchClient(),
     )
 
 
@@ -99,7 +107,7 @@ def test_run_dive_mirrors_grounded_assembly_result(
     """A grounded assembly result populates grounded and cited_passages."""
     passage_id = uuid4()
     assembly = MagicMock(
-        return_value=GroundingResult(
+        return_value=AssemblyResult(
             grounded=True,
             cited_passages=[CitedPassage(chunk_id=passage_id, text="cited corpus chunk")],
         )
@@ -114,6 +122,70 @@ def test_run_dive_mirrors_grounded_assembly_result(
     assert response.cited_passages[0].text == "cited corpus chunk"
 
 
+def test_run_dive_mirrors_successful_search_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful search leaves the failed flag off and no note."""
+    results = [
+        WebSearchResult(title="Paper", url="https://example.com/paper", snippet="short quote")
+    ]
+    assembly = MagicMock(
+        return_value=AssemblyResult(
+            grounded=False,
+            cited_passages=[],
+            external_search_attempted=True,
+            external_search_failed=False,
+            external_search_results=results,
+        )
+    )
+    monkeypatch.setattr(harness, "run_assembly", assembly)
+
+    response = _dive(_VALID_TEXT)
+
+    assert response.external_search_attempted is True
+    assert response.external_search_failed is False
+    assert response.external_search_note is None
+
+
+def test_run_dive_mirrors_failed_search_outcome(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A double-failed search surfaces the failed flag and the user-facing note."""
+    assembly = MagicMock(
+        return_value=AssemblyResult(
+            grounded=False,
+            cited_passages=[],
+            external_search_attempted=True,
+            external_search_failed=True,
+            external_search_note=FALLBACK_NOTE,
+        )
+    )
+    monkeypatch.setattr(harness, "run_assembly", assembly)
+
+    response = _dive(_VALID_TEXT)
+
+    assert response.external_search_attempted is True
+    assert response.external_search_failed is True
+    assert response.external_search_note == FALLBACK_NOTE
+
+
+def test_run_dive_passes_web_search_client_to_assembly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The harness hands the web-search provider to the assembly agent."""
+    assembly = MagicMock(return_value=AssemblyResult(grounded=False, cited_passages=[]))
+    monkeypatch.setattr(harness, "run_assembly", assembly)
+    client = StubWebSearchClient()
+
+    run_dive(
+        HarnessBRequest(captured_passage=_VALID_TEXT),
+        session=MagicMock(),
+        embedder=InMemoryEmbedder(),
+        config=_CONFIG,
+        web_search=client,
+    )
+
+    assert assembly.call_args.kwargs["web_search"] is client
+
+
 def test_run_dive_passes_passage_and_brief_to_assembly(
     patched_assembly: MagicMock,
 ) -> None:
@@ -125,6 +197,7 @@ def test_run_dive_passes_passage_and_brief_to_assembly(
         session=session,
         embedder=embedder,
         config=_CONFIG,
+        web_search=StubWebSearchClient(),
     )
 
     patched_assembly.assert_called_once()

--- a/depth_dive/tests/depth_dive/web_search/test_client.py
+++ b/depth_dive/tests/depth_dive/web_search/test_client.py
@@ -1,0 +1,201 @@
+"""Tests for the web-search provider clients (ADR-0012, ADR-0013).
+
+The ``OpenAIWebSearchClient`` is exercised against hand-built ``Response``
+objects so parsing and error mapping are covered without a hosted API; the
+``StubWebSearchClient`` provides the deterministic in-memory stand-in used by
+the wrapper and harness tests.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from openai import APIConnectionError, APIStatusError, OpenAIError
+from openai.types.responses import Response
+
+from depth_dive.web_search.client import (
+    OpenAIWebSearchClient,
+    StubWebSearchClient,
+    WebSearchClient,
+    WebSearchError,
+    WebSearchResult,
+)
+
+
+def _response_payload(
+    *,
+    annotation: dict[str, object] | None,
+    web_search_status: str = "completed",
+) -> dict[str, object]:
+    """Build a JSON-shaped Responses API payload for the web search tool."""
+    output: list[dict[str, object]] = [
+        {
+            "type": "web_search_call",
+            "id": "ws_1",
+            "status": web_search_status,
+            "action": {"type": "search", "query": "attention is all you need"},
+        }
+    ]
+    if annotation is not None:
+        output.append(
+            {
+                "id": "msg_1",
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "The Transformer paper is famous. See the original.",
+                        "annotations": [annotation],
+                    }
+                ],
+            }
+        )
+    return {
+        "id": "resp_test",
+        "created_at": 1,
+        "object": "response",
+        "model": "gpt-4o-mini",
+        "status": "completed",
+        "parallel_tool_calls": True,
+        "tool_choice": "auto",
+        "tools": [{"type": "web_search"}],
+        "output": output,
+    }
+
+
+def _client(response: Response | None = None) -> tuple[OpenAIWebSearchClient, MagicMock]:
+    client = OpenAIWebSearchClient(api_key="test-key", model="test-model")
+    fake = MagicMock()
+    if response is not None:
+        fake.responses.create.return_value = response
+    client._client = fake
+    return client, fake
+
+
+def test_openai_client_surfaces_cited_urls_as_results() -> None:
+    """url_citation annotations become title/url/snippet results."""
+    response = Response.model_validate(
+        _response_payload(
+            annotation={
+                "type": "url_citation",
+                "url": "https://example.com/paper",
+                "title": "Attention Is All You Need",
+                "start_index": 24,
+                "end_index": 44,
+            }
+        )
+    )
+    client, _ = _client(response)
+    results = client.search("attention is all you need")
+    assert len(results) == 1
+    result = results[0]
+    assert isinstance(result, WebSearchResult)
+    assert result.title == "Attention Is All You Need"
+    assert result.url == "https://example.com/paper"
+    assert result.snippet == " famous. See the ori"
+
+
+def test_openai_client_empty_citations_yields_no_results() -> None:
+    """A response with no url_citation annotations surfaces no results."""
+    response = Response.model_validate(_response_payload(annotation=None))
+    client, _ = _client(response)
+    assert client.search("attention is all you need") == []
+
+
+def test_openai_client_skips_out_of_bounds_annotations() -> None:
+    """Annotations whose indices exceed the part text are skipped, not raised."""
+    response = Response.model_validate(
+        _response_payload(
+            annotation={
+                "type": "url_citation",
+                "url": "https://example.com/paper",
+                "title": "Attention Is All You Need",
+                "start_index": 5,
+                "end_index": 999,
+            }
+        )
+    )
+    client, _ = _client(response)
+    assert client.search("attention is all you need") == []
+
+
+def test_openai_client_failed_search_call_raises() -> None:
+    """A web_search_call whose status is failed is a failed search."""
+    response = Response.model_validate(
+        _response_payload(annotation=None, web_search_status="failed")
+    )
+    client, _ = _client(response)
+    with pytest.raises(WebSearchError):
+        client.search("attention is all you need")
+
+
+def test_openai_client_connection_error_maps_to_web_search_error() -> None:
+    """An unreachable API raises WebSearchError, not a RetrievalError subclass."""
+    client, fake = _client()
+    fake.responses.create.side_effect = APIConnectionError(request=MagicMock())
+    with pytest.raises(WebSearchError):
+        client.search("attention is all you need")
+
+
+def test_openai_client_missing_key_maps_to_web_search_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A client without a usable API key fails gracefully as WebSearchError."""
+
+    def _raise(*, api_key: str | None = None, **_: object) -> None:
+        raise OpenAIError("The api_key client option must be set")
+
+    monkeypatch.setattr("depth_dive.web_search.client.OpenAI", _raise)
+    client = OpenAIWebSearchClient(api_key=None, model="test-model")
+    with pytest.raises(WebSearchError):
+        client.search("attention is all you need")
+
+
+def test_openai_client_bad_status_maps_to_web_search_error() -> None:
+    """A 4xx/5xx API status raises WebSearchError."""
+    client, fake = _client()
+    fake.responses.create.side_effect = APIStatusError("bad", response=MagicMock(), body=None)
+    with pytest.raises(WebSearchError):
+        client.search("attention is all you need")
+
+
+def test_openai_client_uses_web_search_tool() -> None:
+    """The search issues one response with the web_search tool enabled."""
+    response = Response.model_validate(_response_payload(annotation=None))
+    client, fake = _client(response)
+    client.search("attention is all you need")
+    fake.responses.create.assert_called_once()
+    kwargs = fake.responses.create.call_args.kwargs
+    assert kwargs["input"] == "attention is all you need"
+    assert kwargs["tools"] == [{"type": "web_search"}]
+
+
+def test_stub_client_returns_configured_results() -> None:
+    """The stub returns its configured results and records queries."""
+    results = [WebSearchResult(title="t", url="https://example.com", snippet="s")]
+    client = StubWebSearchClient(results=results)
+    assert client.search("query one") == results
+    assert client.search("query two") == results
+    assert client.calls == ["query one", "query two"]
+
+
+def test_stub_client_fails_configured_number_of_times() -> None:
+    """The stub raises WebSearchError for the configured failure count."""
+    client = StubWebSearchClient(results=[], failures=2)
+    with pytest.raises(WebSearchError):
+        client.search("q")
+    with pytest.raises(WebSearchError):
+        client.search("q")
+    assert client.search("q") == []
+
+
+def test_openai_client_conforms_to_protocol() -> None:
+    """The concrete client satisfies the WebSearchClient protocol."""
+    client, _ = _client()
+    assert isinstance(client, WebSearchClient)
+
+
+def test_stub_client_conforms_to_protocol() -> None:
+    """The stub satisfies the WebSearchClient protocol."""
+    assert isinstance(StubWebSearchClient(), WebSearchClient)

--- a/depth_dive/tests/depth_dive/web_search/test_wrapper.py
+++ b/depth_dive/tests/depth_dive/web_search/test_wrapper.py
@@ -1,0 +1,116 @@
+"""Tests for the retry-once web-search wrapper (ADR-0013, ticket #244).
+
+The provider is stubbed so the retry/fallback policy is exercised without a
+hosted API (coding-standards.md): success, single-retry recovery,
+double-failure fallback, and the no-search cases.
+"""
+
+from collections.abc import Sequence
+
+import pytest
+
+from depth_dive.web_search.client import StubWebSearchClient, WebSearchResult
+from depth_dive.web_search.wrapper import FALLBACK_NOTE, SearchOutcome, run_web_search
+
+
+def _result(title: str) -> WebSearchResult:
+    return WebSearchResult(title=title, url=f"https://example.com/{title}", snippet=f"{title} span")
+
+
+def _run(
+    query: str,
+    *,
+    results: Sequence[WebSearchResult] | None = None,
+    failures: int = 0,
+) -> tuple[SearchOutcome, StubWebSearchClient]:
+    client = StubWebSearchClient(results=results, failures=failures)
+    return run_web_search(query, client), client
+
+
+def test_no_search_when_query_is_empty() -> None:
+    """An empty query is not a search attempt at all."""
+    outcome, client = _run("")
+    assert outcome.attempted is False
+    assert outcome.failed is False
+    assert outcome.note is None
+    assert outcome.results == []
+    assert client.calls == []
+
+
+def test_no_search_when_query_is_whitespace() -> None:
+    """A whitespace-only query is not a search attempt."""
+    outcome, client = _run("   ")
+    assert outcome.attempted is False
+    assert client.calls == []
+
+
+def test_success_returns_results_without_retry() -> None:
+    """A successful search returns its results on the first (only) attempt."""
+    results = [_result("attention")]
+    outcome, client = _run("attention is all you need", results=results)
+    assert outcome.attempted is True
+    assert outcome.failed is False
+    assert outcome.note is None
+    assert outcome.results == results
+    assert client.calls == ["attention is all you need"]
+
+
+def test_first_failure_recovers_on_the_retry() -> None:
+    """A failed attempt is retried exactly once and recovers with results."""
+    results = [_result("transformer")]
+    outcome, client = _run("transformer architecture", results=results, failures=1)
+    assert outcome.attempted is True
+    assert outcome.failed is False
+    assert outcome.note is None
+    assert outcome.results == results
+    assert len(client.calls) == 2
+
+
+def test_double_failure_falls_back_with_note() -> None:
+    """Two consecutive failures produce a failed outcome with a note, no retry."""
+    outcome, client = _run("nonsense query", failures=2)
+    assert outcome.attempted is True
+    assert outcome.failed is True
+    assert outcome.note == FALLBACK_NOTE
+    assert outcome.results == []
+    assert len(client.calls) == 2
+
+
+def test_failure_then_empty_results_is_a_fallback() -> None:
+    """A failed retry that returns nothing still falls back (no useful results)."""
+    outcome, client = _run("failing then empty", failures=1)
+    assert outcome.attempted is True
+    assert outcome.failed is True
+    assert outcome.note is not None
+    assert outcome.results == []
+    assert len(client.calls) == 2
+
+
+def test_empty_first_result_is_retried() -> None:
+    """No useful results on the first attempt counts as a failure and is retried."""
+    results = [_result("recovered")]
+
+    class _EmptyThenFullClient:
+        calls: int = 0
+
+        def search(self, query: str) -> list[WebSearchResult]:
+            self.calls += 1
+            return [] if self.calls == 1 else list(results)
+
+    client = _EmptyThenFullClient()
+    outcome = run_web_search("first empty then full", client)
+    assert outcome.attempted is True
+    assert outcome.failed is False
+    assert outcome.results == results
+    assert client.calls == 2
+
+
+def test_unexpected_provider_error_is_not_caught() -> None:
+    """Non-``WebSearchError`` exceptions are not swallowed by the wrapper."""
+
+    class _BoomClient:
+        def search(self, query: str) -> list[WebSearchResult]:
+            raise RuntimeError("unexpected")
+
+    with pytest.raises(RuntimeError):
+        run_web_search("anything", _BoomClient())

--- a/uv.lock
+++ b/uv.lock
@@ -453,12 +453,14 @@ version = "0.1.0"
 source = { editable = "depth_dive" }
 dependencies = [
     { name = "core" },
+    { name = "openai" },
     { name = "pillow" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "core", editable = "core" },
+    { name = "openai", specifier = ">=2.51.0" },
     { name = "pillow", specifier = ">=12.0" },
 ]
 


### PR DESCRIPTION
… (#244)

Add the assembly agent's web-search step: a depth_dive-owned client (OpenAI Responses API web_search tool) behind a WebSearchClient protocol, a retry-once wrapper (ADR-0013), and wiring so POST /dive surfaces external_search_attempted/failed/note. When the framing brief carries a search_intent the assembly agent searches, retries exactly once on failure (exception or no useful results), and on a second failure falls back with a user-facing note instead of a 5xx. Search results stay internal on AssemblyResult for the generation step (ticket #245).