### PR TITLE
feat(deploy): scaffold Caddy edge gate with basic-auth and TLS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,21 @@ RERANKER_MODEL=rerank-v3.5
 # When set, the api exports every request's stage spans to this endpoint.
 OTEL_EXPORTER_OTLP_ENDPOINT=
 OTEL_SERVICE_NAME=learning-hub
+
+# --- Edge gate (decision #269) — only read when compose.edge.yml is explicitly
+# enabled; local dev (`make up`) ignores these. ---------------------------------
+# The public demo URL hostname the Caddy gate fronts. No real domain is bought
+# in this scaffold — set it for real in the public phase, or use `localhost`
+# locally with EDGE_GATE_TLS="tls internal".
+EDGE_GATE_DOMAIN=demo.example.com
+
+# Edge basic-auth credential, "<user> <bcrypt-hash>", one demo user. Generate
+# the hash with:  docker run --rm caddy:2-alpine caddy hash-password
+# Compose interpolates `$` in .env, so double every `$` in the hash (e.g.
+# `demo $$2a$$10$$...`) or the credential silently breaks. Never commit a real
+# hash — this placeholder is committed; the live value goes in .env only.
+EDGE_GATE_AUTH=demo $$2a$$...
+
+# Empty (default) = automatic HTTPS via Let's Encrypt in the public phase.
+# "tls internal" = self-signed certs for a local run without a real domain.
+EDGE_GATE_TLS=

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,55 @@
+# Edge Gate — Caddy reverse proxy + basic-auth + TLS scaffold for the public
+# demo URL (decision #269).
+#
+# INERT BY DEFAULT: this file is only live when the edge-gate service is
+# explicitly started via the compose.edge.yml override. Local dev (`make up`)
+# never loads it, so nothing here changes the dev stack.
+#
+# Public phase:
+#   docker compose -f docker-compose.yml -f compose.deploy.yml \
+#     -f compose.edge.yml up -d --no-build
+#
+# ADR-0018 stays intact: the api remains auth-less; gating happens only at the
+# edge. The observability UIs keep their own native login (decision #269); the
+# edge basic-auth covers the api, the single auth-less service.
+
+{$EDGE_GATE_DOMAIN} {
+	# TLS scaffold (decision #269). Public phase: automatic HTTPS via Caddy's
+	# default ACME issuer (Let's Encrypt) — the empty {$EDGE_GATE_TLS} default
+	# below keeps that. Local run without a real domain: set
+	# EDGE_GATE_TLS="tls internal" for self-signed certs. Plain HTTP is also
+	# possible by adding the global `auto_https off` option and a `http://`
+	# prefix on the site address; both are deliberate, documented switches.
+	{$EDGE_GATE_TLS}
+
+	# Health probe is open — the compose healthcheck, cd.yml smoke test, and
+	# `make deploy` poll all call it unauthenticated. Leaks only {"status":"ok"}.
+	@health path /health
+	handle @health {
+		reverse_proxy api:8000
+	}
+
+	# Observability UIs are path-routed under the demo domain and keep their
+	# own native login; no edge basic-auth on top.
+	handle_path /langfuse* {
+		reverse_proxy langfuse-web:3000
+	}
+	handle_path /grafana* {
+		reverse_proxy grafana:3000
+	}
+	handle_path /prometheus* {
+		reverse_proxy prometheus:9090
+	}
+
+	# Everything else is the api, behind edge basic-auth — including the API
+	# docs routes /docs and /redoc (exposed, but protected). Credentials come
+	# from the EDGE_GATE_AUTH env var as "<user> <bcrypt-hash>"; no plaintext
+	# and no committed htpasswd file. Generate the hash with:
+	#   docker run --rm caddy:2-alpine caddy hash-password
+	handle {
+		basic_auth * {
+			{$EDGE_GATE_AUTH}
+		}
+		reverse_proxy api:8000
+	}
+}

--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,28 @@ deploy: check-docker ## Deploy the demo stack from the published GHCR image (pul
 	docker compose -f docker-compose.yml -f compose.deploy.yml up -d --no-build
 	@bash scripts/health-poll.sh $(HEALTH_POLL_ATTEMPTS) $(HEALTH_POLL_INTERVAL) \
 		|| (docker compose -f docker-compose.yml -f compose.deploy.yml logs api; exit 1)
+
+# Edge gate (decision #269): Caddy reverse proxy + basic-auth + TLS in front of
+# the demo stack. Explicitly opt-in only — never part of `up`/`deploy`, so the
+# dev stack is unchanged by default. EDGE_GATE_AUTH is read from `.env`
+# (required; compose fails fast without it). These targets are the LOCAL
+# scaffold path (localhost + self-signed TLS); the public phase layers
+# compose.deploy.yml too — see the README "edge gate" section for that command.
+EDGE_GATE_DOMAIN ?= localhost
+EDGE_GATE_TLS ?= tls internal
+export EDGE_GATE_DOMAIN EDGE_GATE_TLS
+# Dummy value for teardown: `stop`/`rm` don't recreate the container, so a
+# placeholder satisfies the compose interpolation requirement for the
+# EDGE_GATE_AUTH `:?` check without needing real credentials.
+EDGE_GATE_AUTH_TEARDOWN := teardown-dummy
+
+.PHONY: up-edge
+up-edge: check-docker ## Start the edge gate (Caddy) in front of the local dev stack
+	docker compose -f docker-compose.yml -f compose.edge.yml up -d edge-gate
+
+.PHONY: down-edge
+down-edge: check-docker ## Stop and remove only the edge gate (dev stack untouched)
+	EDGE_GATE_AUTH="$(EDGE_GATE_AUTH_TEARDOWN)" \
+	docker compose -f docker-compose.yml -f compose.edge.yml stop edge-gate
+	EDGE_GATE_AUTH="$(EDGE_GATE_AUTH_TEARDOWN)" \
+	docker compose -f docker-compose.yml -f compose.edge.yml rm -f edge-gate

--- a/README.md
+++ b/README.md
@@ -31,6 +31,28 @@ The root `Makefile` wraps the local dev container lifecycle defined in `docker-c
 
 **Deploying the demo.** CI is the single image build path — the deployed stack pulls, never builds. `make deploy` pulls the published image (`ghcr.io/mrae43/learning-hub-infra:latest` by default, via the `compose.deploy.yml` override), starts the stack with `--no-build`, and polls `GET /health` until ready (bounded). Copy `.env.example` to `.env` first and fill in `OPENAI_API_KEY`. Rollback is manual — re-run with a previous tag, `make deploy IMAGE_TAG=1.2.3` (published semver tags carry no `v` prefix). `cd.yml` only pushes an image after a boot + postgres + `/health` smoke test passes. The deploy override uses the Compose `!reset` tag, so Docker Compose v2.24+ is required.
 
+**The edge gate (Caddy).** For a public demo URL there is a scaffolded edge gate (decision #269): a `Caddyfile` + `compose.edge.yml` override that path-routes one domain to the api (and the Langfuse/Grafana/Prometheus UIs once the observability profile lands), terminates TLS, and enforces basic-auth on every api route except `GET /health` — the API docs routes (`/docs`, `/redoc`) are exposed but sit behind the auth wall. ADR-0018 stays intact: the api is still auth-less; gating happens only at the edge. **It is inert by default** — `make up` / `make deploy` never load it.
+
+To activate locally (self-signed TLS, no domain needed):
+```bash
+# one-time: generate a bcrypt hash for the demo credential
+docker run --rm caddy:2-alpine caddy hash-password
+# then put the credential in .env (compose doubles every `$` in the hash):
+#   EDGE_GATE_AUTH="demo $$2a$$10$$..."        (see .env.example)
+#   EDGE_GATE_DOMAIN=localhost
+#   EDGE_GATE_TLS=tls internal
+make up-edge
+# https://localhost/health stays open; everything else needs the credentials
+make down-edge
+```
+For the public phase, layer the override on the deploy files and let Caddy provision a Let's Encrypt certificate for the real domain:
+```bash
+# in .env: EDGE_GATE_DOMAIN=demo.example.com and a real EDGE_GATE_AUTH
+# (leave EDGE_GATE_TLS empty so automatic HTTPS issues a Let's Encrypt cert)
+docker compose -f docker-compose.yml -f compose.deploy.yml -f compose.edge.yml up -d --no-build
+```
+`EDGE_GATE_AUTH` lives in `.env` (gitignored) — the committed `.env.example` holds only placeholders. Set `EDGE_GATE_TLS="tls internal"` for self-signed local runs (the `make up-edge` default); leave it empty for Let's Encrypt. Passing the credential inline on the shell needs single quotes (`EDGE_GATE_AUTH='demo $2a$...' make up-edge`) so the shell doesn't expand the hash's `$`.
+
 ## Architecture
 
 Structured monorepo with extractable module boundaries:

--- a/compose.edge.yml
+++ b/compose.edge.yml
@@ -1,0 +1,60 @@
+# Edge gate override: add the Caddy reverse proxy (basic-auth + TLS) in front
+# of the demo stack, per decision #269. INERT BY DEFAULT — nothing in this
+# file runs unless it is explicitly layered on, so local dev (`docker compose
+# up` / `make up`) is completely unchanged.
+#
+# Usage (public phase):
+#   docker compose -f docker-compose.yml -f compose.deploy.yml \
+#     -f compose.edge.yml up -d --no-build
+#
+# Local scaffold run (self-signed TLS, no domain purchased):
+#   EDGE_GATE_AUTH='demo $2a$...' EDGE_GATE_DOMAIN=localhost EDGE_GATE_TLS="tls internal" \
+#   docker compose -f docker-compose.yml -f compose.edge.yml up -d
+#
+# Requirements (both cases fail fast if missing):
+#   - EDGE_GATE_AUTH    "<user> <bcrypt-hash>" — generate the hash with
+#                       `docker run --rm caddy:2-alpine caddy hash-password`;
+#                       normally set in .env (see .env.example for the `$$`
+#                       escaping compose requires)
+#   - EDGE_GATE_DOMAIN  the public demo URL hostname
+#
+# ADR-0018 stays intact: the api remains auth-less; gating happens only at the
+# edge. The observability UIs (langfuse-web/grafana/prometheus) are path-routed
+# here and keep their own native login; they join this network when the
+# observability profile (issues #289/#291) is added.
+services:
+  edge-gate:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "${EDGE_GATE_HTTP_PORT:-80}:80"
+      - "${EDGE_GATE_HTTPS_PORT:-443}:443"
+    environment:
+      EDGE_GATE_DOMAIN: ${EDGE_GATE_DOMAIN:?EDGE_GATE_DOMAIN must be set (e.g. demo.example.com) in .env}
+      EDGE_GATE_AUTH: ${EDGE_GATE_AUTH:?EDGE_GATE_AUTH must be set ("<user> <bcrypt-hash>") in .env}
+      # Empty = automatic HTTPS (Let's Encrypt) for the public phase; set to
+      # "tls internal" for a self-signed local run (see Caddyfile header).
+      EDGE_GATE_TLS: ${EDGE_GATE_TLS:-}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - api
+    healthcheck:
+      # The Caddy admin endpoint binds IPv4 only, so probe 127.0.0.1 (not
+      # `localhost`, which may resolve to ::1 first and fail the check).
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:2019/config/"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  # When the edge gate is active, the api is only reachable through Caddy —
+  # its host port binding is removed so nothing bypasses the gate (decision
+  # #269: the edge basic-auth covers the api, the only auth-less service).
+  api:
+    ports: !reset []
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/docs/ai-system-tree.md
+++ b/docs/ai-system-tree.md
@@ -152,10 +152,13 @@ learning-hub/
 ├── pyproject.toml                    # Root: uv workspace, ruff config, import-linter contracts
 ├── conftest.py                       # Root test fixtures (282 lines, shared by all packages)
 ├── alembic.ini                       # Alembic configuration for DB migrations
-├── Makefile                          # Thin docker-compose wrapper for local dev (up/logs/down)
+├── Makefile                          # Thin docker-compose wrapper for local dev (up/logs/down/deploy/up-edge)
 ├── docker-entrypoint.sh              # Container entrypoint: alembic upgrade + uvicorn
 ├── commitlint.config.mjs             # Conventional Commits enforcement
-├── docker-compose.yml                # Local dev: PostgreSQL + pgvector
+├── docker-compose.yml                # Local dev: PostgreSQL + pgvector (+ api)
+├── compose.deploy.yml                # Deploy override: pull GHCR image instead of building
+├── compose.edge.yml                  # Edge gate override (Caddy basic-auth + TLS), inert by default
+├── Caddyfile                         # Edge gate reverse-proxy config (decision #269), inert by default
 ├── Dockerfile                        # Multi-stage build (all 7 packages)
 ├── .env.example
 ├── skills-lock.json                  # Pinned agent skill versions


### PR DESCRIPTION
Add the edge gate decided in #269: a root Caddyfile plus compose.edge.yml override that path-routes the demo URL to the api (Langfuse/Grafana/Prometheus routes stay inert until the observability profile lands), enforces basic-auth on every api route except GET /health (docs routes behind auth), and scaffolds TLS (automatic Let's Encrypt public / tls internal local).

Inert by default — local dev compose and make up/deploy are unchanged unless the override is explicitly layered on. When active, the api's host port binding is reset so nothing bypasses the gate. Credentials come from EDGE_GATE_AUTH (bcrypt-hashed) in .env; .env.example holds only placeholders.

Closes #288