### PR TITLE
feat(depth-dive): ground anchored non-text passages via document context

### DIFF
--- a/core/src/core/retrieval/__init__.py
+++ b/core/src/core/retrieval/__init__.py
@@ -13,12 +13,20 @@ Public surface:
 - ``search_dense_neighbors`` — dense semantic-neighbor search scored by
   cosine similarity.
 - ``fetch_parent_chunk`` — parent-chunk fetch for an anchored chunk id.
+- ``fetch_document_chunks`` — document-relative parent-chunk fetch for an
+  anchored non-text ``document_id`` (ticket #253).
 
 Sparse search and RRF fusion stay private internals of the pipeline module.
 """
 
+from core.retrieval.documents import fetch_document_chunks
 from core.retrieval.neighbors import search_dense_neighbors
 from core.retrieval.parents import fetch_parent_chunk
 from core.retrieval.query import retrieve_relevant_chunks
 
-__all__ = ["fetch_parent_chunk", "retrieve_relevant_chunks", "search_dense_neighbors"]
+__all__ = [
+    "fetch_document_chunks",
+    "fetch_parent_chunk",
+    "retrieve_relevant_chunks",
+    "search_dense_neighbors",
+]

--- a/core/src/core/retrieval/documents.py
+++ b/core/src/core/retrieval/documents.py
@@ -1,0 +1,109 @@
+"""Document-relative text lookup for non-text passages (ADR-0019, ticket #253).
+
+Depth Dive anchors ``image``/``diagram``/``table`` captured passages via
+``document_id`` + ``ordinal`` (ADR-0021). Anchored non-text retrieval fetches
+document-relative text context near the figure/table plus semantic neighbors on
+the passage's embeddable representation (depth-dive spec §8).
+
+The store is text-only today: non-text assets have no rows of their own, and no
+``ordinal`` → position mapping exists. This primitive therefore returns the
+best-effort document-relative context available now — the document's parent
+chunks (its structural units) in reading order — leaving the "near the
+figure/table" narrowing to the future ingestion-redesign map, whose storage
+contract (spec §10) adds ordinal identity and nearest-chunk position. The
+semantic-neighbor half is composed by the harness from
+:func:`core.retrieval.neighbors.search_dense_neighbors` on the passage's
+embeddable representation.
+
+Visibility matches the pipeline (ADR-0014): only chunks of ``status='ready'``
+documents are returned. ``None`` signals an unresolvable anchor (the document
+does not exist or is not ready), mirroring :func:`fetch_parent_chunk`.
+"""
+
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.exc import InterfaceError, OperationalError
+from sqlalchemy.orm import Session
+
+from core.exceptions import UpstreamUnavailable
+from core.types.responses import CitedPassage
+
+_DOCUMENT_READY_SQL = text(
+    """
+    SELECT 1
+    FROM documents
+    WHERE document_id = :document_id
+      AND status = 'ready'
+    """
+)
+
+_DOCUMENT_PARENT_CHUNKS_SQL = text(
+    """
+    SELECT
+        chunks.chunk_id AS chunk_id,
+        chunks.content  AS text
+    FROM chunks
+    JOIN documents ON documents.document_id = chunks.document_id
+    WHERE chunks.document_id = :document_id
+      AND documents.status = 'ready'
+      AND chunks.parent_chunk_id IS NULL
+    ORDER BY chunks.position
+    LIMIT :limit
+    """
+)
+
+
+def fetch_document_chunks(
+    *,
+    session: Session,
+    document_id: UUID,
+    limit: int,
+) -> list[CitedPassage] | None:
+    """Fetch a ready document's parent chunks in document order.
+
+    The document-relative text context for an anchored non-text passage: the
+    document's structural units (parent chunks, ``parent_chunk_id IS NULL``) in
+    reading order, capped at ``limit``. Until the ingestion-redesign map adds
+    ordinal → position metadata, this is the whole-document stand-in for "text
+    context near the figure/table".
+
+    Args:
+        session: SQLAlchemy session bound to the documents database.
+        document_id: The non-text passage's ``document_id`` anchor
+            (ADR-0021).
+        limit: Maximum number of parent chunks to return.
+
+    Returns:
+        The document's parent chunks as ``CitedPassage`` instances ordered by
+        ``position``, or ``None`` when the document does not exist or is not in
+        ``status='ready'`` (the same visibility gate as the retrieval pipeline,
+        ADR-0014). Callers treat ``None`` as an unresolvable anchor, never as
+        an error. An empty list means the ready document has no parent chunks.
+
+    Raises:
+        UpstreamUnavailable: The database is unreachable (maps to 503 per
+            ADR-0014 § Error contract). Other DB-level errors propagate
+            verbatim.
+    """
+    try:
+        # Two queries: the first distinguishes an unresolvable anchor (document
+        # absent or not ready → None) from a resolvable anchor with no parent
+        # chunks (→ []), which callers treat differently.
+        ready = session.execute(_DOCUMENT_READY_SQL, {"document_id": document_id}).first()
+        if ready is None:
+            return None
+        rows = session.execute(
+            _DOCUMENT_PARENT_CHUNKS_SQL,
+            {"document_id": document_id, "limit": limit},
+        ).fetchall()
+        return [
+            CitedPassage(chunk_id=row._mapping["chunk_id"], text=row._mapping["text"])
+            for row in rows
+        ]
+
+    except (OperationalError, InterfaceError) as exc:
+        raise UpstreamUnavailable(f"Database unreachable: {exc}") from exc
+
+
+__all__ = ["fetch_document_chunks"]

--- a/core/tests/core/retrieval/test_documents.py
+++ b/core/tests/core/retrieval/test_documents.py
@@ -1,0 +1,171 @@
+"""Database-backed tests for the document-relative text lookup primitive."""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from core.database.schema import Chunk, Document, Embedding
+from core.exceptions import UpstreamUnavailable
+from core.retrieval.documents import fetch_document_chunks
+from core.types.document import DocumentStatus, DocumentType
+from core.types.responses import CitedPassage
+
+
+def _seed_parent_child_paper(
+    session: Session,
+    *,
+    title: str = "Parent-Child Paper",
+    status: DocumentStatus = DocumentStatus.READY,
+    parent_contents: list[str],
+) -> tuple[Document, list[Chunk], list[Chunk]]:
+    """Seed a document with several parents and one child per parent.
+
+    Returns (document, parent_rows, child_rows).
+    """
+    document = Document(
+        title=title,
+        document_type=DocumentType.PAPER,
+        source_filename=f"{title}.pdf",
+        status=status,
+    )
+    session.add(document)
+    session.flush()
+
+    parents: list[Chunk] = []
+    children: list[Chunk] = []
+    for position, content in enumerate(parent_contents):
+        parent = Chunk(
+            document_id=document.document_id,
+            position=position,
+            content=content,
+            token_count=max(1, len(content.split())),
+            parent_chunk_id=None,
+        )
+        session.add(parent)
+        session.flush()
+        parents.append(parent)
+
+        child = Chunk(
+            document_id=document.document_id,
+            position=position + len(parent_contents),
+            content=f"child of: {content}",
+            token_count=max(1, len(content.split())),
+            parent_chunk_id=parent.chunk_id,
+            content_search=func.to_tsvector("english", content),
+        )
+        session.add(child)
+        session.flush()
+        session.add(
+            Embedding(
+                chunk_id=child.chunk_id,
+                model_name="text-embedding-3-small",
+                embedding=[0.5] * 1536,
+            )
+        )
+        children.append(child)
+
+    return document, parents, children
+
+
+def test_fetch_document_chunks_returns_parent_chunks_in_document_order(
+    test_session: Session,
+) -> None:
+    """Parent chunks come back in position order, children are excluded."""
+    contents = ["first section", "second section", "third section"]
+    _, parents, _ = _seed_parent_child_paper(test_session, parent_contents=contents)
+    test_session.commit()
+
+    chunks = fetch_document_chunks(
+        session=test_session,
+        document_id=parents[0].document_id,
+        limit=10,
+    )
+
+    assert chunks is not None
+    assert chunks == [CitedPassage(chunk_id=p.chunk_id, text=p.content) for p in parents]
+    assert [c.text for c in chunks] == contents
+
+
+def test_fetch_document_chunks_respects_limit(test_session: Session) -> None:
+    """At most ``limit`` parent chunks are returned, still in document order."""
+    contents = [f"section {i}" for i in range(5)]
+    _, parents, _ = _seed_parent_child_paper(test_session, parent_contents=contents)
+    test_session.commit()
+
+    chunks = fetch_document_chunks(
+        session=test_session,
+        document_id=parents[0].document_id,
+        limit=2,
+    )
+
+    assert chunks is not None
+    assert [c.text for c in chunks] == ["section 0", "section 1"]
+
+
+def test_fetch_document_chunks_returns_none_for_unknown_document(
+    test_session: Session,
+) -> None:
+    """A document_id that matches no document is an unresolvable anchor."""
+    assert fetch_document_chunks(session=test_session, document_id=uuid4(), limit=5) is None
+
+
+def test_fetch_document_chunks_returns_none_when_document_not_ready(
+    test_session: Session,
+) -> None:
+    """Chunks of a non-ready document are invisible (ADR-0014 visibility gate)."""
+    _, parents, _ = _seed_parent_child_paper(
+        test_session,
+        title="Still embedding",
+        status=DocumentStatus.EMBEDDING,
+        parent_contents=["hidden section"],
+    )
+    test_session.commit()
+
+    assert (
+        fetch_document_chunks(
+            session=test_session,
+            document_id=parents[0].document_id,
+            limit=5,
+        )
+        is None
+    )
+
+
+def test_fetch_document_chunks_returns_empty_for_ready_document_without_chunks(
+    test_session: Session,
+) -> None:
+    """A ready document with no chunks resolves to an empty context list."""
+    document = Document(
+        title="Empty",
+        document_type=DocumentType.PAPER,
+        source_filename="Empty.pdf",
+        status=DocumentStatus.READY,
+    )
+    test_session.add(document)
+    test_session.commit()
+
+    assert (
+        fetch_document_chunks(
+            session=test_session,
+            document_id=document.document_id,
+            limit=5,
+        )
+        == []
+    )
+
+
+def test_fetch_document_chunks_wraps_db_connection_error_as_upstream_unavailable() -> None:
+    """A DB-level OperationalError surfaces as UpstreamUnavailable (maps to 503)."""
+    from sqlalchemy.exc import OperationalError
+
+    fake_session = MagicMock()
+    fake_session.execute.side_effect = OperationalError(
+        statement="SELECT 1",
+        params={},
+        orig=Exception("connection refused"),
+    )
+    with pytest.raises(UpstreamUnavailable):
+        fetch_document_chunks(session=fake_session, document_id=uuid4(), limit=5)

--- a/depth_dive/src/depth_dive/assembly/assembly_agent.py
+++ b/depth_dive/src/depth_dive/assembly/assembly_agent.py
@@ -5,6 +5,10 @@ through the shared ``core/retrieval/`` primitives (ADR-0019):
 
 - An anchored ``text``/``code`` passage (``chunk_id``) fetches the enclosing
   Parent Chunk plus up to K semantic neighbors from the global corpus.
+- An anchored ``image``/``diagram``/``table`` passage (``document_id`` +
+  ordinal) fetches document-relative text context near the figure/table plus
+  semantic neighbors on the passage's embeddable representation (spec §8,
+  ticket #253).
 - Every other passage runs the corpus-similarity gate on the passage's
   embeddable representation; the gate's threshold and grounded/unverified
   judgement are Depth Dive harness policy (ADR-0019, ADR-0020).
@@ -17,13 +21,14 @@ step (ticket #245), which builds a scene graph from the brief, the cited
 passages, and any search results.
 """
 
+from collections.abc import Sequence
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
 
 from core.clients import CompletionProvider, Embedder
-from core.retrieval import fetch_parent_chunk, search_dense_neighbors
+from core.retrieval import fetch_document_chunks, fetch_parent_chunk, search_dense_neighbors
 from core.types.captured_passage import (
     CapturedPassage,
     CodePassage,
@@ -34,7 +39,7 @@ from core.types.captured_passage import (
     TextPassage,
 )
 from core.types.depth_dive import InteractiveAnimation
-from core.types.responses import CitedPassage
+from core.types.responses import CitedPassage, ScoredChunk
 from core.types.retrieval_config import RetrievalConfig
 from depth_dive.framing.framing_agent import FramingBrief
 from depth_dive.generation.generation_agent import run_generation
@@ -136,6 +141,13 @@ def run_assembly(
         grounding = _ground_anchored(
             passage, passage.chunk_id, session=session, embedder=embedder, config=config
         )
+    elif (
+        isinstance(passage, (ImagePassage, DiagramPassage, TablePassage))
+        and passage.document_id is not None
+    ):
+        grounding = _ground_anchored_document(
+            passage, passage.document_id, session=session, embedder=embedder, config=config
+        )
     else:
         grounding = _ground_via_gate(passage, session=session, embedder=embedder, config=config)
     outcome = _search_outcome(brief, web_search)
@@ -188,13 +200,60 @@ def _ground_anchored(
     query_vector = embedder.embed([passage.content])[0]
     neighbors = search_dense_neighbors(session=session, query_vector=query_vector, config=config)
     cited = [parent]
-    seen = {parent.chunk_id, chunk_id}
+    _append_neighbors(cited, neighbors, seen={parent.chunk_id, chunk_id})
+    return GroundingResult(grounded=True, cited_passages=cited)
+
+
+def _ground_anchored_document(
+    passage: ImagePassage | DiagramPassage | TablePassage,
+    document_id: UUID,
+    *,
+    session: Session,
+    embedder: Embedder,
+    config: RetrievalConfig,
+) -> GroundingResult:
+    """Ground an anchored non-text passage: document context + K neighbors.
+
+    Document-relative text context leads the citations; semantic neighbors on
+    the passage's embeddable representation (caption or serialized table)
+    follow. The anchor is valid whenever the ``document_id`` resolves to a
+    ``status='ready'`` document; the ``ordinal`` is carried as provenance but
+    is not yet resolvable against the text-only store (no non-text storage).
+    """
+    document_chunks = fetch_document_chunks(
+        session=session, document_id=document_id, limit=config.top_k
+    )
+    if document_chunks is None:
+        return GroundingResult(grounded=False, cited_passages=[])
+    cited = list(document_chunks)
+    embeddable = _embeddable_text(passage)
+    if embeddable is not None:
+        query_vector = embedder.embed([embeddable])[0]
+        neighbors = search_dense_neighbors(
+            session=session, query_vector=query_vector, config=config
+        )
+        _append_neighbors(cited, neighbors, seen={c.chunk_id for c in cited})
+    if not cited:
+        return GroundingResult(grounded=False, cited_passages=[])
+    return GroundingResult(grounded=True, cited_passages=cited)
+
+
+def _append_neighbors(
+    cited: list[CitedPassage],
+    neighbors: Sequence[ScoredChunk],
+    *,
+    seen: set[UUID],
+) -> None:
+    """Append neighbors whose chunk id is not already cited, deduplicating.
+
+    Mutates ``cited`` in place. ``seen`` seeds the already-cited id set; every
+    appended neighbor's id is added to it so duplicates are cited once.
+    """
     for neighbor in neighbors:
         if neighbor.chunk_id in seen:
             continue
         seen.add(neighbor.chunk_id)
         cited.append(CitedPassage(chunk_id=neighbor.chunk_id, text=neighbor.text))
-    return GroundingResult(grounded=True, cited_passages=cited)
 
 
 def _ground_via_gate(

--- a/depth_dive/tests/depth_dive/assembly/test_assembly_agent.py
+++ b/depth_dive/tests/depth_dive/assembly/test_assembly_agent.py
@@ -19,6 +19,7 @@ from core.exceptions import UpstreamUnavailable
 from core.types.captured_passage import (
     CapturedPassage,
     CodePassage,
+    DiagramPassage,
     ImagePassage,
     TablePassage,
     TextPassage,
@@ -333,16 +334,114 @@ def test_unanchored_dict_table_rows_serialize_keyed_cells(
     assert embedder.embedded == ["l: a | v: 1"]
 
 
-def test_anchored_image_falls_back_to_gate(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A document_id anchor cannot resolve yet (ADR-0019), so the gate runs."""
-    close_id = uuid4()
-    fetch_parent = MagicMock()
-    monkeypatch.setattr(assembly_agent, "fetch_parent_chunk", fetch_parent)
+def _doc_chunk(chunk_id: UUID, text: str) -> CitedPassage:
+    return CitedPassage(chunk_id=chunk_id, text=text)
+
+
+# ============================================================
+# Anchored non-text passages: document-relative context (ticket #253)
+# ============================================================
+
+
+def test_anchored_image_grounds_with_document_context_and_neighbors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A valid document anchor grounds on the document's text plus neighbors."""
+    document_id = uuid4()
+    doc_chunk_id = uuid4()
+    neighbor_id = uuid4()
+    fetch_document = MagicMock(
+        return_value=[_doc_chunk(doc_chunk_id, "the section surrounding the figure")]
+    )
+    search_neighbors = MagicMock(return_value=[_neighbor(neighbor_id, "a semantic neighbor", 0.9)])
+    monkeypatch.setattr(assembly_agent, "fetch_document_chunks", fetch_document)
+    monkeypatch.setattr(assembly_agent, "search_dense_neighbors", search_neighbors)
+
+    passage = ImagePassage(
+        content=b"\x00",
+        media_type="image/png",
+        caption="An attention plot",
+        document_id=document_id,
+        ordinal="Figure 3",
+    )
+    session = MagicMock()
+    embedder = _StubEmbedder()
+    result = _run(passage, session=session, embedder=embedder)
+
+    assert result.grounded is True
+    assert [p.chunk_id for p in result.cited_passages] == [doc_chunk_id, neighbor_id]
+    assert result.cited_passages[0].text == "the section surrounding the figure"
+    assert embedder.embedded == ["An attention plot"]
+    fetch_document.assert_called_once_with(
+        session=session, document_id=document_id, limit=_CONFIG.top_k
+    )
+
+
+def test_anchored_diagram_grounds_with_document_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A diagram uses the same document-relative grounding path as an image."""
+    document_id = uuid4()
+    doc_chunk_id = uuid4()
+    monkeypatch.setattr(
+        assembly_agent,
+        "fetch_document_chunks",
+        MagicMock(return_value=[_doc_chunk(doc_chunk_id, "a diagram's section")]),
+    )
+    monkeypatch.setattr(assembly_agent, "search_dense_neighbors", MagicMock(return_value=[]))
+
+    passage = DiagramPassage(
+        content=b"\x00",
+        media_type="image/png",
+        caption="The attention mechanism",
+        document_id=document_id,
+        ordinal="Figure 2",
+    )
+    result = _run(passage, session=MagicMock(), embedder=_StubEmbedder())
+
+    assert result.grounded is True
+    assert [p.chunk_id for p in result.cited_passages] == [doc_chunk_id]
+
+
+def test_anchored_table_grounds_with_document_context_and_serialized_neighbors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An anchored table embeds its serialized form for the neighbor search."""
+    doc_chunk_id = uuid4()
+    neighbor_id = uuid4()
+    monkeypatch.setattr(
+        assembly_agent,
+        "fetch_document_chunks",
+        MagicMock(return_value=[_doc_chunk(doc_chunk_id, "table context")]),
+    )
     monkeypatch.setattr(
         assembly_agent,
         "search_dense_neighbors",
-        MagicMock(return_value=[_neighbor(close_id, "caption-matching chunk", 0.9)]),
+        MagicMock(return_value=[_neighbor(neighbor_id, "related table chunk", 0.9)]),
     )
+
+    passage = TablePassage(
+        rows=[["a", "1"]],
+        headers=["l", "v"],
+        caption="Scores",
+        document_id=uuid4(),
+        ordinal="Table 1",
+    )
+    embedder = _StubEmbedder()
+    result = _run(passage, session=MagicMock(), embedder=embedder)
+
+    assert result.grounded is True
+    assert [p.chunk_id for p in result.cited_passages] == [doc_chunk_id, neighbor_id]
+    assert embedder.embedded == ["Scores\nl | v\na | 1"]
+
+
+def test_anchored_non_text_unresolvable_document_is_not_grounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A document_id the corpus cannot resolve grounds nothing, without embedding."""
+    monkeypatch.setattr(assembly_agent, "fetch_document_chunks", MagicMock(return_value=None))
+    search_neighbors = MagicMock()
+    monkeypatch.setattr(assembly_agent, "search_dense_neighbors", search_neighbors)
 
     passage = ImagePassage(
         content=b"\x00",
@@ -351,11 +450,99 @@ def test_anchored_image_falls_back_to_gate(monkeypatch: pytest.MonkeyPatch) -> N
         document_id=uuid4(),
         ordinal="Figure 3",
     )
+    embedder = _StubEmbedder()
+    result = _run(passage, session=MagicMock(), embedder=embedder)
+
+    assert result.grounded is False
+    assert result.cited_passages == []
+    assert embedder.embedded == []
+    search_neighbors.assert_not_called()
+
+
+def test_anchored_non_text_without_caption_still_grounds_on_document(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A captionless image still grounds on its valid document anchor alone."""
+    doc_chunk_id = uuid4()
+    monkeypatch.setattr(
+        assembly_agent,
+        "fetch_document_chunks",
+        MagicMock(return_value=[_doc_chunk(doc_chunk_id, "the figure's section")]),
+    )
+    search_neighbors = MagicMock()
+    monkeypatch.setattr(assembly_agent, "search_dense_neighbors", search_neighbors)
+
+    passage = ImagePassage(
+        content=b"\x00",
+        media_type="image/png",
+        document_id=uuid4(),
+        ordinal="Figure 4",
+    )
+    embedder = _StubEmbedder()
+    result = _run(passage, session=MagicMock(), embedder=embedder)
+
+    assert result.grounded is True
+    assert [p.chunk_id for p in result.cited_passages] == [doc_chunk_id]
+    assert embedder.embedded == []
+    search_neighbors.assert_not_called()
+
+
+def test_anchored_non_text_deduplicates_document_chunks_from_neighbors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A document chunk that also surfaces as a neighbor is cited once."""
+    doc_chunk_id = uuid4()
+    other_id = uuid4()
+    monkeypatch.setattr(
+        assembly_agent,
+        "fetch_document_chunks",
+        MagicMock(return_value=[_doc_chunk(doc_chunk_id, "shared section")]),
+    )
+    monkeypatch.setattr(
+        assembly_agent,
+        "search_dense_neighbors",
+        MagicMock(
+            return_value=[
+                _neighbor(doc_chunk_id, "the same section as a neighbor", 0.99),
+                _neighbor(other_id, "a distinct neighbor", 0.9),
+            ]
+        ),
+    )
+
+    passage = ImagePassage(
+        content=b"\x00",
+        media_type="image/png",
+        caption="An attention plot",
+        document_id=uuid4(),
+        ordinal="Figure 5",
+    )
     result = _run(passage, session=MagicMock(), embedder=_StubEmbedder())
 
     assert result.grounded is True
-    assert [p.chunk_id for p in result.cited_passages] == [close_id]
-    fetch_parent.assert_not_called()
+    assert [p.chunk_id for p in result.cited_passages] == [doc_chunk_id, other_id]
+
+
+def test_anchored_non_text_empty_document_context_is_not_grounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ready-but-empty document anchors nothing citable, so grounded is False."""
+    monkeypatch.setattr(assembly_agent, "fetch_document_chunks", MagicMock(return_value=[]))
+    search_neighbors = MagicMock()
+    monkeypatch.setattr(assembly_agent, "search_dense_neighbors", search_neighbors)
+
+    passage = ImagePassage(
+        content=b"\x00",
+        media_type="image/png",
+        document_id=uuid4(),
+        ordinal="Figure 6",
+    )
+    embedder = _StubEmbedder()
+    result = _run(passage, session=MagicMock(), embedder=embedder)
+
+    assert result.grounded is False
+    assert result.cited_passages == []
+    assert embedder.embedded == []
+    search_neighbors.assert_not_called()
 
 
 # ============================================================


### PR DESCRIPTION
Extend the assembly agent's anchor branch to cover image/diagram/table passages anchored by document_id + ordinal (spec §8, #253). A new core/retrieval primitive, fetch_document_chunks, returns a ready document's parent chunks in reading order as best-effort document-relative text context; the store is text-only today, so ordinal-to-position narrowing remains deferred to the ingestion-redesign map.

Anchored non-text passages now cite document context plus semantic neighbors on the passage's embeddable representation (caption or serialized table), grounding when the document anchor resolves. Unresolvable anchors and empty document contexts return grounded=False rather than raising.