### PR TITLE
feat(depth-dive): render tables to an image with image-only fallback

### DIFF
--- a/api/tests/api/test_dive.py
+++ b/api/tests/api/test_dive.py
@@ -371,13 +371,14 @@ def test_dive_image_unsupported_media_type_returns_422(mock_client: TestClient) 
     assert response.status_code == 422
 
 
-def test_dive_table_over_row_bound_returns_422(mock_client: TestClient) -> None:
-    """A table exceeding the row bound returns 422 with a clear message."""
+def test_dive_table_over_row_bound_falls_back_to_image(
+    mock_client: TestClient, patched_dive_grounding: Any
+) -> None:
+    """A table exceeding the row bound falls back to the rendered image and returns 200."""
+    patched_dive_grounding()
     rows = [["x"] for _ in range(TABLE_MAX_ROWS + 1)]
     response = mock_client.post("/dive", json=_table_body(rows=rows))
-    assert response.status_code == 422
-    detail = response.json()["detail"]
-    assert "row limit" in detail
+    assert response.status_code == 200, response.text
 
 
 # ============================================================

--- a/depth_dive/src/depth_dive/transform.py
+++ b/depth_dive/src/depth_dive/transform.py
@@ -3,20 +3,24 @@
 Runs before the framing agent: validates the carried content against the
 declared ``passage_type``, normalizes, and emits a model-ready content block.
 Each passage variant maps to a carrier — plain text for ``text``, a base64
-image block for ``image``/``diagram``, and structured rows for ``table``.
+image block for ``image``/``diagram``, and structured rows plus a rendered
+image for ``table``.
 
 Requests exceeding declared bounds are rejected (422 via the route), never
 silently cropped. Image bytes are size-capped before decoding and validated
 for format, dimensions, and animation; tables are validated for row/column
-shape.
+shape. A table whose structured form exceeds the row/column bounds falls back
+to its rendered image alone (spec §5) rather than being rejected; only when
+the rendered image itself exceeds the image size bounds is the passage
+rejected.
 """
 
 import base64
 import io
 from dataclasses import dataclass
-from typing import Annotated, Literal
+from typing import Annotated, Literal, cast
 
-from PIL import Image, UnidentifiedImageError
+from PIL import Image, ImageDraw, ImageFont, UnidentifiedImageError
 from pydantic import BaseModel, ConfigDict, Field
 
 from core.types.captured_passage import (
@@ -106,13 +110,21 @@ class ImageBlock(BaseModel):
 
 
 class TableBlock(BaseModel):
-    """A model-ready structured table content block."""
+    """A model-ready table content block: structured rows plus a rendered image.
+
+    ``headers``/``rows`` carry the canonical structured form (spec §5's
+    "structured text"), and ``image`` carries a faithful render of the same
+    table as a PNG. When the structured form exceeds the row/column bounds the
+    transform returns a bare ``ImageBlock`` instead (image-only fallback), so a
+    ``TableBlock`` always carries all three fields.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
     kind: Literal["table"] = "table"
     headers: list[str] | None = None
     rows: list[TableRow]
+    image: ImageBlock
 
 
 ModelReadyBlock = Annotated[
@@ -252,31 +264,190 @@ def _read_image_metadata(content: bytes, media_type: ImageMediaType) -> _ImageMe
     return _ImageMetadata(width=width, height=height, decoded_bytes=decoded_bytes)
 
 
-def _transform_table(headers: list[str] | None, rows: list[TableRow]) -> TableBlock:
-    """Validate table shape and build the structured rows carrier.
+def _transform_table(headers: list[str] | None, rows: list[TableRow]) -> TableBlock | ImageBlock:
+    """Validate table shape and build the structured-rows-plus-image carrier.
+
+    A table within the row/column bounds yields a ``TableBlock`` carrying both
+    the structured form and a rendered image. A table whose structured form
+    exceeds those bounds falls back to the rendered image alone (an
+    ``ImageBlock``), per spec §5's "image-only fallback", rather than being
+    rejected. In both cases the rendered image must fit the image size bounds.
 
     Args:
         headers: Optional header metadata.
         rows: The canonical structured rows.
 
     Returns:
-        A ``TableBlock`` carrying the validated headers and rows.
+        A ``TableBlock`` (structured rows + rendered image) when the table is
+        within bounds, or an ``ImageBlock`` (rendered image only) when the
+        structured form exceeds them.
 
     Raises:
-        PassageTransformError: The table is empty or exceeds the row/column
-            bounds.
+        PassageTransformError: The table is empty, or the rendered image
+            exceeds the image size bounds.
     """
     has_content = bool(headers) or any(any(cell != "" for cell in row) for row in rows)
     if not has_content:
         raise PassageTransformError("table passage must contain at least one column")
+    within_bounds = _within_table_bounds(headers, rows)
+    image = _render_table_image(headers, rows, check_bounds=not within_bounds)
+    if within_bounds:
+        return TableBlock(headers=headers, rows=rows, image=image)
+    return image
+
+
+def _within_table_bounds(headers: list[str] | None, rows: list[TableRow]) -> bool:
+    """Return whether the structured table form fits the row/column bounds."""
     if headers and len(headers) > TABLE_MAX_COLUMNS:
-        raise PassageTransformError(f"table exceeds the {TABLE_MAX_COLUMNS} column limit")
+        return False
     if len(rows) > TABLE_MAX_ROWS:
-        raise PassageTransformError(f"table exceeds the {TABLE_MAX_ROWS} row limit")
+        return False
+    return all(len(row) <= TABLE_MAX_COLUMNS for row in rows)
+
+
+_TABLE_RENDER_CELL_PAD_X = 2
+"""Total horizontal padding (pixels) inside a rendered table cell."""
+
+_TABLE_RENDER_CELL_PAD_Y = 0
+"""Total vertical padding (pixels) inside a rendered table cell."""
+
+
+def _render_table_image(
+    headers: list[str] | None, rows: list[TableRow], *, check_bounds: bool
+) -> ImageBlock:
+    """Render the table to a PNG and return its ``ImageBlock`` carrier.
+
+    Args:
+        headers: Optional header metadata.
+        rows: The canonical structured rows.
+        check_bounds: Whether to reject the render for exceeding the image
+            size bounds. Only the image-only fallback enforces these bounds
+            (spec §5); an in-bounds table keeps its structured rows as the
+            primary carrier and is accepted even if its render is large.
+
+    Returns:
+        An ``ImageBlock`` carrying the base64-encoded PNG render and its pixel
+        dimensions.
+
+    Raises:
+        PassageTransformError: ``check_bounds`` is true and the rendered image
+            exceeds the image size bounds (per-axis dimension, decoded bytes,
+            or encoded bytes).
+    """
+    grid = _table_to_grid(headers, rows)
+    # ``load_default`` always returns a ``FreeTypeFont`` when FreeType support
+    # is present (it is, in the bundled Pillow wheels); the union in the stub
+    # covers the no-FreeType fallback, which we never hit.
+    font = cast(ImageFont.FreeTypeFont, ImageFont.load_default())
+    ascent, descent = font.getmetrics()
+    line_height = ascent + descent
+
+    n_cols = max((len(cells) for cells in grid), default=0)
+    col_widths = [
+        max(
+            (_cell_text_width(font, _cell_at(grid, row, col)) for row in range(len(grid))),
+            default=0,
+        )
+        for col in range(n_cols)
+    ]
+
+    cell_height = line_height + _TABLE_RENDER_CELL_PAD_Y
+    width = sum(col_widths) + _TABLE_RENDER_CELL_PAD_X * n_cols + (n_cols + 1)
+    height = cell_height * len(grid) + (len(grid) + 1)
+    if check_bounds:
+        _check_rendered_bounds(width, height)
+
+    image = Image.new("RGB", (width, height), "white")
+    draw = ImageDraw.Draw(image)
+    for row in range(len(grid) + 1):
+        y = row * cell_height
+        draw.line([(0, y), (width - 1, y)], fill="black")
+    x = 0
+    text_offsets: list[int] = []
+    for _col, col_width in enumerate(col_widths):
+        draw.line([(x, 0), (x, height - 1)], fill="black")
+        text_offsets.append(x + 1 + _TABLE_RENDER_CELL_PAD_X // 2)
+        x += 1 + _TABLE_RENDER_CELL_PAD_X + col_width
+    draw.line([(x, 0), (x, height - 1)], fill="black")
+
+    for row, cells in enumerate(grid):
+        y = row * cell_height + _TABLE_RENDER_CELL_PAD_Y // 2
+        for col, cell in enumerate(cells):
+            if col >= n_cols:
+                break
+            draw.text((text_offsets[col], y), cell, font=font, fill="black")
+
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    png = buffer.getvalue()
+    if check_bounds and len(png) > IMAGE_MAX_BYTES:
+        raise PassageTransformError(
+            f"rendered table image exceeds the {IMAGE_MAX_BYTES} byte size limit"
+        )
+    return ImageBlock(
+        media_type="image/png",
+        base64=base64.b64encode(png).decode("ascii"),
+        width=width,
+        height=height,
+    )
+
+
+def _table_to_grid(headers: list[str] | None, rows: list[TableRow]) -> list[list[str]]:
+    """Normalize the structured table into a rectangular grid of cell strings."""
+    if headers is not None:
+        return [list(headers), *[_row_cells(row, headers) for row in rows]]
+    if rows and isinstance(rows[0], dict):
+        columns = _dict_columns(rows)
+        return [columns, *[_row_cells(row, columns) for row in rows]]
+    return [_row_cells(row, None) for row in rows]
+
+
+def _row_cells(row: TableRow, columns: list[str] | None) -> list[str]:
+    """Flatten one table row to its ordered cell strings."""
+    if isinstance(row, list):
+        return list(row)
+    if columns is None:
+        return list(row.values())
+    return [row.get(column, "") for column in columns]
+
+
+def _dict_columns(rows: list[TableRow]) -> list[str]:
+    """Return the union of dict-row keys in first-seen order."""
+    columns: list[str] = []
     for row in rows:
-        if len(row) > TABLE_MAX_COLUMNS:
-            raise PassageTransformError(f"table exceeds the {TABLE_MAX_COLUMNS} column limit")
-    return TableBlock(headers=headers, rows=rows)
+        if isinstance(row, list):
+            continue
+        for key in row:
+            if key not in columns:
+                columns.append(key)
+    return columns
+
+
+def _cell_at(grid: list[list[str]], row: int, col: int) -> str:
+    """Return the cell at ``(row, col)``, or an empty string if out of range."""
+    cells = grid[row]
+    return cells[col] if col < len(cells) else ""
+
+
+def _cell_text_width(font: ImageFont.FreeTypeFont, text: str) -> int:
+    """Measure the rendered width (pixels) of a cell's text."""
+    if not text:
+        return 0
+    left, _, right, _ = font.getbbox(text)
+    return int(right - left)
+
+
+def _check_rendered_bounds(width: int, height: int) -> None:
+    """Reject a rendered table that exceeds the image size bounds."""
+    if width > IMAGE_MAX_DIMENSION or height > IMAGE_MAX_DIMENSION:
+        raise PassageTransformError(
+            f"rendered table image exceeds the {IMAGE_MAX_DIMENSION}x"
+            f"{IMAGE_MAX_DIMENSION} dimension limit"
+        )
+    if width * height * _CHANNELS_BY_MODE["RGB"] > IMAGE_MAX_DECODED_BYTES:
+        raise PassageTransformError(
+            f"rendered table image exceeds the {IMAGE_MAX_DECODED_BYTES} decoded byte size limit"
+        )
 
 
 __all__ = [

--- a/depth_dive/tests/depth_dive/test_transform.py
+++ b/depth_dive/tests/depth_dive/test_transform.py
@@ -193,11 +193,22 @@ def test_animated_gif_is_rejected() -> None:
 
 
 def test_table_passage_returns_table_block() -> None:
-    """A valid table yields a ``TableBlock`` carrying headers and rows."""
+    """A valid table yields a ``TableBlock`` carrying headers, rows, and a render."""
     result = transform_passage(_table(rows=[["a", "1"], ["b", "2"]], headers=["l", "v"]))
     assert isinstance(result, TableBlock)
     assert result.headers == ["l", "v"]
     assert result.rows == [["a", "1"], ["b", "2"]]
+    assert result.image.media_type == "image/png"
+
+
+def test_table_render_is_a_valid_png() -> None:
+    """The rendered table image decodes as a PNG matching its declared dimensions."""
+    result = transform_passage(_table(rows=[["a", "1"], ["b", "2"]], headers=["l", "v"]))
+    assert isinstance(result, TableBlock)
+    png = base64.b64decode(result.image.base64)
+    with Image.open(io.BytesIO(png)) as rendered:
+        assert rendered.format == "PNG"
+        assert rendered.size == (result.image.width, result.image.height)
 
 
 def test_table_passage_accepts_dict_rows() -> None:
@@ -227,33 +238,49 @@ def test_all_empty_rows_are_rejected() -> None:
         transform_passage(_table(rows=[[""], [""]]))
 
 
-def test_table_over_row_bound_is_rejected() -> None:
-    """A table exceeding the row bound is rejected."""
+def test_table_over_row_bound_falls_back_to_image() -> None:
+    """A table exceeding the row bound falls back to the rendered image alone."""
     rows = [["x"] for _ in range(TABLE_MAX_ROWS + 1)]
+    result = transform_passage(_table(rows=rows))
+    assert isinstance(result, ImageBlock)
+    assert result.media_type == "image/png"
+
+
+def test_table_over_column_bound_falls_back_to_image() -> None:
+    """A row exceeding the column bound falls back to the rendered image alone."""
+    row = ["x"] * (TABLE_MAX_COLUMNS + 1)
+    result = transform_passage(_table(rows=[row]))
+    assert isinstance(result, ImageBlock)
+
+
+def test_table_over_column_bound_in_headers_falls_back_to_image() -> None:
+    """Headers exceeding the column bound fall back to the rendered image alone."""
+    headers = ["h"] * (TABLE_MAX_COLUMNS + 1)
+    result = transform_passage(_table(rows=[["x"]], headers=headers))
+    assert isinstance(result, ImageBlock)
+
+
+def test_table_render_exceeding_image_dimension_is_rejected() -> None:
+    """An over-bounds table whose render exceeds the image dimension is rejected."""
+    rows = [["x" * 2000] for _ in range(TABLE_MAX_ROWS + 1)]
     with pytest.raises(PassageTransformError):
         transform_passage(_table(rows=rows))
 
 
-def test_table_over_column_bound_is_rejected() -> None:
-    """A table exceeding the column bound in a row is rejected."""
-    row = ["x"] * (TABLE_MAX_COLUMNS + 1)
-    with pytest.raises(PassageTransformError):
-        transform_passage(_table(rows=[row]))
-
-
-def test_table_over_column_bound_in_headers_is_rejected() -> None:
-    """Headers exceeding the column bound are rejected."""
-    headers = ["h"] * (TABLE_MAX_COLUMNS + 1)
-    with pytest.raises(PassageTransformError):
-        transform_passage(_table(rows=[["x"]], headers=headers))
+def test_table_long_cell_within_bounds_is_accepted() -> None:
+    """An in-bounds table with a wide cell is accepted; image bounds apply only to the fallback."""
+    result = transform_passage(_table(rows=[["x" * 2000]]))
+    assert isinstance(result, TableBlock)
+    assert result.image.media_type == "image/png"
 
 
 def test_table_boundary_shape_is_accepted() -> None:
-    """A table exactly at the row and column bounds is accepted."""
+    """A table exactly at the row and column bounds is accepted with a render."""
     rows = [["x"] * TABLE_MAX_COLUMNS for _ in range(TABLE_MAX_ROWS)]
     result = transform_passage(_table(rows=rows))
     assert isinstance(result, TableBlock)
     assert len(result.rows) == TABLE_MAX_ROWS
+    assert result.image.media_type == "image/png"
 
 
 # ============================================================


### PR DESCRIPTION
The table transform now emits a structured-table carrier plus a faithful PNG render (spec §5). Tables whose structured form exceeds the row/column bounds fall back to the rendered image alone instead of being rejected. The image size bounds are enforced only on that fallback path, so in-bounds tables keep their existing acceptance behavior.