### PR TITLE
docs: refresh stale status, structure, and line counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## Current state
 
-This repository is in **early implementation (tracer bullet complete)**. ADRs, stack decisions, coding standards, and the monorepo layout are in place, plus the build/CI scaffolding: root + per-module `pyproject.toml` (uv workspace), `uv.lock`, `.github/workflows/` (`ci.yml`, `cd.yml`, `security.yml`, `dependabot-auto-merge.yml`), `commitlint.config.mjs`, and `Dockerfile`. Six packages make up the workspace (`core/`, `retrieval_qa/`, `api/`, `ingestion/`, `depth_dive/`, `scripts/`); all six have real implementation code (~5300 source lines, plus ~6300 lines of tests) — `depth_dive/` runs the full transform → framing → assembly (corpus grounding + web search) → LLM-generation harness. `scripts/` holds the eval & chunk-size-tuning tooling over the `eval_corpus/` tuning set, with its tests in root `tests/scripts/`. The toolchain is green: `uv sync --all-packages` installs all deps; `uv run ruff check`, `uv run mypy`, `uv run lint-imports`, and `uv run pytest` all pass. (`uv run ruff format --check` reports 3 unformatted markdown files in `docs/adr/` and `docs/.out-of-scope/`; cosmetic, outside package dirs, so not caught by per-package CI checks.)
+This repository is in **early implementation (tracer bullet complete)**. ADRs, stack decisions, coding standards, and the monorepo layout are in place, plus the build/CI scaffolding: root + per-module `pyproject.toml` (uv workspace), `uv.lock`, `.github/workflows/` (`ci.yml`, `cd.yml`, `security.yml`, `dependabot-auto-merge.yml`), `commitlint.config.mjs`, and `Dockerfile`. Six packages make up the workspace (`core/`, `retrieval_qa/`, `api/`, `ingestion/`, `depth_dive/`, `scripts/`); all six have real implementation code (~7,800 source lines, plus ~10,700 lines of tests) — `depth_dive/` runs the full transform → framing → assembly (corpus grounding + web search) → LLM-generation harness. `scripts/` holds the eval & chunk-size-tuning tooling over the `eval_corpus/` tuning set, with its tests in root `tests/scripts/`. The toolchain is green: `uv sync --all-packages` installs all deps; `uv run ruff check`, `uv run mypy`, `uv run lint-imports`, and `uv run pytest` all pass. (`uv run ruff format --check` reports 3 unformatted markdown files in `docs/adr/` and `docs/.out-of-scope/`; cosmetic, outside package dirs, so not caught by per-package CI checks.)
 
 ## Authoritative sources — read before acting
 
@@ -28,7 +28,7 @@ These docs are **not** auto-loaded into session context. Only this `AGENTS.md` i
 **Before choosing or adding a library, model, or external service:**
 
 - `docs/tech-stack.md` — MVP stack and staged post-MVP milestones.
-- `docs/adr/` — read the ADR(s) most relevant to the area (e.g., ADR-0001 inference, ADR-0002 pgvector, ADR-0003 hand-rolled RAG, ADR-0004 embeddings, ADR-0006 background ingestion, ADR-0007 path-gated retrieval eval (superseded by ADR-0015), ADR-0009 HarnessAResponse shape, ADR-0012 depth-dive-web-search-agentic, ADR-0013 depth-dive-search-failure-retry-fallback, ADR-0014 data-schema-api-contracts-harness-a, ADR-0015 deepeval-for-retrieval-evaluation, ADR-0016 retrieval-qa-critical-gaps-parent-child-hybrid-rerank, ADR-0017 important-but-gatable-retrieval-phase, ADR-0018 no-auth-access-control-for-mvp). Note: ADR-0008 is intentionally skipped in numbering. Treat ADRs as **constraints, not suggestions**. If a decision contradicts an ADR, stop and propose a new/updated ADR rather than silently deviating.
+- `docs/adr/` — read the ADR(s) most relevant to the area (e.g., ADR-0001 inference, ADR-0002 pgvector, ADR-0003 hand-rolled RAG, ADR-0004 embeddings, ADR-0006 background ingestion, ADR-0007 path-gated retrieval eval (superseded by ADR-0015), ADR-0009 HarnessAResponse shape, ADR-0012 depth-dive-web-search-agentic, ADR-0013 depth-dive-search-failure-retry-fallback, ADR-0014 data-schema-api-contracts-harness-a, ADR-0015 deepeval-for-retrieval-evaluation, ADR-0016 retrieval-qa-critical-gaps-parent-child-hybrid-rerank, ADR-0017 important-but-gatable-retrieval-phase, ADR-0018 no-auth-access-control-for-mvp, ADR-0019 shared-retrieval-primitives-in-core, ADR-0020 depth-dive-harness-b-architecture, ADR-0021 captured-passage-model). Note: ADR-0008 is intentionally skipped in numbering. Treat ADRs as **constraints, not suggestions**. If a decision contradicts an ADR, stop and propose a new/updated ADR rather than silently deviating.
 
 **Before writing a commit message:**
 
@@ -115,8 +115,7 @@ Rules:
 ## What does not exist yet
 
 - **`api/routes/__init__.py`** — route modules are imported directly in `server.py`; no package init file exists.
-
-Bootstrap order is complete for all six packages (`core/` (shared retrieval layer included) → `retrieval_qa/` → `depth_dive/` → `api/` → `ingestion/`, plus the `scripts/` eval & tuning tooling over the `eval_corpus/` tuning set). `depth_dive/` now runs the full harness: transform → framing → assembly (corpus grounding + retry-once web search + LLM generation turn) → `interactive_animation` scene graph. The framing brief and the pre-framing demo payload are gone; the framing agent is still a deterministic tracer-bullet stand-in for the eventual LLM framing turn (ADR-0012).
+- **LLM framing turn** — the framing agent (`depth_dive/src/depth_dive/framing/framing_agent.py`) is still a deterministic tracer-bullet stand-in for the eventual LLM framing turn (ADR-0012); treatment routing and search intent are keyed on the passage's type/content rather than content analysis.
 
 ## Agent skills
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,16 @@ A hand-rolled RAG study tool for learning AI/ML from papers, books, and document
 
 **Query (MVP).** Send `{query: str}` to `POST /query`. The system retrieves candidate chunks from your entire corpus using a hybrid dense + sparse retrieval pipeline, reranks the top candidates with a cross-encoder, and assembles the most relevant grounded context for model generation. The response is a structured `HarnessAResponse` — answer text, cited passages, and a `grounded: bool` flag so you know whether the answer actually came from your documents.
 
+**Depth Dive (post-MVP 1).** Send a `CapturedPassage` to `POST /dive`. The framing agent resolves the treatment set and search intent, the assembly agent grounds the passage against the corpus (with retry-once web search when the brief calls for it), and the LLM generates an `interactive_animation` scene graph — the richer, multi-modal explanation format ([ADR-0020](./docs/adr/0020-depth-dive-harness-b-architecture.md)).
+
 **Roadmap.**
 | Phase | What | Status |
 |---|---|---|
 | MVP | Grounded Q&A against your personal corpus | ✅ Operational |
-| Post-MVP 1 | **Depth Dive** — richer explanations (text + diagrams + code) with agentic web search | 🔧 Scaffold |
+| Post-MVP 1 | **Depth Dive** — richer explanations (text + diagrams + code) with agentic web search | ✅ Operational |
 | Post-MVP 2 | **Concept Linking + Retrieval Practice / Spaced Repetition** — query-independent relationship surfacing and review-style learning triggers | 📅 Planned |
 
-> **Status:** Early implementation — tracer bullet complete. Five of six packages (`core/`, `retrieval_qa/`, `api/`, `ingestion/`, `scripts/`) have implementation code (~5300 source lines, plus `tests/`). Only `depth_dive/` is still a stub (just `__init__.py` + smoke test). Ingestion pipeline, Harness A query pipeline, four API endpoints (`POST /ingest`, `GET /documents/{id}`, `POST /query`, `GET /health`), and the `scripts/` eval & chunk-size-tuning tooling are operational. See [docs/](./docs/) for architecture decisions and plans.
+> **Status:** Early implementation — tracer bullet complete. All six packages (`core/`, `retrieval_qa/`, `depth_dive/`, `api/`, `ingestion/`, `scripts/`) have implementation code (~7,800 source lines, plus ~10,700 lines of tests). `depth_dive/` runs the full Harness B: transform → framing → assembly (corpus grounding + retry-once web search) → LLM generation of the `interactive_animation` scene graph. Ingestion pipeline, Harness A query pipeline, five API endpoints (`POST /ingest`, `GET /documents/{id}`, `POST /query`, `POST /dive`, `GET /health`), and the `scripts/` eval & chunk-size-tuning tooling are operational. See [docs/](./docs/) for architecture decisions and plans.
 
 ## Local development
 

--- a/docs/ai-system-tree.md
+++ b/docs/ai-system-tree.md
@@ -14,13 +14,27 @@ learning-hub/
 │   │   └── __init__.py
 │   ├── tests/retrieval_qa/           # chunker tests
 │   ├── tests/eval/                   # retrieval eval (path-gated, eval_set.yaml + eval_vectors.json)
-│   ├── pyproject.toml
-│   └── README.md
-├── depth_dive/                        # Depth Dive generation (stub — TODO)
+│   └── pyproject.toml
+├── depth_dive/                        # Depth Dive generation (Harness B, ADR-0020)
 │   ├── src/depth_dive/
-│   │   └── __init__.py               # Package marker only
-│   ├── tests/depth_dive/
-│   │   └── test_smoke.py
+│   │   ├── transform.py               # Passage transform → model-ready carrier
+│   │   ├── harness.py                 # Harness B entrypoint (ADR-0020)
+│   │   ├── framing/                   # Framing agent (treatment routing + search intent)
+│   │   │   ├── framing_agent.py
+│   │   │   └── __init__.py
+│   │   ├── assembly/                  # Assembly agent (corpus grounding + web search + generation)
+│   │   │   ├── assembly_agent.py
+│   │   │   └── __init__.py
+│   │   ├── generation/                # LLM generation turn + fallback scene graph
+│   │   │   ├── generation_agent.py
+│   │   │   ├── fallback_animation.py
+│   │   │   └── __init__.py
+│   │   ├── web_search/                # Web-search wrapper (retry-once + fallback)
+│   │   │   ├── client.py
+│   │   │   ├── wrapper.py
+│   │   │   └── __init__.py
+│   │   └── __init__.py
+│   ├── tests/depth_dive/              # transform/harness/framing/assembly/generation/web_search tests
 │   └── pyproject.toml
 ├── core/                             # Shared (may stay here or move to common/ later)
 │   ├── src/core/
@@ -30,6 +44,8 @@ learning-hub/
 │   │   │   ├── chat.py               # Chat / conversation models
 │   │   │   ├── responses.py          # HarnessAResponse, etc.
 │   │   │   ├── retrieval_config.py   # Retrieval config models
+│   │   │   ├── depth_dive.py         # HarnessBRequest/Response, scene graph types
+│   │   │   ├── captured_passage.py   # Captured Passage five-type model (ADR-0021)
 │   │   │   └── __init__.py
 │   │   ├── config/
 │   │   │   ├── settings.py           # Pydantic settings
@@ -41,24 +57,25 @@ learning-hub/
 │   │   ├── retrieval/                # Shared retrieval primitives (ADR-0019)
 │   │   │   ├── query.py              # Full hybrid pipeline
 │   │   │   ├── neighbors.py          # Dense semantic-neighbor search
-│   │   │   └── parents.py            # Parent-chunk fetch
+│   │   │   ├── parents.py            # Parent-chunk fetch
+│   │   │   └── documents.py          # Document-level lookup helpers
 │   │   ├── database/                 # pgvector wrapper, Alembic migrations
 │   │   │   ├── connection.py
 │   │   │   ├── schema.py
-│   │   │   └── migrations/           # env.py + script.py.mako + versions/
+│   │   │   └── migrations/           # env.py + script.py.mako + versions/ (2 revisions)
 │   │   ├── exceptions.py             # Named exception types
 │   │   ├── utils.py                  # Shared text utilities (e.g. count_tokens)
 │   │   └── __init__.py
-│   ├── tests/core/                   # types, clients, migration tests
-│   ├── pyproject.toml
-│   └── README.md
+│   ├── tests/core/                   # types, clients, retrieval, migration tests
+│   └── pyproject.toml
 ├── api/                              # FastAPI server (thin controller layer)
 │   ├── src/api/
 │   │   ├── routes/
 │   │   │   ├── retrieval_qa.py       # /query endpoint
 │   │   │   ├── health.py             # /health endpoint
 │   │   │   ├── ingest.py             # /ingest endpoint
-│   │   │   └── documents.py          # /documents/{id} endpoint
+│   │   │   ├── documents.py          # /documents/{id} endpoint
+│   │   │   └── dive.py               # /dive endpoint (Harness B)
 │   │   ├── controllers/
 │   │   │   └── qa_controller.py      # Orchestrates Harness A
 │   │   ├── dependencies.py           # FastAPI dependency injection
@@ -67,9 +84,10 @@ learning-hub/
 │   │   ├── main.py                   # Entry point
 │   │   └── __init__.py
 │   ├── tests/api/                    # route + controller + prompt tests
+│   │   ├── controllers/               # qa_controller tests
+│   │   └── test_dive.py               # /dive route tests
 │   ├── tests/conftest.py
-│   ├── pyproject.toml
-│   └── README.md
+│   └── pyproject.toml
 ├── ingestion/                        # Document upload & background task logic
 │   ├── src/ingestion/
 │   │   ├── models.py                 # Pydantic models for ingestion
@@ -79,8 +97,7 @@ learning-hub/
 │   │   └── __init__.py
 │   ├── tests/ingestion/              # pipeline/splitting/tasks unit tests
 │   ├── tests/integration/            # real-API ingestion tests (integration-marked)
-│   ├── pyproject.toml
-│   └── README.md
+│   └── pyproject.toml
 ├── scripts/                          # Eval & chunk-size tuning tooling
 │   ├── __init__.py
 │   ├── eval_metrics.py               # Recall@k, MRR, is_hit metrics
@@ -94,12 +111,21 @@ learning-hub/
 │   ├── books/                        # DDIA excerpts, deep learning concepts
 │   ├── papers/                       # FlashAttention, vLLM paged attention
 │   ├── synthetic/                    # RAG reference, SOLID principles
-│   └── eval_set_tuning.yaml          # Tuning query set
+│   ├── eval_set_tuning.yaml          # Tuning query set
+│   └── eval_vectors_*.json           # Pre-generated eval vectors (256/512/1024-dim)
 ├── tests/                            # Root-level tests (scripts/ eval tooling)
 │   └── scripts/
 ├── docs/
-│   ├── adr/                          # 0001–0018 (skip 0008; 0015 supersedes 0007 scorer)
-│   ├── agent/issue-tracker.md        # Code review tracker
+│   ├── adr/                          # 0001–0021 (skip 0008; 0015 supersedes 0007 scorer)
+│   ├── agents/                       # Agent skill docs (issue tracker, triage labels, domain)
+│   │   ├── issue-tracker.md
+│   │   ├── triage-labels.md
+│   │   └── domain.md
+│   ├── research/                     # Research notes (multimodal inputs, neuroscience methods)
+│   │   ├── multimodal-passage-inputs.md
+│   │   └── neuroscience-methods-output-types.md
+│   ├── specs/                        # Feature specs
+│   │   └── depth-dive-redefinition.md
 │   ├── ai-system-tree.md
 │   ├── coding-standards.md
 │   ├── commit-instructions.md
@@ -116,7 +142,7 @@ learning-hub/
 │   ├── security.yml                  # CodeQL, secret scanning (gitleaks), Trivy, license audit
 │   └── dependabot-auto-merge.yml     # Auto-merge for low-risk Dependabot bumps
 ├── pyproject.toml                    # Root: uv workspace, ruff config, import-linter contracts
-├── conftest.py                       # Root test fixtures (276 lines, shared by all packages)
+├── conftest.py                       # Root test fixtures (282 lines, shared by all packages)
 ├── alembic.ini                       # Alembic configuration for DB migrations
 ├── Makefile                          # Thin docker-compose wrapper for local dev (up/logs/down)
 ├── docker-entrypoint.sh              # Container entrypoint: alembic upgrade + uvicorn
@@ -124,6 +150,8 @@ learning-hub/
 ├── docker-compose.yml                # Local dev: PostgreSQL + pgvector
 ├── Dockerfile                        # Multi-stage build (all 6 packages)
 ├── .env.example
+├── skills-lock.json                  # Pinned agent skill versions
+├── tuning_results.json               # Chunk-size tuning run output
 ├── AGENTS.md                         # Session notes for AI coding tools
 ├── CONTEXT.md                        # Domain glossary
 └── README.md


### PR DESCRIPTION
Update README, AGENTS.md, and docs/ai-system-tree.md to match the current state now that all six packages are implemented. The docs still described depth_dive/ as a stub, listed only four API endpoints, and stopped at ADR-0018 despite ADR-0019/0020/0021 being accepted.