### PR TITLE
feat(depth-dive): send transform carriers to the LLM generation turn …

### DIFF
--- a/core/src/core/types/__init__.py
+++ b/core/src/core/types/__init__.py
@@ -9,7 +9,13 @@ from core.types.captured_passage import (
     TablePassage,
     TextPassage,
 )
-from core.types.chat import ChatMessage
+from core.types.chat import (
+    ChatContentImagePart,
+    ChatContentImageURL,
+    ChatContentPart,
+    ChatContentTextPart,
+    ChatMessage,
+)
 from core.types.chunk import (
     BookChunkMetadata,
     Chunk,
@@ -46,6 +52,10 @@ __all__ = [
     "AnimationStep",
     "BookChunkMetadata",
     "CapturedPassage",
+    "ChatContentImagePart",
+    "ChatContentImageURL",
+    "ChatContentPart",
+    "ChatContentTextPart",
     "ChatMessage",
     "Chunk",
     "CitedPassage",

--- a/core/src/core/types/chat.py
+++ b/core/src/core/types/chat.py
@@ -1,10 +1,64 @@
 """Boundary types for chat messages across the inference pipeline."""
 
-from pydantic import BaseModel
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ChatContentImageURL(BaseModel):
+    """An image reference for a multimodal content part.
+
+    ``url`` is either a public URL or a base64 data URI
+    (``data:<media_type>;base64,<payload>``), matching the OpenAI vision shape.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    url: str
+
+
+class ChatContentTextPart(BaseModel):
+    """A plain-text content part of a chat message."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["text"] = "text"
+    text: str
+
+
+class ChatContentImagePart(BaseModel):
+    """An image content part of a chat message."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["image_url"] = "image_url"
+    image_url: ChatContentImageURL
+
+
+ChatContentPart = Annotated[
+    ChatContentTextPart | ChatContentImagePart,
+    Field(discriminator="type"),
+]
+"""A content part of a multimodal chat message: text or an image reference."""
 
 
 class ChatMessage(BaseModel):
-    """A single chat-completions message with role and content."""
+    """A single chat-completions message with role and content.
+
+    ``content`` is a plain string for text-only messages (Harness A and the
+    Depth Dive generation turn's system message), or a list of content parts
+    when the message carries image content (Depth Dive's model-ready image
+    carriers).
+    """
 
     role: str
-    content: str
+    content: str | list[ChatContentPart]
+
+
+__all__ = [
+    "ChatContentImagePart",
+    "ChatContentImageURL",
+    "ChatContentPart",
+    "ChatContentTextPart",
+    "ChatMessage",
+]

--- a/core/tests/core/test_llm_client.py
+++ b/core/tests/core/test_llm_client.py
@@ -7,7 +7,12 @@ from openai import APIConnectionError, APIStatusError
 
 from core.clients.llm_client import CompletionProvider, LLMClient, MockCompletionProvider
 from core.exceptions import UpstreamBadResponse, UpstreamUnavailable
-from core.types.chat import ChatMessage
+from core.types.chat import (
+    ChatContentImagePart,
+    ChatContentImageURL,
+    ChatContentTextPart,
+    ChatMessage,
+)
 
 
 def _fake_completion(content: str) -> MagicMock:
@@ -53,6 +58,42 @@ def test_chat_returns_message_content(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_openai.chat.completions.create.assert_called_once_with(
         model="gpt-4o-mini",
         messages=[{"role": "user", "content": "What is the answer?"}],
+    )
+
+
+def test_chat_serializes_multimodal_content_parts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A message with image content serializes to the OpenAI content-part shape."""
+    client = LLMClient(api_key="sk-test", model="gpt-4o-mini")
+
+    fake_openai = MagicMock()
+    fake_openai.chat.completions.create = MagicMock(return_value=_fake_completion("Understood."))
+    monkeypatch.setattr(client, "_get_client", lambda: fake_openai)
+
+    message = ChatMessage(
+        role="user",
+        content=[
+            ChatContentTextPart(text="Here is the figure:"),
+            ChatContentImagePart(
+                image_url=ChatContentImageURL(url="data:image/png;base64,aGVsbG8=")
+            ),
+        ],
+    )
+    client.chat(messages=[message])
+
+    fake_openai.chat.completions.create.assert_called_once_with(
+        model="gpt-4o-mini",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Here is the figure:"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,aGVsbG8="},
+                    },
+                ],
+            }
+        ],
     )
 
 

--- a/depth_dive/src/depth_dive/assembly/assembly_agent.py
+++ b/depth_dive/src/depth_dive/assembly/assembly_agent.py
@@ -17,8 +17,8 @@ The brief's ``search_intent`` drives the web-search step (ticket #244): when
 the framing agent judged external grounding would help (ADR-0012), the
 assembly agent calls the retry-once web-search wrapper (ADR-0013) and surfaces
 the outcome on :class:`AssemblyResult`. The final turn is the LLM generation
-step (ticket #245), which builds a scene graph from the brief, the cited
-passages, and any search results.
+step (ticket #245), which builds a scene graph from the brief, the
+model-ready carrier, the cited passages, and any search results.
 """
 
 from collections.abc import Sequence
@@ -43,6 +43,7 @@ from core.types.responses import CitedPassage, ScoredChunk
 from core.types.retrieval_config import RetrievalConfig
 from depth_dive.framing.framing_agent import FramingBrief
 from depth_dive.generation.generation_agent import run_generation
+from depth_dive.transform import ModelReadyBlock
 from depth_dive.web_search.client import WebSearchClient, WebSearchResult
 from depth_dive.web_search.wrapper import SearchOutcome, run_web_search
 
@@ -101,6 +102,7 @@ class AssemblyResult(BaseModel):
 def run_assembly(
     passage: CapturedPassage,
     brief: FramingBrief,
+    carrier: ModelReadyBlock,
     *,
     session: Session,
     embedder: Embedder,
@@ -115,6 +117,9 @@ def run_assembly(
         brief: The framing agent's creative brief for this dive. Its
             ``search_intent`` drives the web-search step (ADR-0012, ADR-0013);
             corpus grounding is keyed on the passage's anchor.
+        carrier: The model-ready carrier chosen by the Passage Transform for
+            ``passage``; forwarded to the generation turn so its content
+            (text, structured rows, or image bytes) reaches the model.
         session: SQLAlchemy session bound to the documents database.
         embedder: Provider used to embed the passage content (1536-dim).
         config: Retrieval configuration (model name, ef_search, top_k).
@@ -155,6 +160,7 @@ def run_assembly(
         brief,
         grounding.cited_passages,
         outcome.results,
+        carrier,
         completion_provider=completion_provider,
     )
     return AssemblyResult(

--- a/depth_dive/src/depth_dive/generation/generation_agent.py
+++ b/depth_dive/src/depth_dive/generation/generation_agent.py
@@ -1,10 +1,11 @@
 """LLM-driven interactive-animation generation (ADR-0020, ticket #245).
 
 The assembly agent's final turn: builds the generation prompt from the framing
-brief, the cited corpus passages, and any web-search results, calls the hosted
-inference API, and parses the response into a validated
-``InteractiveAnimation`` scene graph. Malformed model output does not fail the
-dive — it falls back to a minimal valid scene graph carrying a note
+brief, the model-ready carrier chosen by the Passage Transform, the cited
+corpus passages, and any web-search results, calls the hosted inference API,
+and parses the response into a validated ``InteractiveAnimation`` scene graph.
+Malformed model output does not fail the dive — it falls back to a minimal
+valid scene graph carrying a note
 (:mod:`depth_dive.generation.fallback_animation`).
 """
 
@@ -15,11 +16,17 @@ from collections.abc import Sequence
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 from core.clients import CompletionProvider
-from core.types.chat import ChatMessage
+from core.types.chat import (
+    ChatContentImagePart,
+    ChatContentImageURL,
+    ChatContentTextPart,
+    ChatMessage,
+)
 from core.types.depth_dive import InteractiveAnimation, Treatment
 from core.types.responses import CitedPassage
 from depth_dive.framing.framing_agent import FramingBrief
 from depth_dive.generation.fallback_animation import build_fallback_animation
+from depth_dive.transform import ImageBlock, ModelReadyBlock, TableBlock, TextBlock
 from depth_dive.web_search.client import WebSearchResult
 
 # User-facing note carried by the fallback scene graph (ticket #245).
@@ -67,8 +74,9 @@ SYSTEM_PROMPT = (
     "Rules:\n"
     "- Every element id referenced in a step's element_states must be "
     "declared in elements, and initial_state must seed every declared element.\n"
-    "- Ground the explanation in the grounding passages and web-search "
-    "results when they are present; never invent facts that contradict them.\n"
+    "- Ground the explanation in the captured passage content, the grounding "
+    "passages, and web-search results when they are present; never invent "
+    "facts that contradict them.\n"
     "- Concept-centric primitives over decorative shapes; keep narration "
     "short and concrete.\n"
 )
@@ -108,6 +116,7 @@ def build_generation_prompt(
     brief: FramingBrief,
     cited_passages: Sequence[CitedPassage],
     search_results: Sequence[WebSearchResult],
+    carrier: ModelReadyBlock,
 ) -> list[ChatMessage]:
     """Assemble the chat-completions messages for the generation turn.
 
@@ -117,20 +126,69 @@ def build_generation_prompt(
             passage could not be verified against the ingested corpus.
         search_results: External material surfaced by web search; empty when no
             search ran or none returned results.
+        carrier: The model-ready carrier chosen by the Passage Transform for
+            the captured passage. Its content is carried into the prompt: text
+            carriers render as text, image carriers attach as an image content
+            part so the bytes reach the model, and table carriers attach both
+            their structured rows (text) and their rendered image.
 
     Returns:
         A two-message list: a system message setting the scene-graph contract,
-        and a user message carrying the brief, the grounding passages (or the
-        unverified notice), and the web-search results (or the no-material
-        notice).
+        and a user message carrying the captured passage, the brief, the
+        grounding passages (or the unverified notice), and the web-search
+        results (or the no-material notice). When the carrier carries image
+        content (an image/diagram, or a table's render) the user message's
+        content is a list of content parts (text plus the image); otherwise it
+        is a plain string.
     """
-    user_parts: list[str] = [
-        "Creative brief:",
-        f"- Concept: {brief.concept}",
-        f"- Applied treatments: {_treatment_guidance(brief.applied_treatments)}",
-        f"- Search intent: {brief.search_intent or 'none'}",
-        f"- Routing note: {brief.routing_note or 'none'}",
+    image_part = _carrier_image_part(carrier)
+    user_text = _build_user_text(
+        brief,
+        cited_passages,
+        search_results,
+        carrier,
+        has_image=image_part is not None,
+    )
+    if image_part is None:
+        return [
+            ChatMessage(role="system", content=SYSTEM_PROMPT),
+            ChatMessage(role="user", content=user_text),
+        ]
+    return [
+        ChatMessage(role="system", content=SYSTEM_PROMPT),
+        ChatMessage(
+            role="user",
+            content=[ChatContentTextPart(text=user_text), image_part],
+        ),
     ]
+
+
+def _build_user_text(
+    brief: FramingBrief,
+    cited_passages: Sequence[CitedPassage],
+    search_results: Sequence[WebSearchResult],
+    carrier: ModelReadyBlock,
+    *,
+    has_image: bool,
+) -> str:
+    """Render the user-message text: captured passage, brief, grounding, search."""
+    user_parts: list[str] = ["Captured passage:"]
+    carrier_text = _carrier_text(carrier)
+    if carrier_text is not None:
+        user_parts.append(carrier_text)
+        if has_image:
+            user_parts.append("(a rendered image of the same passage is attached below)")
+    else:
+        user_parts.append("an image is attached below as the captured passage.")
+    user_parts.extend(
+        [
+            "\nCreative brief:",
+            f"- Concept: {brief.concept}",
+            f"- Applied treatments: {_treatment_guidance(brief.applied_treatments)}",
+            f"- Search intent: {brief.search_intent or 'none'}",
+            f"- Routing note: {brief.routing_note or 'none'}",
+        ]
+    )
     user_parts.append("\nGrounding passages from the learner's corpus:")
     if cited_passages:
         user_parts.extend(
@@ -146,10 +204,65 @@ def build_generation_prompt(
         )
     else:
         user_parts.append("- none: no external material was retrieved")
-    return [
-        ChatMessage(role="system", content=SYSTEM_PROMPT),
-        ChatMessage(role="user", content="\n".join(user_parts)),
-    ]
+    return "\n".join(user_parts)
+
+
+def _carrier_text(carrier: ModelReadyBlock) -> str | None:
+    """Render the carrier's text-visible content for the prompt.
+
+    Text/code carriers render their content (a code carrier appends its
+    language hint); table carriers render their structured rows. Image
+    carriers have no text-visible form, so they return ``None``.
+    """
+    if isinstance(carrier, TextBlock):
+        if carrier.language:
+            return f"{carrier.text}\n(language: {carrier.language})"
+        return carrier.text
+    if isinstance(carrier, TableBlock):
+        return _render_table_rows(carrier)
+    return None
+
+
+def _render_table_rows(carrier: TableBlock) -> str:
+    """Serialize a table carrier's structured form for the prompt.
+
+    Headers (when present) lead, then one line per row; cells joined with
+    ``" | "`` and dict rows rendered as ``key: value`` cells. The row/header
+    serialization is consistent with the assembly agent's embedding form
+    (``key: value`` for dict cells), minus the passage caption, which the
+    ``TableBlock`` carrier does not carry.
+    """
+    lines: list[str] = []
+    if carrier.headers:
+        lines.append(" | ".join(carrier.headers))
+    for row in carrier.rows:
+        if isinstance(row, dict):
+            lines.append(" | ".join(f"{key}: {value}" for key, value in row.items()))
+        else:
+            lines.append(" | ".join(row))
+    return "\n".join(lines)
+
+
+def _carrier_image_part(carrier: ModelReadyBlock) -> ChatContentImagePart | None:
+    """Return the carrier's image content part, or ``None`` for a text carrier.
+
+    Image/diagram carriers travel as an ``image_url`` part holding a base64
+    data URI so the bytes reach the model (OpenAI vision shape); a table
+    carrier attaches its rendered image the same way alongside its structured
+    rows (spec §5's "structured text + rendered image").
+    """
+    if isinstance(carrier, ImageBlock):
+        return _image_part(carrier)
+    if isinstance(carrier, TableBlock):
+        return _image_part(carrier.image)
+    return None
+
+
+def _image_part(block: ImageBlock) -> ChatContentImagePart:
+    """Build an ``image_url`` content part from a base64 image block."""
+    return ChatContentImagePart(
+        image_url=ChatContentImageURL(url=f"data:{block.media_type};base64,{block.base64}")
+    )
 
 
 def _treatment_guidance(treatments: Sequence[Treatment]) -> str:
@@ -216,6 +329,7 @@ def run_generation(
     brief: FramingBrief,
     cited_passages: Sequence[CitedPassage],
     search_results: Sequence[WebSearchResult],
+    carrier: ModelReadyBlock,
     *,
     completion_provider: CompletionProvider,
 ) -> GenerationResult:
@@ -227,6 +341,9 @@ def run_generation(
             unverified).
         search_results: External material surfaced by web search (empty when
             no search ran or none returned results).
+        carrier: The model-ready carrier chosen by the Passage Transform; its
+            content (text, structured rows, or image bytes) reaches the model
+            in the user message.
         completion_provider: The chat-completions provider to call.
 
     Returns:
@@ -240,7 +357,7 @@ def run_generation(
         UpstreamUnavailable: The inference API was unreachable (route maps to
             503).
     """
-    messages = build_generation_prompt(brief, cited_passages, search_results)
+    messages = build_generation_prompt(brief, cited_passages, search_results, carrier)
     raw = completion_provider.chat(messages)
     animation = parse_animation(raw)
     if animation is None:

--- a/depth_dive/src/depth_dive/harness.py
+++ b/depth_dive/src/depth_dive/harness.py
@@ -1,13 +1,14 @@
 """Harness B entrypoint (ADR-0020).
 
 Runs the Depth Dive pipeline for one ``HarnessBRequest`` and returns a
-``HarnessBResponse``. The passage is validated by the Passage Transform stage,
-the framing agent resolves the treatment set and search intent (ticket #242),
-and the assembly agent grounds the passage against the ingested corpus via the
-shared ``core/retrieval/`` primitives (ticket #243), runs the retry-once
-web-search step when the brief carries a ``search_intent`` (ticket #244), and
-runs the LLM generation turn that produces the ``interactive_animation`` scene
-graph (ticket #245).
+``HarnessBResponse``. The passage is validated by the Passage Transform stage
+(whose model-ready carrier is forwarded to the generation turn), the framing
+agent resolves the treatment set and search intent (ticket #242), and the
+assembly agent grounds the passage against the ingested corpus via the shared
+``core/retrieval/`` primitives (ticket #243), runs the retry-once web-search
+step when the brief carries a ``search_intent`` (ticket #244), and runs the
+LLM generation turn that produces the ``interactive_animation`` scene graph
+(ticket #245).
 """
 
 from sqlalchemy.orm import Session
@@ -62,7 +63,7 @@ def run_dive(
             inference API was unreachable during grounding/generation (route
             maps to 503).
     """
-    transform_passage(request.captured_passage)
+    carrier = transform_passage(request.captured_passage)
     brief = run_framing(
         request.captured_passage,
         requested_treatments=request.requested_treatments,
@@ -71,6 +72,7 @@ def run_dive(
     assembly = run_assembly(
         request.captured_passage,
         brief,
+        carrier,
         session=session,
         embedder=embedder,
         config=config,

--- a/depth_dive/tests/depth_dive/assembly/test_assembly_agent.py
+++ b/depth_dive/tests/depth_dive/assembly/test_assembly_agent.py
@@ -35,6 +35,7 @@ from depth_dive.assembly.assembly_agent import (
 from depth_dive.framing.framing_agent import run_framing
 from depth_dive.generation.fallback_animation import build_fallback_animation
 from depth_dive.generation.generation_agent import GenerationResult
+from depth_dive.transform import ModelReadyBlock, TextBlock
 from depth_dive.web_search.client import StubWebSearchClient, WebSearchResult
 from depth_dive.web_search.wrapper import FALLBACK_NOTE
 
@@ -79,12 +80,14 @@ def _run(
     embedder: Embedder,
     web_search: StubWebSearchClient | None = None,
     completion_provider: CompletionProvider | None = None,
+    carrier: ModelReadyBlock | None = None,
 ) -> AssemblyResult:
     if web_search is None:
         web_search = StubWebSearchClient()
     return run_assembly(
         passage,
         run_framing(passage),
+        carrier or TextBlock(text="Attention is all you need."),
         session=session,
         embedder=embedder,
         config=_CONFIG,
@@ -688,6 +691,7 @@ def test_assembly_passes_citations_and_provider_to_generation(
     assert args[0] == brief
     assert args[1] == [CitedPassage(chunk_id=parent_id, text="parent")]
     assert args[2] == []
+    assert args[3] == TextBlock(text="Attention is all you need.")
     assert kwargs["completion_provider"] is provider
     assert result.animation == _stub_generation.return_value.animation
 
@@ -736,6 +740,22 @@ def test_assembly_surfaces_generated_animation(
         embedder=_StubEmbedder(),
     )
     assert result.animation == _stub_generation.return_value.animation
+
+
+def test_assembly_forwards_the_model_ready_carrier_to_generation(
+    monkeypatch: pytest.MonkeyPatch, _stub_generation: MagicMock
+) -> None:
+    """The carrier chosen by the transform reaches the generation turn."""
+    _passing_gate(monkeypatch)
+    carrier = TextBlock(text="the captured passage")
+    _run(
+        TextPassage(content="Attention is all you need."),
+        session=MagicMock(),
+        embedder=_StubEmbedder(),
+        carrier=carrier,
+    )
+    _stub_generation.assert_called_once()
+    assert _stub_generation.call_args.args[3] == carrier
 
 
 # ============================================================

--- a/depth_dive/tests/depth_dive/generation/test_generation_agent.py
+++ b/depth_dive/tests/depth_dive/generation/test_generation_agent.py
@@ -16,7 +16,7 @@ import pytest
 from core.clients import MockCompletionProvider
 from core.exceptions import UpstreamBadResponse
 from core.types.captured_passage import TextPassage
-from core.types.chat import ChatMessage
+from core.types.chat import ChatContentImagePart, ChatContentTextPart, ChatMessage
 from core.types.depth_dive import InteractiveAnimation, Treatment
 from core.types.responses import CitedPassage
 from depth_dive.framing.framing_agent import run_framing
@@ -26,6 +26,7 @@ from depth_dive.generation.generation_agent import (
     parse_animation,
     run_generation,
 )
+from depth_dive.transform import ImageBlock, TableBlock, TextBlock
 from depth_dive.web_search.client import WebSearchResult
 
 
@@ -60,10 +61,29 @@ def _search_result(title: str = "Paper") -> WebSearchResult:
     return WebSearchResult(title=title, url="https://example.com/paper", snippet="short quote")
 
 
+def _text_carrier(text: str = "Attention is all you need.") -> TextBlock:
+    return TextBlock(text=text)
+
+
+def _image_carrier() -> ImageBlock:
+    return ImageBlock(media_type="image/png", base64="aGVsbG8=", width=4, height=4)
+
+
+def _table_carrier() -> TableBlock:
+    return TableBlock(
+        headers=["l", "v"],
+        rows=[["a", "1"], ["b", "2"]],
+        image=ImageBlock(media_type="image/png", base64="aGVsbG8=", width=4, height=4),
+    )
+
+
 def _user_message(prompt: list[ChatMessage]) -> str:
     assert len(prompt) == 2
     assert prompt[0].role == "system"
-    return prompt[1].content
+    content = prompt[1].content
+    if isinstance(content, str):
+        return content
+    return "\n".join(part.text for part in content if isinstance(part, ChatContentTextPart))
 
 
 # ============================================================
@@ -74,7 +94,7 @@ def _user_message(prompt: list[ChatMessage]) -> str:
 def test_prompt_includes_the_framing_brief() -> None:
     """The prompt carries the brief's concept, treatments, and search intent."""
     brief = run_framing(TextPassage(content="Attention is all you need."))
-    user = _user_message(build_generation_prompt(brief, [], []))
+    user = _user_message(build_generation_prompt(brief, [], [], _text_carrier()))
     assert "Attention is all you need." in user
     assert "worked_example" in user
     assert "none" in user
@@ -84,7 +104,7 @@ def test_prompt_includes_cited_passages() -> None:
     """Grounding passages are included in the prompt."""
     brief = run_framing(TextPassage(content="A concept"))
     citations = [_citation("the enclosing section on attention")]
-    user = _user_message(build_generation_prompt(brief, citations, []))
+    user = _user_message(build_generation_prompt(brief, citations, [], _text_carrier()))
     assert "the enclosing section on attention" in user
     assert "1" in user
 
@@ -92,7 +112,7 @@ def test_prompt_includes_cited_passages() -> None:
 def test_prompt_notes_when_passage_is_ungrounded() -> None:
     """An ungrounded dive tells the model there are no grounding passages."""
     brief = run_framing(TextPassage(content="A concept"))
-    user = _user_message(build_generation_prompt(brief, [], []))
+    user = _user_message(build_generation_prompt(brief, [], [], _text_carrier()))
     assert "could not be grounded" in user
 
 
@@ -100,7 +120,7 @@ def test_prompt_includes_web_search_results() -> None:
     """Web-search material is included in the prompt."""
     brief = run_framing(TextPassage(content="A concept"))
     results = [_search_result("The Illustrated Attention")]
-    user = _user_message(build_generation_prompt(brief, [], results))
+    user = _user_message(build_generation_prompt(brief, [], results, _text_carrier()))
     assert "The Illustrated Attention" in user
     assert "short quote" in user
     assert "https://example.com/paper" in user
@@ -109,7 +129,7 @@ def test_prompt_includes_web_search_results() -> None:
 def test_prompt_notes_when_no_external_material() -> None:
     """A dive without search results tells the model no material was retrieved."""
     brief = run_framing(TextPassage(content="A concept"))
-    user = _user_message(build_generation_prompt(brief, [], []))
+    user = _user_message(build_generation_prompt(brief, [], [], _text_carrier()))
     assert "no external material" in user
 
 
@@ -119,7 +139,7 @@ def test_prompt_is_treatment_specific() -> None:
         TextPassage(content="A concept"),
         requested_treatments=[Treatment.SEGMENTED_CAROUSEL],
     )
-    user = _user_message(build_generation_prompt(brief, [], []))
+    user = _user_message(build_generation_prompt(brief, [], [], _text_carrier()))
     assert "segmented_carousel" in user
     assert "swipeable segments" in user
 
@@ -127,11 +147,85 @@ def test_prompt_is_treatment_specific() -> None:
 def test_system_prompt_declares_the_scene_graph_contract() -> None:
     """The system message sets the JSON contract the model must satisfy."""
     brief = run_framing(TextPassage(content="A concept"))
-    prompt = build_generation_prompt(brief, [], [])
+    prompt = build_generation_prompt(brief, [], [], _text_carrier())
     assert prompt[0].role == "system"
     assert "output_type" in prompt[0].content
     assert "initial_state" in prompt[0].content
     assert "elements" in prompt[0].content
+
+
+# ============================================================
+# Captured-passage carrier wiring (ticket #254)
+# ============================================================
+
+
+def test_prompt_includes_the_captured_text_passage() -> None:
+    """The text carrier's full content reaches the prompt, not just the concept."""
+    brief = run_framing(TextPassage(content="Attention is all you need."))
+    user = _user_message(
+        build_generation_prompt(brief, [], [], _text_carrier("the full captured text"))
+    )
+    assert "Captured passage:" in user
+    assert "the full captured text" in user
+
+
+def test_prompt_includes_code_language_hint() -> None:
+    """A code carrier carries its language hint alongside the content."""
+    brief = run_framing(TextPassage(content="A concept"))
+    carrier = TextBlock(text="def f():\n    return 1", language="python")
+    user = _user_message(build_generation_prompt(brief, [], [], carrier))
+    assert "def f():" in user
+    assert "language: python" in user
+
+
+def test_prompt_serializes_table_rows() -> None:
+    """A table carrier's structured rows reach the prompt as text."""
+    brief = run_framing(TextPassage(content="A concept"))
+    user = _user_message(build_generation_prompt(brief, [], [], _table_carrier()))
+    assert "l | v" in user
+    assert "a | 1" in user
+    assert "b | 2" in user
+
+
+def test_prompt_attaches_image_part_for_image_carrier() -> None:
+    """An image carrier travels as an image_url content part alongside the text."""
+    brief = run_framing(TextPassage(content="A concept"))
+    prompt = build_generation_prompt(brief, [], [], _image_carrier())
+    assert prompt[1].role == "user"
+    content = prompt[1].content
+    assert isinstance(content, list)
+    text_parts = [part for part in content if isinstance(part, ChatContentTextPart)]
+    image_parts = [part for part in content if isinstance(part, ChatContentImagePart)]
+    assert len(text_parts) == 1
+    assert "an image is attached below" in text_parts[0].text
+    assert len(image_parts) == 1
+    assert image_parts[0].type == "image_url"
+    assert image_parts[0].image_url.url == "data:image/png;base64,aGVsbG8="
+
+
+def test_table_carrier_attaches_rendered_image() -> None:
+    """A table carries both its structured rows and its rendered image."""
+    brief = run_framing(TextPassage(content="A concept"))
+    prompt = build_generation_prompt(brief, [], [], _table_carrier())
+    content = prompt[1].content
+    assert isinstance(content, list)
+    text_parts = [part for part in content if isinstance(part, ChatContentTextPart)]
+    image_parts = [part for part in content if isinstance(part, ChatContentImagePart)]
+    assert len(text_parts) == 1
+    assert "l | v" in text_parts[0].text
+    assert "a | 1" in text_parts[0].text
+    assert len(image_parts) == 1
+    assert image_parts[0].image_url.url == "data:image/png;base64,aGVsbG8="
+
+
+def test_run_generation_passes_image_carrier_to_provider() -> None:
+    """The image carrier's bytes reach the provider as part of the user message."""
+    provider = MagicMock(return_value=json.dumps(_valid_scene_graph()))
+    brief = run_framing(TextPassage(content="A concept"))
+    carrier = _image_carrier()
+    run_generation(brief, [], [], carrier, completion_provider=provider)
+    expected = build_generation_prompt(brief, [], [], carrier)
+    provider.chat.assert_called_once_with(expected)
 
 
 # ============================================================
@@ -201,7 +295,7 @@ def test_run_generation_returns_the_model_scene_graph() -> None:
     """A valid model response becomes the generated animation, no fallback."""
     provider = MockCompletionProvider(json.dumps(_valid_scene_graph()))
     brief = run_framing(TextPassage(content="Attention is all you need."))
-    result = run_generation(brief, [_citation()], [], completion_provider=provider)
+    result = run_generation(brief, [_citation()], [], _text_carrier(), completion_provider=provider)
     assert result.fallback_note is None
     assert result.animation.title == "Self-attention"
     assert isinstance(result.animation, InteractiveAnimation)
@@ -213,8 +307,8 @@ def test_run_generation_passes_the_assembled_messages() -> None:
     brief = run_framing(TextPassage(content="Attention is all you need."))
     citations = [_citation()]
     results = [_search_result()]
-    run_generation(brief, citations, results, completion_provider=provider)
-    expected = build_generation_prompt(brief, citations, results)
+    run_generation(brief, citations, results, _text_carrier(), completion_provider=provider)
+    expected = build_generation_prompt(brief, citations, results, _text_carrier())
     provider.chat.assert_called_once_with(expected)
 
 
@@ -222,7 +316,7 @@ def test_run_generation_falls_back_on_malformed_output() -> None:
     """Malformed model output yields the fallback scene graph plus a note."""
     provider = MockCompletionProvider("I cannot do that.")
     brief = run_framing(TextPassage(content="Attention is all you need."))
-    result = run_generation(brief, [], [], completion_provider=provider)
+    result = run_generation(brief, [], [], _text_carrier(), completion_provider=provider)
     assert result.fallback_note == MALFORMED_OUTPUT_NOTE
     assert result.animation.output_type == "interactive_animation"
     assert any(e.text == MALFORMED_OUTPUT_NOTE for e in result.animation.elements)
@@ -232,7 +326,7 @@ def test_run_generation_falls_back_on_schema_violation() -> None:
     """JSON that fails contract validation also falls back."""
     provider = MockCompletionProvider('{"output_type": "interactive_animation"}')
     brief = run_framing(TextPassage(content="Attention is all you need."))
-    result = run_generation(brief, [], [], completion_provider=provider)
+    result = run_generation(brief, [], [], _text_carrier(), completion_provider=provider)
     assert result.fallback_note == MALFORMED_OUTPUT_NOTE
 
 
@@ -245,4 +339,4 @@ def test_run_generation_propagates_upstream_errors() -> None:
 
     brief = run_framing(TextPassage(content="Attention is all you need."))
     with pytest.raises(UpstreamBadResponse):
-        run_generation(brief, [], [], completion_provider=_FailingProvider())
+        run_generation(brief, [], [], _text_carrier(), completion_provider=_FailingProvider())

--- a/depth_dive/tests/depth_dive/test_harness.py
+++ b/depth_dive/tests/depth_dive/test_harness.py
@@ -18,6 +18,7 @@ from core.clients import InMemoryEmbedder, MockCompletionProvider
 from core.types.captured_passage import (
     CapturedPassage,
     CodePassage,
+    DiagramPassage,
     ImagePassage,
     TablePassage,
     TextPassage,
@@ -35,7 +36,7 @@ from depth_dive.assembly.assembly_agent import AssemblyResult
 from depth_dive.framing.framing_agent import FramingBrief
 from depth_dive.generation.fallback_animation import build_fallback_animation
 from depth_dive.harness import run_dive
-from depth_dive.transform import PassageTransformError
+from depth_dive.transform import ImageBlock, PassageTransformError, TableBlock, TextBlock
 from depth_dive.web_search.client import StubWebSearchClient, WebSearchResult
 from depth_dive.web_search.wrapper import FALLBACK_NOTE
 
@@ -233,6 +234,7 @@ def test_run_dive_passes_passage_and_brief_to_assembly(
     call = patched_assembly.call_args
     assert call.args[0] == _VALID_TEXT
     assert isinstance(call.args[1], FramingBrief)
+    assert call.args[2] == TextBlock(text="Attention is all you need.")
     assert call.kwargs["session"] is session
     assert call.kwargs["embedder"] is embedder
     assert call.kwargs["config"] is _CONFIG
@@ -326,6 +328,33 @@ def test_run_dive_rejects_invalid_image(patched_assembly: MagicMock) -> None:
     with pytest.raises(PassageTransformError):
         _dive(ImagePassage(content=b"not an image", media_type="image/png"))
     patched_assembly.assert_not_called()
+
+
+def test_run_dive_passes_image_carrier_to_assembly(patched_assembly: MagicMock) -> None:
+    """An image passage's transform carrier (ImageBlock) reaches the assembly agent."""
+    _dive(_valid_image())
+    patched_assembly.assert_called_once()
+    carrier = patched_assembly.call_args.args[2]
+    assert isinstance(carrier, ImageBlock)
+    assert carrier.media_type == "image/png"
+
+
+def test_run_dive_passes_diagram_carrier_to_assembly(patched_assembly: MagicMock) -> None:
+    """A diagram passage shares the image carrier and reaches the assembly agent."""
+    _dive(DiagramPassage(content=_png_bytes(), media_type="image/png"))
+    patched_assembly.assert_called_once()
+    carrier = patched_assembly.call_args.args[2]
+    assert isinstance(carrier, ImageBlock)
+    assert carrier.media_type == "image/png"
+
+
+def test_run_dive_passes_table_carrier_to_assembly(patched_assembly: MagicMock) -> None:
+    """A table passage's transform carrier (TableBlock) reaches the assembly agent."""
+    _dive(_valid_table())
+    patched_assembly.assert_called_once()
+    carrier = patched_assembly.call_args.args[2]
+    assert isinstance(carrier, TableBlock)
+    assert carrier.rows == [["a", "1"], ["b", "2"]]
 
 
 def test_run_dive_accepts_type_checked_union_payload(patched_assembly: MagicMock) -> None:


### PR DESCRIPTION
…

Wire the Passage Transform's model-ready carriers through the harness and assembly agent into the generation prompt so the captured content reaches the model instead of being discarded. Image/diagram carriers attach as an image_url content part (base64 data URI), and table carriers attach both their structured rows and their rendered image.

ChatMessage gains multimodal content parts (text + image_url) so image content can travel alongside text; the OpenAI client serializes them unchanged.