### PR TITLE
chore(commitlint): disable body-max-line-length for dependabot bodies

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -6,5 +6,6 @@ export default {
       'always',
       ['feat', 'fix', 'refactor', 'test', 'docs', 'chore', 'ci', 'perf'],
     ],
+    'body-max-line-length': [0],
   },
 };


### PR DESCRIPTION
Dependabot auto-generated commit bodies contain long `[Commits](URL)` lines (compare links) that cannot be wrapped without breaking the markdown, so they always violate `body-max-line-length` (100). This blocks the commit-message CI check on every Dependabot PR (e.g. #282) and prevents auto-merge.

Disable the rule so auto-generated dependabot bodies pass.