### PR TITLE
feat: instrument five RAG stage seams with OpenTelemetry spans

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,10 @@ WEB_SEARCH_MODEL=gpt-4o-mini
 
 # Active reranker model.
 RERANKER_MODEL=rerank-v3.5
+
+# OpenTelemetry OTLP/HTTP endpoint (collector) for the five RAG stage spans
+# (embed / retrieve / rerank / generate / web-search). Leave empty to keep the
+# instrumentation inert — no exporter is installed and no spans leave the api.
+# When set, the api exports every request's stage spans to this endpoint.
+OTEL_EXPORTER_OTLP_ENDPOINT=
+OTEL_SERVICE_NAME=learning-hub

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -79,4 +79,4 @@ jobs:
         run: uv sync --all-packages
 
       - name: Check licenses
-        run: uv run pip-licenses --allow-only="Apache License 2.0;Apache Software License;Apache Software License; MIT License;Apache-2.0;Apache-2.0 AND MIT;Apache-2.0 OR BSD-2-Clause;BSD License;BSD-2-Clause;BSD-3-Clause;GNU Library or Lesser General Public License (LGPL);ISC;ISC License (ISCL);MIT;MIT AND PSF-2.0;MIT License;MIT-CMU;MPL-2.0;MPL-2.0 AND MIT;Mozilla Public License 2.0 (MPL 2.0);PSF-2.0;Python Software Foundation License;Unlicense"
+        run: uv run pip-licenses --allow-only="Apache License 2.0;Apache Software License;Apache Software License; MIT License;Apache-2.0;Apache-2.0 AND MIT;Apache-2.0 OR BSD-2-Clause;BSD License;BSD-2-Clause;BSD-3-Clause;3-Clause BSD License;GNU Library or Lesser General Public License (LGPL);ISC;ISC License (ISCL);MIT;MIT AND PSF-2.0;MIT License;MIT-CMU;MPL-2.0;MPL-2.0 AND MIT;Mozilla Public License 2.0 (MPL 2.0);PSF-2.0;Python Software Foundation License;Unlicense"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "fastapi>=0.141.1",
     "uvicorn>=0.52.3",
     "python-multipart>=0.0.9",
+    "opentelemetry-sdk>=1.24",
+    "opentelemetry-exporter-otlp-proto-http>=1.24",
 ]
 
 [tool.uv.sources]

--- a/api/src/api/server.py
+++ b/api/src/api/server.py
@@ -1,5 +1,8 @@
 """FastAPI application factory."""
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 
@@ -8,6 +11,8 @@ from api.routes.documents import router as documents_router
 from api.routes.health import router as health_router
 from api.routes.ingest import router as ingest_router
 from api.routes.retrieval_qa import router as query_router
+from api.telemetry import TraceRequestMiddleware, configure_telemetry, shutdown_telemetry
+from core.config.settings import settings
 from core.exceptions import UpstreamBadResponse, UpstreamUnavailable
 
 
@@ -21,9 +26,19 @@ def _retrieval_error_handler(request: Request, exc: Exception, status_code: int)
     return JSONResponse(status_code=status_code, content={"detail": str(exc)})
 
 
+@asynccontextmanager
+async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Flush the api's span exporter when the process shuts down."""
+    _ = app  # unused; lifespan signature tracks Starlette's contract.
+    yield
+    shutdown_telemetry()
+
+
 def create_app() -> FastAPI:
     """Create and configure the Learning Hub API."""
-    app = FastAPI(title="Learning Hub", version="0.1.0")
+    configure_telemetry(settings)
+    app = FastAPI(title="Learning Hub", version="0.1.0", lifespan=_lifespan)
+    app.add_middleware(TraceRequestMiddleware)
     app.include_router(health_router)
     app.include_router(ingest_router)
     app.include_router(documents_router)

--- a/api/src/api/telemetry.py
+++ b/api/src/api/telemetry.py
@@ -1,0 +1,109 @@
+"""OTLP/HTTP export wiring for the api process (issue #286).
+
+The api is the single export point for the five RAG stage spans
+(embed / retrieve / rerank / generate / web-search). When
+``Settings.otel_exporter_otlp_endpoint`` is configured, :func:`configure_telemetry`
+installs a global ``TracerProvider`` that batch-exports spans over OTLP/HTTP to
+that collector. Otherwise it leaves the OpenTelemetry default no-op provider in
+place, so the stage spans created by :mod:`core.telemetry` are dropped — the
+instrumentation is inert unless explicitly enabled by configuration.
+
+:class:`TraceRequestMiddleware` opens one root span per request so the stage
+spans nest under a single per-request trace instead of minting one orphaned
+root per stage, and :func:`shutdown_telemetry` flushes the final batch on
+graceful process shutdown.
+"""
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter
+from opentelemetry.trace import SpanKind
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from core.config.settings import Settings
+from core.telemetry import TRACER_NAME
+
+_provider: TracerProvider | None = None
+"""The provider this module installed; shut down on process exit."""
+
+
+def configure_telemetry(
+    settings: Settings,
+    exporter: SpanExporter | None = None,
+) -> bool:
+    """Install the global OTLP/HTTP tracer provider when configured.
+
+    Args:
+        settings: Application settings. Export is enabled only when
+            ``otel_exporter_otlp_endpoint`` is set; ``otel_service_name``
+            seeds the ``service.name`` resource attribute on exported spans.
+        exporter: Optional span exporter override. Defaults to an
+            ``OTLPSpanExporter`` pointed at the configured endpoint; tests
+            pass an in-memory exporter to exercise the wiring without network.
+
+    Returns:
+        True when the OTLP exporter was installed (export enabled); False when
+        the instrumentation was left inert (no endpoint configured).
+    """
+    global _provider
+    endpoint = settings.otel_exporter_otlp_endpoint
+    if not endpoint:
+        return False
+    resource = Resource.create({"service.name": settings.otel_service_name})
+    _provider = TracerProvider(resource=resource)
+    _provider.add_span_processor(
+        BatchSpanProcessor(exporter or OTLPSpanExporter(endpoint=endpoint))
+    )
+    trace.set_tracer_provider(_provider)
+    return True
+
+
+def shutdown_telemetry() -> None:
+    """Flush and stop the api's span exporter on process shutdown.
+
+    ``BatchSpanProcessor`` exports asynchronously every few seconds; without
+    a shutdown the final request's spans could be dropped when the process
+    exits. A no-op when no exporter was installed.
+    """
+    provider = _provider
+    if provider is not None:
+        provider.shutdown()
+
+
+class TraceRequestMiddleware:
+    """Start one root span per request so stage spans share a trace.
+
+    Each request opens a server-kind span (``GET /health``, ``POST /query``,
+    ...) under which the five stage spans nest, so a collector renders a
+    single per-request trace instead of five orphaned roots. Inert by default:
+    without a configured provider the span is a no-op and the request is
+    unaffected.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        """Wrap the downstream ASGI application.
+
+        Args:
+            app: The ASGI application this middleware sits in front of.
+        """
+        self._app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Handle one request, spanning its full duration."""
+        if scope["type"] != "http":
+            await self._app(scope, receive, send)
+            return
+        path = scope["path"]
+        method = scope["method"]
+        with trace.get_tracer(TRACER_NAME).start_as_current_span(
+            f"{method} {path}",
+            kind=SpanKind.SERVER,
+        ) as span:
+            span.set_attribute("http.request.method", method)
+            span.set_attribute("url.path", path)
+            await self._app(scope, receive, send)
+
+
+__all__ = ["TraceRequestMiddleware", "configure_telemetry", "shutdown_telemetry"]

--- a/api/tests/api/test_telemetry.py
+++ b/api/tests/api/test_telemetry.py
@@ -1,0 +1,85 @@
+"""Tests for the api's OTLP export wiring (:mod:`api.telemetry`).
+
+``configure_telemetry`` is the switch that keeps the five RAG stage spans
+(issue #286) inert by default: without an ``otel_exporter_otlp_endpoint`` the
+process exports nothing; with one, a global ``TracerProvider`` is installed
+that exports every stage span.
+"""
+
+from fastapi.testclient import TestClient
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind
+
+from api.telemetry import configure_telemetry, shutdown_telemetry
+from core.config.settings import Settings
+from core.telemetry import stage_span
+
+
+def test_configure_telemetry_stays_inert_without_an_endpoint() -> None:
+    """Without an endpoint the provider is untouched and no exporter is set up."""
+    previous = otel_trace._TRACER_PROVIDER
+    try:
+        result = configure_telemetry(Settings(otel_exporter_otlp_endpoint=None))
+
+        assert result is False
+        assert otel_trace._TRACER_PROVIDER is previous
+    finally:
+        otel_trace._TRACER_PROVIDER = previous
+
+
+def test_configure_telemetry_installs_provider_and_exports_stage_spans() -> None:
+    """With an endpoint the provider carries the service name and exports spans."""
+    previous = otel_trace._TRACER_PROVIDER
+    exporter = InMemorySpanExporter()
+    provider: TracerProvider | None = None
+    try:
+        result = configure_telemetry(
+            Settings(
+                otel_exporter_otlp_endpoint="http://collector:4318",
+                otel_service_name="test-api",
+            ),
+            exporter=exporter,
+        )
+
+        assert result is True
+        installed = otel_trace._TRACER_PROVIDER
+        assert isinstance(installed, TracerProvider)
+        provider = installed
+        assert provider.resource.attributes["service.name"] == "test-api"
+
+        @stage_span("embed")
+        def seam() -> None:
+            return None
+
+        seam()
+        provider.force_flush()
+
+        assert [s.name for s in exporter.get_finished_spans()] == ["embed"]
+    finally:
+        otel_trace._TRACER_PROVIDER = previous
+        if provider is not None:
+            provider.shutdown()
+
+
+def test_create_app_adds_request_root_span(
+    client: TestClient,
+    in_memory_tracing: InMemorySpanExporter,
+) -> None:
+    """Each request opens a server root span so stage spans share one trace."""
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    spans = in_memory_tracing.get_finished_spans()
+    assert [s.name for s in spans] == ["GET /health"]
+    assert spans[0].kind == SpanKind.SERVER
+    attributes = spans[0].attributes
+    assert attributes is not None
+    assert attributes["http.request.method"] == "GET"
+    assert attributes["url.path"] == "/health"
+
+
+def test_shutdown_telemetry_is_a_noop_without_an_exporter() -> None:
+    """Shutdown never raises when no exporter was installed."""
+    shutdown_telemetry()

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ import os
 import zipfile
 from collections.abc import Callable, Generator
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import pytest
@@ -18,6 +19,9 @@ from reportlab.pdfgen import canvas
 from sqlalchemy import Engine, create_engine, text
 from sqlalchemy.dialects.postgresql import ENUM
 from sqlalchemy.orm import Session, sessionmaker
+
+if TYPE_CHECKING:
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 # Pre-import workspace packages so their installed (src/) versions are cached
 # in sys.modules before per-package test collection runs.  Without this a test
@@ -256,6 +260,33 @@ def sample_documentation_md() -> bytes:
         b"POST /api/v1/users\n\n"
         b"Creates a new user.\n"
     )
+
+
+@pytest.fixture
+def in_memory_tracing() -> Generator["InMemorySpanExporter", None, None]:
+    """Install an in-memory OpenTelemetry exporter for the test's duration.
+
+    Lets tests assert that the five RAG stage spans (issue #286) were recorded
+    without any network. The global tracer provider is replaced directly —
+    bypassing ``opentelemetry``'s set-once guard so tests can install and
+    restore providers freely — and the previous value is restored afterwards,
+    keeping the instrumentation inert for every other test.
+    """
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    previous = otel_trace._TRACER_PROVIDER
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    otel_trace._TRACER_PROVIDER = provider
+    try:
+        yield exporter
+    finally:
+        otel_trace._TRACER_PROVIDER = previous
+        provider.shutdown()
 
 
 def _create_enums(engine: Engine) -> None:

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "uuid-utils>=0.10",
     "cohere>=5.0",
     "httpx>=0.27",
+    "opentelemetry-api>=1.24",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/core/src/core/clients/embeddings_client.py
+++ b/core/src/core/clients/embeddings_client.py
@@ -8,6 +8,7 @@ from openai.types.create_embedding_response import CreateEmbeddingResponse
 
 from core.config.settings import resolve_openai_base_url, settings
 from core.exceptions import UpstreamBadResponse, UpstreamUnavailable
+from core.telemetry import stage_span
 
 
 @runtime_checkable
@@ -66,6 +67,7 @@ class EmbeddingsClient:
             )
         return self._client
 
+    @stage_span("embed")
     def embed(self, texts: Sequence[str]) -> list[list[float]]:
         """Embed a batch of texts synchronously.
 
@@ -93,6 +95,7 @@ class EmbeddingsClient:
 
         return self._parse_embedding_response(response)
 
+    @stage_span("embed")
     async def aembed(self, texts: Sequence[str]) -> list[list[float]]:
         """Embed a batch of texts asynchronously."""
         if self._async_client is None:

--- a/core/src/core/clients/llm_client.py
+++ b/core/src/core/clients/llm_client.py
@@ -13,6 +13,7 @@ from openai import APIConnectionError, APIStatusError, OpenAI
 
 from core.config.settings import resolve_openai_base_url, settings
 from core.exceptions import UpstreamBadResponse, UpstreamUnavailable
+from core.telemetry import stage_span
 from core.types.chat import ChatMessage
 
 
@@ -72,6 +73,7 @@ class LLMClient:
             )
         return self._client
 
+    @stage_span("generate")
     def chat(self, messages: Sequence[ChatMessage]) -> str:
         """Generate a completion synchronously and return the message content.
 

--- a/core/src/core/clients/reranker_client.py
+++ b/core/src/core/clients/reranker_client.py
@@ -11,6 +11,7 @@ import httpx
 
 from core.config.settings import settings
 from core.exceptions import RerankerRateLimitError, UpstreamBadResponse, UpstreamUnavailable
+from core.telemetry import stage_span
 from core.types.responses import ScoredChunk
 
 
@@ -74,6 +75,7 @@ class CohereReranker:
             self._client = cohere.ClientV2(api_key=self._api_key, timeout=30.0, max_retries=2)
         return self._client
 
+    @stage_span("rerank")
     def rerank(
         self,
         query: str,

--- a/core/src/core/config/settings.py
+++ b/core/src/core/config/settings.py
@@ -39,6 +39,12 @@ class Settings(BaseSettings):
             (OpenAI Responses API ``web_search`` tool).
         max_upload_bytes: Maximum accepted upload size in bytes.
         allowed_file_extensions: Lower-case file extensions accepted for upload.
+        otel_exporter_otlp_endpoint: OTLP/HTTP collector endpoint for the five
+            RAG stage spans (embed / retrieve / rerank / generate /
+            web-search). Empty means tracing stays inert: no exporter is
+            installed and no spans leave the process.
+        otel_service_name: ``service.name`` resource attribute applied to the
+            exported spans.
     """
 
     model_config = SettingsConfigDict(
@@ -61,6 +67,8 @@ class Settings(BaseSettings):
     allowed_file_extensions: set[str] = {"pdf", "epub", "md", "html"}
     cohere_api_key: str | None = None
     reranker_model: str = "rerank-v3.5"
+    otel_exporter_otlp_endpoint: str | None = None
+    otel_service_name: str = "learning-hub"
 
     @field_validator("openai_api_key", "openai_base_url", "cohere_api_key", mode="before")
     @classmethod

--- a/core/src/core/retrieval/neighbors.py
+++ b/core/src/core/retrieval/neighbors.py
@@ -20,6 +20,7 @@ from sqlalchemy.exc import InterfaceError, OperationalError
 from sqlalchemy.orm import Session
 
 from core.exceptions import UpstreamUnavailable
+from core.telemetry import stage_span
 from core.types.responses import ScoredChunk
 from core.types.retrieval_config import RetrievalConfig
 
@@ -41,6 +42,7 @@ _DENSE_NEIGHBORS_SQL = text(
 )
 
 
+@stage_span("retrieve")
 def search_dense_neighbors(
     *,
     session: Session,

--- a/core/src/core/retrieval/query.py
+++ b/core/src/core/retrieval/query.py
@@ -57,6 +57,7 @@ from sqlalchemy.orm import Session
 
 from core.clients.reranker_client import Reranker
 from core.exceptions import RerankerRateLimitError, UpstreamUnavailable
+from core.telemetry import stage_span
 from core.types.responses import RetrievalResult, ScoredChunk
 from core.types.retrieval_config import RetrievalConfig
 
@@ -279,6 +280,7 @@ def _parent_swap(
     return passages
 
 
+@stage_span("retrieve")
 def retrieve_relevant_chunks(
     *,
     query_vector: list[float],

--- a/core/src/core/telemetry.py
+++ b/core/src/core/telemetry.py
@@ -1,0 +1,89 @@
+"""Manual OpenTelemetry stage spans for the hand-rolled RAG pipeline.
+
+The five RAG stages — embed, retrieve, rerank, generate, web-search — are
+wrapped at their existing seams with :func:`stage_span` so every request's
+stages are traceable (issue #286). No pipeline behaviour changes: the spans
+record the call, its duration, and its outcome; failures propagate unchanged.
+
+The instrumentation is **inert by default**: spans flow through whatever
+tracer provider the process has configured, and ``opentelemetry`` supplies a
+no-op tracer until a provider is installed. Library packages never configure
+the SDK here — the exporter is owned by the api process, the single export
+point (``api.telemetry.configure_telemetry``). The tracer is resolved per call
+so a provider installed after import time (the api does this at app creation)
+takes effect immediately.
+"""
+
+from collections.abc import Callable
+from functools import wraps
+from inspect import iscoroutinefunction
+from typing import Any, Literal, ParamSpec, TypeVar, cast
+
+from opentelemetry import trace
+from opentelemetry.trace import Span, Status, StatusCode
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+StageName = Literal["embed", "retrieve", "rerank", "generate", "web-search"]
+"""The five RAG stage names the stage spans carry (issue #286)."""
+
+TRACER_NAME = "learning_hub"
+"""Instrumenting scope shared by the stage spans and the api's request root span."""
+
+
+def _mark_span_failed(span: Span, exc: Exception) -> None:
+    """Record an exception on a span and set its status to ERROR.
+
+    Args:
+        span: The span that observed the failure.
+        exc: The exception that escaped the seam call.
+    """
+    span.record_exception(exc)
+    span.set_status(Status(StatusCode.ERROR, str(exc)))
+
+
+def stage_span(name: StageName) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """Decorate a pipeline seam so each call runs inside a span named ``name``.
+
+    Wraps the function's body in a manual span: the span carries the stage
+    name, the stage's duration, and — on failure — the recorded exception with
+    an error status. The wrapped call's behaviour is unchanged; sync and async
+    functions are both supported.
+
+    Args:
+        name: The stage name the span carries.
+
+    Returns:
+        A decorator that wraps the seam function.
+    """
+
+    def decorator(func: Callable[P, T]) -> Callable[P, T]:
+        if iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
+                with trace.get_tracer(TRACER_NAME).start_as_current_span(name) as span:
+                    try:
+                        return await func(*args, **kwargs)
+                    except Exception as exc:
+                        _mark_span_failed(span, exc)
+                        raise
+
+            return cast(Callable[P, T], async_wrapper)
+
+        @wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            with trace.get_tracer(TRACER_NAME).start_as_current_span(name) as span:
+                try:
+                    return func(*args, **kwargs)
+                except Exception as exc:
+                    _mark_span_failed(span, exc)
+                    raise
+
+        return wrapper
+
+    return decorator
+
+
+__all__ = ["TRACER_NAME", "StageName", "stage_span"]

--- a/core/tests/core/retrieval/test_neighbors.py
+++ b/core/tests/core/retrieval/test_neighbors.py
@@ -1,8 +1,10 @@
 """Database-backed tests for the dense semantic-neighbor search primitive."""
 
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -280,6 +282,31 @@ def test_dense_neighbors_issues_set_local_ef_search_inside_transaction(
         event.remove(test_session.bind, "before_cursor_execute", _before_cursor_execute)
 
     assert 123 in ef_search_params
+
+
+def test_dense_neighbors_records_retrieve_stage_span(
+    in_memory_tracing: InMemorySpanExporter,
+) -> None:
+    """The dense-neighbor retrieve seam records a ``retrieve`` stage span (issue #286)."""
+    fake_session = MagicMock()
+    row = MagicMock()
+    row._mapping = {
+        "chunk_id": uuid4(),
+        "text": "neighbor text",
+        "score": 0.9,
+        "parent_chunk_id": None,
+    }
+    fake_session.execute.return_value.fetchall.return_value = [row]
+
+    neighbors = search_dense_neighbors(
+        session=fake_session,
+        query_vector=[0.5] * 1536,
+        config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=1),
+    )
+
+    assert [n.text for n in neighbors] == ["neighbor text"]
+    spans = in_memory_tracing.get_finished_spans()
+    assert [s.name for s in spans] == ["retrieve"]
 
 
 def test_dense_neighbors_wraps_db_connection_error_as_upstream_unavailable() -> None:

--- a/core/tests/core/retrieval/test_query.py
+++ b/core/tests/core/retrieval/test_query.py
@@ -1,8 +1,10 @@
 """Database-backed tests for the retrieval query module."""
 
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from sqlalchemy import func, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
@@ -325,6 +327,31 @@ def test_retrieve_wraps_db_connection_error_as_upstream_unavailable() -> None:
             session=fake_session,
             config=RetrievalConfig(model_name="text-embedding-3-small", ef_search=40, top_k=1),
         )
+
+
+def test_retrieve_records_retrieve_stage_span(
+    in_memory_tracing: InMemorySpanExporter,
+) -> None:
+    """The retrieve seam records a ``retrieve`` stage span (issue #286)."""
+    fake_session = MagicMock()
+    row = MagicMock()
+    row._mapping = {"chunk_id": uuid4(), "text": "chunk text", "parent_chunk_id": None}
+    fake_session.execute.return_value.fetchall.return_value = [row]
+
+    result = retrieve_relevant_chunks(
+        query_vector=[0.5] * 1536,
+        session=fake_session,
+        config=RetrievalConfig(
+            model_name="text-embedding-3-small",
+            ef_search=40,
+            top_k=1,
+            hybrid_search=False,
+        ),
+    )
+
+    assert [c.text for c in result.fused] == ["chunk text"]
+    spans = in_memory_tracing.get_finished_spans()
+    assert [s.name for s in spans] == ["retrieve"]
 
 
 # ── ScoredChunk building (shared helper) ─────────────────────────────────────

--- a/core/tests/core/test_embeddings_client.py
+++ b/core/tests/core/test_embeddings_client.py
@@ -4,6 +4,7 @@ import asyncio
 from unittest.mock import MagicMock
 
 import pytest
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from core.clients import embeddings_client as embeddings_module
 from core.clients.embeddings_client import Embedder, EmbeddingsClient, InMemoryEmbedder
@@ -117,6 +118,24 @@ def test_async_client_threads_explicit_base_url(monkeypatch: pytest.MonkeyPatch)
 
     assert vectors == [[0.1] * 1536]
     assert captured["base_url"] == "http://mock/v1"
+
+
+def test_embed_records_embed_stage_span(
+    monkeypatch: pytest.MonkeyPatch,
+    in_memory_tracing: InMemorySpanExporter,
+) -> None:
+    """The embed seam records an ``embed`` stage span (issue #286)."""
+    fake_response = MagicMock()
+    fake_response.data = [MagicMock(embedding=[0.1] * 1536)]
+    fake_client = MagicMock()
+    fake_client.embeddings.create = MagicMock(return_value=fake_response)
+
+    client = EmbeddingsClient(api_key="sk-test", model="text-embedding-3-small")
+    monkeypatch.setattr(client, "_get_client", lambda: fake_client)
+    client.embed(["hello"])
+
+    spans = in_memory_tracing.get_finished_spans()
+    assert [s.name for s in spans] == ["embed"]
 
 
 def test_in_memory_embedder_returns_one_vector_per_text() -> None:

--- a/core/tests/core/test_llm_client.py
+++ b/core/tests/core/test_llm_client.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from openai import APIConnectionError, APIStatusError
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from core.clients import llm_client as llm_module
 from core.clients.llm_client import CompletionProvider, LLMClient, MockCompletionProvider
@@ -97,6 +98,23 @@ def test_chat_serializes_multimodal_content_parts(monkeypatch: pytest.MonkeyPatc
             }
         ],
     )
+
+
+def test_chat_records_generate_stage_span(
+    monkeypatch: pytest.MonkeyPatch,
+    in_memory_tracing: InMemorySpanExporter,
+) -> None:
+    """The generate seam records a ``generate`` stage span (issue #286)."""
+    client = LLMClient(api_key="sk-test", model="gpt-4o-mini")
+
+    fake_openai = MagicMock()
+    fake_openai.chat.completions.create = MagicMock(return_value=_fake_completion("answer"))
+    monkeypatch.setattr(client, "_get_client", lambda: fake_openai)
+
+    client.chat([ChatMessage(role="user", content="x")])
+
+    spans = in_memory_tracing.get_finished_spans()
+    assert [s.name for s in spans] == ["generate"]
 
 
 def test_chat_uses_default_model_from_settings() -> None:

--- a/core/tests/core/test_reranker_client.py
+++ b/core/tests/core/test_reranker_client.py
@@ -14,6 +14,7 @@ import cohere.core.api_error
 import cohere.errors
 import httpx
 import pytest
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from core.clients.reranker_client import CohereReranker
 from core.exceptions import RerankerRateLimitError, UpstreamBadResponse, UpstreamUnavailable
@@ -32,6 +33,24 @@ def _reranker_with(raise_exc: Exception) -> CohereReranker:
     # the return type is the protocol's client type but we substitute a mock.
     reranker._get_client = lambda: client  # type: ignore[method-assign]
     return reranker
+
+
+def test_rerank_records_rerank_stage_span(in_memory_tracing: InMemorySpanExporter) -> None:
+    """The rerank seam records a ``rerank`` stage span (issue #286)."""
+    reranker = CohereReranker(api_key="test-key", model="rerank-test")
+    fake = MagicMock()
+    result = MagicMock()
+    result.index = 0
+    fake.rerank.return_value = MagicMock(results=[result])
+    # Override the lazy-init accessor so no real Cohere client is constructed.
+    reranker._get_client = lambda: fake  # type: ignore[method-assign]
+
+    passages = _passages()
+    reranked = reranker.rerank("query", passages, top_k=2)
+
+    assert reranked == [passages[0]]
+    spans = in_memory_tracing.get_finished_spans()
+    assert [s.name for s in spans] == ["rerank"]
 
 
 def test_rerank_connection_error_raises_upstream_unavailable() -> None:

--- a/core/tests/core/test_telemetry.py
+++ b/core/tests/core/test_telemetry.py
@@ -1,0 +1,79 @@
+"""Tests for the stage-span decorator (:mod:`core.telemetry`).
+
+The five RAG stage seams use :func:`stage_span` so every request's stages are
+traceable (issue #286). These tests pin the decorator's contract: a named span
+per call, error status + recorded exception on failure, async support, and
+inert behaviour when no tracer provider is configured.
+"""
+
+import asyncio
+
+import pytest
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
+
+from core.telemetry import stage_span
+
+
+def test_stage_span_records_named_span_on_success(
+    in_memory_tracing: InMemorySpanExporter,
+) -> None:
+    """A successful seam call records one span carrying the stage name."""
+
+    @stage_span("retrieve")
+    def seam() -> str:
+        return "result"
+
+    assert seam() == "result"
+
+    spans = in_memory_tracing.get_finished_spans()
+    assert [s.name for s in spans] == ["retrieve"]
+
+
+def test_stage_span_records_error_and_re_raises(
+    in_memory_tracing: InMemorySpanExporter,
+) -> None:
+    """A failing seam call records the exception and propagates unchanged."""
+
+    @stage_span("generate")
+    def seam() -> None:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        seam()
+
+    spans = in_memory_tracing.get_finished_spans()
+    assert [s.name for s in spans] == ["generate"]
+    assert spans[0].status.status_code == StatusCode.ERROR
+    assert "exception" in [event.name for event in spans[0].events]
+
+
+def test_stage_span_wraps_async_seams(in_memory_tracing: InMemorySpanExporter) -> None:
+    """Async seam functions are wrapped in the same named span."""
+
+    @stage_span("embed")
+    async def seam() -> int:
+        return 42
+
+    assert asyncio.run(seam()) == 42
+
+    spans = in_memory_tracing.get_finished_spans()
+    assert [s.name for s in spans] == ["embed"]
+
+
+def test_stage_span_is_inert_without_a_configured_provider() -> None:
+    """Without a configured provider the span is a no-op and the call succeeds."""
+    previous = otel_trace._TRACER_PROVIDER
+    otel_trace._TRACER_PROVIDER = None
+    try:
+
+        @stage_span("embed")
+        def seam() -> str:
+            return "ok"
+
+        assert seam() == "ok"
+        current = otel_trace.get_current_span()
+        assert not current.get_span_context().is_valid
+    finally:
+        otel_trace._TRACER_PROVIDER = previous

--- a/depth_dive/src/depth_dive/web_search/client.py
+++ b/depth_dive/src/depth_dive/web_search/client.py
@@ -22,6 +22,7 @@ from openai.types.responses.response_output_text import AnnotationURLCitation
 from pydantic import BaseModel, ConfigDict
 
 from core.config.settings import resolve_openai_base_url, settings
+from core.telemetry import stage_span
 
 
 class WebSearchError(Exception):
@@ -112,6 +113,7 @@ class OpenAIWebSearchClient:
             )
         return self._client
 
+    @stage_span("web-search")
     def search(self, query: str) -> list[WebSearchResult]:
         """Search the web and return the cited external material.
 

--- a/depth_dive/tests/depth_dive/web_search/test_client.py
+++ b/depth_dive/tests/depth_dive/web_search/test_client.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 import pytest
 from openai import APIConnectionError, APIStatusError, OpenAIError
 from openai.types.responses import Response
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from core.config.settings import settings
 from depth_dive.web_search import client as web_search_module
@@ -96,6 +97,19 @@ def test_openai_client_surfaces_cited_urls_as_results() -> None:
     assert result.title == "Attention Is All You Need"
     assert result.url == "https://example.com/paper"
     assert result.snippet == " famous. See the ori"
+
+
+def test_openai_client_records_web_search_stage_span(
+    in_memory_tracing: InMemorySpanExporter,
+) -> None:
+    """The web-search seam records a ``web-search`` stage span (issue #286)."""
+    response = Response.model_validate(_response_payload(annotation=None))
+    client, _ = _client(response)
+
+    client.search("attention is all you need")
+
+    spans = in_memory_tracing.get_finished_spans()
+    assert [s.name for s in spans] == ["web-search"]
 
 
 def test_openai_client_empty_citations_yields_no_results() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
     "deepeval>=4.1.8",
     "pyyaml>=6.0",
     "types-pyyaml>=6.0.12.20260724",
+    "opentelemetry-sdk>=1.24",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -194,6 +194,8 @@ dependencies = [
     { name = "depth-dive" },
     { name = "fastapi" },
     { name = "ingestion" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
     { name = "python-multipart" },
     { name = "uvicorn" },
 ]
@@ -204,6 +206,8 @@ requires-dist = [
     { name = "depth-dive", editable = "depth_dive" },
     { name = "fastapi", specifier = ">=0.141.1" },
     { name = "ingestion", editable = "ingestion" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.24" },
+    { name = "opentelemetry-sdk", specifier = ">=1.24" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "uvicorn", specifier = ">=0.52.3" },
 ]
@@ -386,6 +390,7 @@ dependencies = [
     { name = "cohere" },
     { name = "httpx" },
     { name = "openai" },
+    { name = "opentelemetry-api" },
     { name = "pgvector" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
@@ -400,6 +405,7 @@ requires-dist = [
     { name = "cohere", specifier = ">=5.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "openai", specifier = ">=2.51.0" },
+    { name = "opentelemetry-api", specifier = ">=1.24" },
     { name = "pgvector", specifier = ">=0.3" },
     { name = "psycopg2-binary", specifier = ">=2.9" },
     { name = "pydantic", specifier = ">=2" },
@@ -642,6 +648,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/73/74bcab964c9a7a61f2bb71e8179b0f13e6fa98f7ce00fd168aab291e4a2e/googleapis_common_protos-1.75.1.tar.gz", hash = "sha256:d3042c6c5a2d4e67113104d6b6818b59b6bd92a197f2a91508e801fe815cf071", size = 150967, upload-time = "2026-08-06T06:24:51.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/51/186c02b8549b69ccda44429cf6ff5081e4b61a602ddfe6a8020d1be31d1b/googleapis_common_protos-1.75.1-py3-none-any.whl", hash = "sha256:28a1934bcd33b9c9da66ac301a0a4227e3367f095a17d0375cb98f0a09d93b79", size = 300626, upload-time = "2026-08-06T06:23:46.696Z" },
 ]
 
 [[package]]
@@ -1065,6 +1083,7 @@ dev = [
     { name = "httpx2" },
     { name = "import-linter" },
     { name = "mypy" },
+    { name = "opentelemetry-sdk" },
     { name = "pip-licenses" },
     { name = "pytest" },
     { name = "pyyaml" },
@@ -1082,6 +1101,7 @@ dev = [
     { name = "httpx2", specifier = ">=2.10.0" },
     { name = "import-linter", specifier = ">=2.1" },
     { name = "mypy", specifier = ">=1.11" },
+    { name = "opentelemetry-sdk", specifier = ">=1.24" },
     { name = "pip-licenses", specifier = ">=5" },
     { name = "pytest", specifier = ">=8" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -1460,6 +1480,48 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
 name = "opentelemetry-sdk"
 version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1748,6 +1810,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
     { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
     { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Wrap the embed, retrieve, rerank, generate, and web-search seams in manual stage spans so every request's stages are traceable, with the api exporting them once over OTLP/HTTP to a configurable collector endpoint. No pipeline behaviour changes.

The instrumentation is inert by default: spans flow through whatever tracer provider the process has installed, and opentelemetry supplies a no-op tracer until the api installs the SDK exporter (gated on OTEL_EXPORTER_OTLP_ENDPOINT). Library packages never configure the SDK — the api is the single export point (api/telemetry.py), matching the map's research decision (issue #266).