### PR TITLE
feat(deploy): run demo from GHCR image with smoke-tested push

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,13 +30,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Log in to GHCR
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Image metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
@@ -48,15 +41,57 @@ jobs:
             type=sha,prefix=,suffix=,format=short,enable=${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_run' }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_run' }}
 
-      - name: Build and push
+      - name: Build image (push deferred until smoke test passes)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          push: true
+          push: false
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # SMOKE TEST GATE: boot + postgres + /health must pass before anything is
+      # pushed. The api image is loaded into the daemon (load: true above) and
+      # exercised via the same compose.deploy.yml override the local demo uses,
+      # so the artifact tested here is the exact artifact pushed below. GHCR
+      # login is deliberately AFTER this step: a failed smoke test never touches
+      # the registry. The health poll is scripts/health-poll.sh — the same
+      # script `make deploy` runs locally.
+      - name: Smoke test (boot + postgres + /health)
+        run: |
+          # compose.deploy.yml's api service uses `.env` as env_file; it is
+          # gitignored, so create an empty one (compose defaults supply the rest).
+          touch .env
+          if [ "${{ github.event_name }}" = "push" ] && [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            IMAGE_TAG="${GITHUB_REF_NAME#v}"
+          else
+            IMAGE_TAG="latest"
+          fi
+          export IMAGE_TAG
+          echo "Smoke-testing ghcr.io/${{ github.repository }}:${IMAGE_TAG}"
+          docker compose -f docker-compose.yml -f compose.deploy.yml up -d --no-build
+          bash scripts/health-poll.sh 30 2 || {
+            echo "smoke test failed: /health not OK within 60s" >&2
+            docker compose -f docker-compose.yml -f compose.deploy.yml logs api
+            docker compose -f docker-compose.yml -f compose.deploy.yml ps
+            exit 1
+          }
+          echo "smoke test passed: api booted, postgres reachable, /health ok"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push images to GHCR
+        run: |
+          for tag in ${{ steps.meta.outputs.tags }}; do
+            docker push "$tag"
+          done
 
   changelog:
     name: Create GitHub release with changelog

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -64,7 +64,7 @@ jobs:
           # compose.deploy.yml's api service uses `.env` as env_file; it is
           # gitignored, so create an empty one (compose defaults supply the rest).
           touch .env
-          if [ "${{ github.event_name }}" = "push" ] && [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             IMAGE_TAG="${GITHUB_REF_NAME#v}"
           else
             IMAGE_TAG="latest"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,16 @@ SHELL := /bin/bash
 # Scope `make logs` to a single service, e.g. `make logs SERVICE=postgres`.
 SERVICE ?=
 
+# Image tag pulled by `make deploy`. Defaults to `latest`; override for
+# rollback, e.g. `make deploy IMAGE_TAG=1.2.3` (published semver tags carry no
+# `v` prefix). Exported so the compose.deploy.yml `image:` interpolation sees it.
+IMAGE_TAG ?= latest
+export IMAGE_TAG
+
+# Bounded /health poll used by `make deploy` (via scripts/health-poll.sh).
+HEALTH_POLL_ATTEMPTS ?= 30
+HEALTH_POLL_INTERVAL ?= 2
+
 .PHONY: help
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -37,3 +47,10 @@ load-up: check-docker ## Start the volume-load stack (mock upstream + api) in th
 .PHONY: load-down
 load-down: check-docker ## Stop the volume-load stack (never deletes the pgvector data volume)
 	docker compose --profile load down
+
+.PHONY: deploy
+deploy: check-docker ## Deploy the demo stack from the published GHCR image (pull, no-build up, poll /health)
+	docker compose -f docker-compose.yml -f compose.deploy.yml pull
+	docker compose -f docker-compose.yml -f compose.deploy.yml up -d --no-build
+	@bash scripts/health-poll.sh $(HEALTH_POLL_ATTEMPTS) $(HEALTH_POLL_INTERVAL) \
+		|| (docker compose -f docker-compose.yml -f compose.deploy.yml logs api; exit 1)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ A hand-rolled RAG study tool for learning AI/ML from papers, books, and document
 
 The root `Makefile` wraps the local dev container lifecycle defined in `docker-compose.yml` (Postgres + pgvector): `make up` to start the stack in the background, `make logs` to tail service logs (`make logs SERVICE=postgres` scopes to one service), and `make down` to stop and remove containers/network — `down` never deletes the pgvector data volume. `make load-up` starts the volume-load stack: the `load` compose profile adds the OpenAI-compatible `mock-upstream` service and points the api at it (`OPENAI_BASE_URL`), so `/query` and `/dive` return deterministic answers with no real API key or outbound calls (`make load-down` stops it). Run `make help` to list every target. Docker's daemon must be running; `up`/`logs`/`down` fail fast with a clear message if it isn't. Per-package checks (`ruff`, `mypy`, `pytest`) stay explicit `uv run` invocations.
 
+**Deploying the demo.** CI is the single image build path — the deployed stack pulls, never builds. `make deploy` pulls the published image (`ghcr.io/mrae43/learning-hub-infra:latest` by default, via the `compose.deploy.yml` override), starts the stack with `--no-build`, and polls `GET /health` until ready (bounded). Copy `.env.example` to `.env` first and fill in `OPENAI_API_KEY`. Rollback is manual — re-run with a previous tag, `make deploy IMAGE_TAG=1.2.3` (published semver tags carry no `v` prefix). `cd.yml` only pushes an image after a boot + postgres + `/health` smoke test passes. The deploy override uses the Compose `!reset` tag, so Docker Compose v2.24+ is required.
+
 ## Architecture
 
 Structured monorepo with extractable module boundaries:

--- a/compose.deploy.yml
+++ b/compose.deploy.yml
@@ -1,0 +1,21 @@
+# Deploy override: run the demo stack from the published GHCR image instead of
+# a local build. CI (`cd.yml`) is the single build path; this file is how a
+# deployed copy pulls the published artifact. Dev keeps `docker compose up -d`
+# (local `build: .`); deploy always pulls.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f compose.deploy.yml up -d --no-build
+#   IMAGE_TAG=1.2.3 docker compose -f docker-compose.yml -f compose.deploy.yml up -d --no-build
+#
+# IMAGE_TAG defaults to `latest` and is overridable for rollback (re-run with
+# a previous tag, e.g. `IMAGE_TAG=1.2.3`). No digest pinning locally
+# (scaffold-for-hybrid, wayfinder #273).
+#
+# Requires Docker Compose v2.24+ — the `!reset` tag (Compose spec) is what
+# removes the base `build:` key; older compose would keep `build` and `image`
+# both set. `make deploy` never builds, so an image-only result is what deploy
+# wants either way, but this keeps the merged config honest.
+services:
+  api:
+    image: ghcr.io/mrae43/learning-hub-infra:${IMAGE_TAG:-latest}
+    build: !reset null

--- a/scripts/health-poll.sh
+++ b/scripts/health-poll.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Poll the api /health endpoint until it returns ok, or fail after a bounded
+# number of attempts. Single source of truth for the deploy health poll used by
+# `make deploy` (host-side) and the cd.yml smoke-test gate (CI runner).
+set -eu
+
+attempts="${1:-30}"
+interval="${2:-2}"
+
+for i in $(seq 1 "${attempts}"); do
+  if curl -fsS http://localhost:8000/health | grep -q '"status":"ok"'; then
+    echo "api /health OK"
+    exit 0
+  fi
+  sleep "${interval}"
+done
+
+echo "error: api /health not OK after ${attempts} polls" >&2
+exit 1


### PR DESCRIPTION
Add compose.deploy.yml swapping the api build: for the published GHCR image (${IMAGE_TAG:-latest}), a `make deploy` target (pull + up --no-build + bounded /health poll, manual rollback via IMAGE_TAG), and gate cd.yml's image push on a boot + postgres + /health smoke test reusing the same override. Dev keeps building locally; CI stays the single build path.