### PR TITLE
feat(depth-dive): honor requested_output_type with routing fallback

### DIFF
--- a/api/tests/api/test_dive.py
+++ b/api/tests/api/test_dive.py
@@ -304,6 +304,32 @@ def test_dive_deferred_treatment_is_accepted_and_routed_not_422(
     assert "analogy_mapping" in data["routing_note"]
 
 
+def test_dive_unsupported_output_type_is_routed_not_422(
+    mock_client: TestClient, patched_dive_grounding: Any
+) -> None:
+    """An unsupported requested_output_type returns 200 with a routing note."""
+    patched_dive_grounding()
+    body = {**_VALID_BODY, "requested_output_type": "carousel"}
+    response = mock_client.post("/dive", json=body)
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["output"]["output_type"] == "interactive_animation"
+    assert data["routing_note"] is not None
+    assert "carousel" in data["routing_note"]
+
+
+def test_dive_supported_output_type_returns_no_routing_note(
+    mock_client: TestClient, patched_dive_grounding: Any
+) -> None:
+    """A supported interactive_animation request routes without a note."""
+    patched_dive_grounding()
+    body = {**_VALID_BODY, "requested_output_type": "interactive_animation"}
+    response = mock_client.post("/dive", json=body)
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["routing_note"] is None
+
+
 # ============================================================
 # 200 + 422 — image, diagram, and table passages
 # ============================================================

--- a/core/src/core/types/depth_dive.py
+++ b/core/src/core/types/depth_dive.py
@@ -13,6 +13,14 @@ from pydantic import BaseModel, ConfigDict, Field
 from core.types.captured_passage import CapturedPassage
 from core.types.responses import CitedPassage
 
+SUPPORTED_OUTPUT_TYPE = "interactive_animation"
+"""The single output type the MVP can honor (depth-dive spec §6).
+
+``requested_output_type`` is modeled as a free string rather than a
+``Literal`` so an unsupported value reaches the framing agent and is routed
+(with a ``routing_note``) instead of being rejected at the request boundary.
+"""
+
 
 class Treatment(StrEnum):
     """MVP pedagogical patterns layered onto an interactive animation (spec §3).
@@ -154,7 +162,7 @@ class HarnessBRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     captured_passage: CapturedPassage
-    requested_output_type: Literal["interactive_animation"] | None = None
+    requested_output_type: str | None = None
     requested_treatments: list[TreatmentHint] | None = None
     preferred_treatments: list[TreatmentHint] | None = None
     client_passage_id: str | None = None
@@ -177,6 +185,7 @@ class HarnessBResponse(BaseModel):
 
 
 __all__ = [
+    "SUPPORTED_OUTPUT_TYPE",
     "AnimationStep",
     "DeferredTreatment",
     "ElementState",

--- a/core/tests/core/types/test_depth_dive.py
+++ b/core/tests/core/types/test_depth_dive.py
@@ -60,13 +60,27 @@ def test_harness_b_request_rejects_missing_passage() -> None:
         HarnessBRequest()  # type: ignore[call-arg]
 
 
-def test_harness_b_request_rejects_unknown_output_type() -> None:
-    """HarnessBRequest restricts requested_output_type to interactive_animation."""
-    with pytest.raises(ValidationError):
-        HarnessBRequest(
-            captured_passage=TextPassage(content="x"),
-            requested_output_type="carousel",  # type: ignore[arg-type]
-        )
+def test_harness_b_request_accepts_supported_output_type() -> None:
+    """HarnessBRequest accepts the supported interactive_animation output type."""
+    body = HarnessBRequest(
+        captured_passage=TextPassage(content="x"),
+        requested_output_type="interactive_animation",
+    )
+    assert body.requested_output_type == "interactive_animation"
+
+
+def test_harness_b_request_accepts_unknown_output_type() -> None:
+    """An unsupported requested_output_type is accepted at the boundary.
+
+    The framing agent (not request validation) is responsible for honoring it
+    or falling back with a ``routing_note`` (spec §6), so the field is a free
+    string rather than a ``Literal``.
+    """
+    body = HarnessBRequest(
+        captured_passage=TextPassage(content="x"),
+        requested_output_type="carousel",
+    )
+    assert body.requested_output_type == "carousel"
 
 
 def test_harness_b_response_serializes_scene_graph() -> None:

--- a/depth_dive/src/depth_dive/framing/framing_agent.py
+++ b/depth_dive/src/depth_dive/framing/framing_agent.py
@@ -25,7 +25,12 @@ from core.types.captured_passage import (
     TablePassage,
     TextPassage,
 )
-from core.types.depth_dive import DeferredTreatment, Treatment, TreatmentHint
+from core.types.depth_dive import (
+    SUPPORTED_OUTPUT_TYPE,
+    DeferredTreatment,
+    Treatment,
+    TreatmentHint,
+)
 
 _SEARCH_INTENT_MAX_CHARS = 200
 """Cap on the length of a derived web-search intent."""
@@ -57,6 +62,7 @@ def run_framing(
     *,
     requested_treatments: Sequence[TreatmentHint] | None = None,
     preferred_treatments: Sequence[TreatmentHint] | None = None,
+    requested_output_type: str | None = None,
 ) -> FramingBrief:
     """Produce the framing brief for one captured passage and request hints.
 
@@ -66,6 +72,9 @@ def run_framing(
             deferred/still-deferred names).
         preferred_treatments: UI-supplied, request-time-only treatment
             preferences.
+        requested_output_type: Explicit, user-typed output-type ask. MVP
+            supports only ``interactive_animation`` (spec §6); any other value
+            falls back with a ``routing_note`` rather than an error.
 
     Returns:
         A ``FramingBrief`` carrying the recommended and applied treatments,
@@ -73,12 +82,15 @@ def run_framing(
         per-request web-search intent.
     """
     recommended = _recommend_treatments(passage)
-    applied, notes = _resolve_treatments(requested_treatments, preferred_treatments, recommended)
+    applied, treatment_notes = _resolve_treatments(
+        requested_treatments, preferred_treatments, recommended
+    )
+    output_notes = _resolve_output_type_notes(requested_output_type)
     return FramingBrief(
         concept=_concept(passage),
         recommended_treatments=recommended,
         applied_treatments=applied,
-        routing_note=_join_notes(notes),
+        routing_note=_join_notes([*output_notes, *treatment_notes]),
         search_intent=_decide_search_intent(passage),
     )
 
@@ -124,6 +136,22 @@ def _resolve_treatments(
                 notes.append(override_note)
             return applied, notes
     return list(recommendation), []
+
+
+def _resolve_output_type_notes(requested: str | None) -> list[str]:
+    """Return a routing note when the requested output type is unsupported.
+
+    MVP supports only ``interactive_animation`` (spec §6), so a request for the
+    supported type — or no request at all — produces no note. Any other value
+    cannot be honored, so it falls back to the supported type with an
+    explanatory note rather than a hard error. The resolved output type is
+    always the supported one; the note records the override. An incompatible
+    output-type/treatment combination cannot arise in MVP because every
+    treatment layers onto the single supported output type.
+    """
+    if requested is None or requested == SUPPORTED_OUTPUT_TYPE:
+        return []
+    return [f"unsupported output type {requested!r}, falling back to {SUPPORTED_OUTPUT_TYPE}"]
 
 
 def _filter_supported(hints: Sequence[TreatmentHint]) -> tuple[list[Treatment], list[str]]:

--- a/depth_dive/src/depth_dive/harness.py
+++ b/depth_dive/src/depth_dive/harness.py
@@ -68,6 +68,7 @@ def run_dive(
         request.captured_passage,
         requested_treatments=request.requested_treatments,
         preferred_treatments=request.preferred_treatments,
+        requested_output_type=request.requested_output_type,
     )
     assembly = run_assembly(
         request.captured_passage,

--- a/depth_dive/tests/depth_dive/framing/test_framing_agent.py
+++ b/depth_dive/tests/depth_dive/framing/test_framing_agent.py
@@ -144,6 +144,45 @@ def test_deferred_preferred_treatment_falls_back_with_note() -> None:
 
 
 # ------------------------------------------------------------
+# Output-type routing (spec §6, ticket #256)
+# ------------------------------------------------------------
+
+
+def test_supported_output_type_produces_no_note() -> None:
+    """A requested interactive_animation output type is honored with no note."""
+    brief = run_framing(_VALID_TEXT, requested_output_type="interactive_animation")
+    assert brief.routing_note is None
+    assert brief.applied_treatments == brief.recommended_treatments
+
+
+def test_absent_output_type_produces_no_note() -> None:
+    """Omitting requested_output_type contributes no routing note."""
+    brief = run_framing(_VALID_TEXT)
+    assert brief.routing_note is None
+
+
+def test_unsupported_output_type_falls_back_with_note() -> None:
+    """An unsupported output type falls back to interactive_animation with a note."""
+    brief = run_framing(_VALID_TEXT, requested_output_type="carousel")
+    assert brief.routing_note is not None
+    assert "carousel" in brief.routing_note
+    assert "interactive_animation" in brief.routing_note
+    assert brief.applied_treatments == brief.recommended_treatments
+
+
+def test_unsupported_output_type_combines_with_treatment_note() -> None:
+    """An output-type fallback and a treatment override surface both notes."""
+    brief = run_framing(
+        _VALID_TEXT,
+        requested_output_type="carousel",
+        requested_treatments=[Treatment.SEGMENTED_CAROUSEL],
+    )
+    assert brief.routing_note is not None
+    assert "carousel" in brief.routing_note
+    assert "explicit request" in brief.routing_note
+
+
+# ------------------------------------------------------------
 # Web-search intent decision
 # ------------------------------------------------------------
 

--- a/depth_dive/tests/depth_dive/test_harness.py
+++ b/depth_dive/tests/depth_dive/test_harness.py
@@ -249,6 +249,43 @@ def test_run_dive_recommends_and_applies_worked_example(patched_assembly: MagicM
     assert response.routing_note is None
 
 
+def test_run_dive_routes_unsupported_output_type_with_note(
+    patched_assembly: MagicMock,
+) -> None:
+    """An unsupported requested_output_type surfaces a routing note, not an error."""
+    response = run_dive(
+        HarnessBRequest(
+            captured_passage=_VALID_TEXT,
+            requested_output_type="carousel",
+        ),
+        session=MagicMock(),
+        embedder=InMemoryEmbedder(),
+        config=_CONFIG,
+        web_search=StubWebSearchClient(),
+        completion_provider=_completion(),
+    )
+    assert response.routing_note is not None
+    assert "carousel" in response.routing_note
+    assert response.output.output_type == "interactive_animation"
+
+
+def test_run_dive_accepts_supported_output_type(patched_assembly: MagicMock) -> None:
+    """A supported interactive_animation request produces no routing note."""
+    response = run_dive(
+        HarnessBRequest(
+            captured_passage=_VALID_TEXT,
+            requested_output_type="interactive_animation",
+        ),
+        session=MagicMock(),
+        embedder=InMemoryEmbedder(),
+        config=_CONFIG,
+        web_search=StubWebSearchClient(),
+        completion_provider=_completion(),
+    )
+    assert response.routing_note is None
+    assert response.output.output_type == "interactive_animation"
+
+
 def test_run_dive_mirrors_the_assembly_animation(monkeypatch: pytest.MonkeyPatch) -> None:
     """The harness returns the assembly agent's generated scene graph as output."""
     first_animation = build_fallback_animation("first dive")

--- a/docs/specs/depth-dive-redefinition.md
+++ b/docs/specs/depth-dive-redefinition.md
@@ -293,7 +293,7 @@ New standalone Pydantic models in `core/types/depth_dive.py`. `CapturedPassage` 
 | Field | Type | Description |
 |---|---|---|
 | `captured_passage` | `CapturedPassage` | One captured passage per request. |
-| `requested_output_type` | `Literal["interactive_animation"] \| None` | Forward-compatible. |
+| `requested_output_type` | `str \| None` | Forward-compatible; unsupported values fall back to `interactive_animation` with a `routing_note` (never a 422). |
 | `requested_treatments` | `list[Treatment] \| None` | Explicit ask. |
 | `preferred_treatments` | `list[Treatment] \| None` | UI-supplied, request-time only. |
 | `client_passage_id` | `str \| None` | UI-only; backend ignores. |


### PR DESCRIPTION
requested_output_type was carried on HarnessBRequest but never read, so no routing decision or routing_note was produced for it. Widen the field from a Literal to a free string so an unsupported value reaches the framing agent instead of 422-ing at the boundary, then route it per depth-dive spec §6: accept interactive_animation silently, and fall back to it with an explanatory routing_note for anything else. Treatment precedence is unchanged.

Closes #256